### PR TITLE
Refactor AzureServiceBusService to prioritize connection string

### DIFF
--- a/ConferenceV2/services/singletons/azure_service_bus_service.py
+++ b/ConferenceV2/services/singletons/azure_service_bus_service.py
@@ -25,9 +25,13 @@ class AzureServiceBusService:
         """Initialize the Azure Service Bus client."""
         self.queue_to_wsservice = "queue-to-wsservice"
         self.queue_from_wsservice = "queue-to-confserver"
-        self.credential = DefaultAzureCredential()  # Store credential for reuse
         servicebus_namespace = os.environ.get('SERVICE_BUS_NS_NAME', '')
-        self.servicebus_client = ServiceBusClient(fully_qualified_namespace=servicebus_namespace, credential=self.credential, logging_enable=True)
+        azure_storage_connection_string = os.environ.get('AZURE_STORAGE_CONNECTION_STRING', '')
+        if azure_storage_connection_string:
+            self.servicebus_client = ServiceBusClient.from_connection_string(conn_str=azure_storage_connection_string, logging_enable=True)
+        else:
+            self.credential = DefaultAzureCredential()  # Store credential for reuse
+            self.servicebus_client = ServiceBusClient(fully_qualified_namespace=servicebus_namespace, credential=self.credential, logging_enable=True)
 
     async def send_message(self, message: WebsocketServiceMessage):
         try:

--- a/ConferenceV2/services/singletons/azure_service_bus_service.py
+++ b/ConferenceV2/services/singletons/azure_service_bus_service.py
@@ -26,9 +26,9 @@ class AzureServiceBusService:
         self.queue_to_wsservice = "queue-to-wsservice"
         self.queue_from_wsservice = "queue-to-confserver"
         servicebus_namespace = os.environ.get('SERVICE_BUS_NS_NAME', '')
-        azure_storage_connection_string = os.environ.get('AZURE_STORAGE_CONNECTION_STRING', '')
-        if azure_storage_connection_string:
-            self.servicebus_client = ServiceBusClient.from_connection_string(conn_str=azure_storage_connection_string, logging_enable=True)
+        servicebus_connection_string = os.environ.get('SERVICE_BUS_CONNECTION_STRING', '')
+        if servicebus_connection_string:
+            self.servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_string, logging_enable=True)
         else:
             self.credential = DefaultAzureCredential()  # Store credential for reuse
             self.servicebus_client = ServiceBusClient(fully_qualified_namespace=servicebus_namespace, credential=self.credential, logging_enable=True)


### PR DESCRIPTION
Refactor the AzureServiceBusService to initialize the Service Bus client using the SERVICE_BUS_CONNECTION_STRING environment variable, falling back to DefaultAzureCredential if the connection string is not provided.