### PR TITLE
Blob service updated for exoplayer

### DIFF
--- a/backend-server/src/services/BlobService.js
+++ b/backend-server/src/services/BlobService.js
@@ -1,13 +1,17 @@
-const { BlobServiceClient, generateBlobSASQueryParameters, BlobSASPermissions } = require("@azure/storage-blob");
-const { DefaultAzureCredential } = require("@azure/identity");
+const { BlobServiceClient, generateBlobSASQueryParameters, BlobSASPermissions, StorageSharedKeyCredential } = require("@azure/storage-blob");
+
 const { URL } = require('url');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-STORAGE_ACCOUNT_NAME = process.env.STORAGE_ACCOUNT_NAME;
+
+STORAGE_ACCOUNT_NAME = process.env.AZURE_STORAGE_ACCOUNT_NAME;
+STORAGE_ACCOUNT_KEY = process.env.AZURE_STORAGE_ACCOUNT_KEY; 
+
 class BlobService {
     constructor() {
-        const credential = new DefaultAzureCredential();
+        // Changed to use StorageSharedKeyCredential
+        const credential = new StorageSharedKeyCredential(STORAGE_ACCOUNT_NAME, STORAGE_ACCOUNT_KEY);
         this.blobServiceClient = new BlobServiceClient(
             `https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net`, 
             credential
@@ -32,8 +36,12 @@ class BlobService {
             permissions: BlobSASPermissions.parse("rw"),
         };
         
-        const userDelegationKey = await this.blobServiceClient.getUserDelegationKey(new Date(), expiresOn);
-        const sasToken = generateBlobSASQueryParameters(sasOptions, userDelegationKey, this.blobServiceClient.accountName).toString();
+        // Removed userDelegationKey logic, using StorageSharedKeyCredential to sign
+        const sasToken = generateBlobSASQueryParameters(
+            sasOptions, 
+            this.blobServiceClient.credential, 
+            this.blobServiceClient.accountName
+        ).toString();
         return sasToken
     }
 
@@ -53,8 +61,7 @@ class BlobService {
 
         const expiresOn = new Date(new Date().valueOf() + 3600 * 1000); // 1 hour from now
 
-        // Fetch a user delegation key
-        const userDelegationKey = await this.blobServiceClient.getUserDelegationKey(new Date(), expiresOn);
+        // Removed userDelegationKey logic
 
         const sasOptions = {
             containerName,
@@ -62,10 +69,15 @@ class BlobService {
             permissions: sasPermissions.toString(),
             expiresOn: expiresOn,
             startsOn: new Date(new Date().valueOf() - 300 * 1000), // Optional: start time is 5 minutes before now
-            userDelegationKey
+            // userDelegationKey is removed for Shared Key SAS
         };
 
-        const sasToken = generateBlobSASQueryParameters(sasOptions, userDelegationKey, this.blobServiceClient.accountName).toString();
+        // Removed userDelegationKey logic, using StorageSharedKeyCredential to sign
+        const sasToken = generateBlobSASQueryParameters(
+            sasOptions, 
+            this.blobServiceClient.credential, 
+            this.blobServiceClient.accountName
+        ).toString();
         return `${blobClient.url}?${sasToken}`;
     }
 

--- a/backend-server/src/services/BlobService.js
+++ b/backend-server/src/services/BlobService.js
@@ -1,17 +1,27 @@
 const { BlobServiceClient, generateBlobSASQueryParameters, BlobSASPermissions, StorageSharedKeyCredential } = require("@azure/storage-blob");
-
+const { DefaultAzureCredential } = require("@azure/identity");
 const { URL } = require('url');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-AZURE_STORAGE_ACCOUNT_NAME = process.env.AZURE_STORAGE_ACCOUNT_NAME;
-AZURE_STORAGE_ACCOUNT_KEY = process.env.AZURE_STORAGE_ACCOUNT_KEY; 
+const AZURE_STORAGE_ACCOUNT_NAME = process.env.AZURE_STORAGE_ACCOUNT_NAME;
+const AZURE_STORAGE_ACCOUNT_KEY = process.env.AZURE_STORAGE_ACCOUNT_KEY;
 
 class BlobService {
     constructor() {
-        // Changed to use StorageSharedKeyCredential
-        const credential = new StorageSharedKeyCredential(AZURE_STORAGE_ACCOUNT_NAME, AZURE_STORAGE_ACCOUNT_KEY);
+        let credential;
+        
+        // Check if the Shared Key is available
+        if (AZURE_STORAGE_ACCOUNT_KEY) {
+            credential = new StorageSharedKeyCredential(AZURE_STORAGE_ACCOUNT_NAME, AZURE_STORAGE_ACCOUNT_KEY);
+            this.useSharedKey = true;
+        } else {
+            // Fallback to Default Azure Credential (User Delegation SAS)
+            credential = new DefaultAzureCredential();
+            this.useSharedKey = false;
+        }
+
         this.blobServiceClient = new BlobServiceClient(
             `https://${AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net`, 
             credential
@@ -32,17 +42,26 @@ class BlobService {
             containerName: containerName,
             blobName: blobname,
             startsOn: new Date(),
-            expiresOn: expiresOn, //change this time duration later
+            expiresOn: expiresOn,
             permissions: BlobSASPermissions.parse("rw"),
         };
         
-        // Removed userDelegationKey logic, using StorageSharedKeyCredential to sign
-        const sasToken = generateBlobSASQueryParameters(
-            sasOptions, 
-            this.blobServiceClient.credential, 
-            this.blobServiceClient.accountName
-        ).toString();
-        return sasToken
+        let sasToken;
+        
+        if (this.useSharedKey) {
+            // 1. Shared Key SAS (Service SAS)
+            sasToken = generateBlobSASQueryParameters(
+                sasOptions, 
+                this.blobServiceClient.credential, 
+                this.blobServiceClient.accountName
+            ).toString();
+        } else {
+            // 2. Azure AD SAS (User Delegation SAS)
+            const userDelegationKey = await this.blobServiceClient.getUserDelegationKey(new Date(), expiresOn);
+            sasToken = generateBlobSASQueryParameters(sasOptions, userDelegationKey, this.blobServiceClient.accountName).toString();
+        }
+        
+        return sasToken;
     }
 
     async getURLWithSAS(url) {
@@ -61,23 +80,35 @@ class BlobService {
 
         const expiresOn = new Date(new Date().valueOf() + 3600 * 1000); // 1 hour from now
 
-        // Removed userDelegationKey logic
-
         const sasOptions = {
             containerName,
             blobName: blobPath,
             permissions: sasPermissions.toString(),
             expiresOn: expiresOn,
             startsOn: new Date(new Date().valueOf() - 300 * 1000), // Optional: start time is 5 minutes before now
-            // userDelegationKey is removed for Shared Key SAS
         };
+        
+        let sasToken;
+        
+        if (this.useSharedKey) {
+            // 1. Shared Key SAS (Service SAS)
+            sasToken = generateBlobSASQueryParameters(
+                sasOptions, 
+                this.blobServiceClient.credential, 
+                this.blobServiceClient.accountName
+            ).toString();
+        } else {
+            // 2. Azure AD SAS (User Delegation SAS)
+            const userDelegationKey = await this.blobServiceClient.getUserDelegationKey(new Date(), expiresOn);
+            sasOptions.userDelegationKey = userDelegationKey; // Add key to options for User Delegation SAS
+            
+            sasToken = generateBlobSASQueryParameters(
+                sasOptions, 
+                userDelegationKey, 
+                this.blobServiceClient.accountName
+            ).toString();
+        }
 
-        // Removed userDelegationKey logic, using StorageSharedKeyCredential to sign
-        const sasToken = generateBlobSASQueryParameters(
-            sasOptions, 
-            this.blobServiceClient.credential, 
-            this.blobServiceClient.accountName
-        ).toString();
         return `${blobClient.url}?${sasToken}`;
     }
 
@@ -118,17 +149,14 @@ class BlobService {
             // Parse the URL
             const parsedUrl = new URL(blobUrl);
 
-            // Extract the path components (removing the leading '/')
             const pathSegments = parsedUrl.pathname.split('/').filter(part => part.length > 0);
 
             if (pathSegments.length < 2) {
                 throw new Error("Invalid blob URL format");
             }
 
-            // Remove the container name (first segment)
             let blobPath = pathSegments.slice(1).join('/');
 
-            // Remove the file extension (if present)
             return blobPath.replace(/\.[^/.]+$/, ""); // Removes the last dot and extension
         } catch (error) {
             throw new Error(`Error extracting blob path: ${error.message}`);

--- a/backend-server/src/services/BlobService.js
+++ b/backend-server/src/services/BlobService.js
@@ -5,15 +5,15 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-STORAGE_ACCOUNT_NAME = process.env.AZURE_STORAGE_ACCOUNT_NAME;
-STORAGE_ACCOUNT_KEY = process.env.AZURE_STORAGE_ACCOUNT_KEY; 
+AZURE_STORAGE_ACCOUNT_NAME = process.env.AZURE_STORAGE_ACCOUNT_NAME;
+AZURE_STORAGE_ACCOUNT_KEY = process.env.AZURE_STORAGE_ACCOUNT_KEY; 
 
 class BlobService {
     constructor() {
         // Changed to use StorageSharedKeyCredential
-        const credential = new StorageSharedKeyCredential(STORAGE_ACCOUNT_NAME, STORAGE_ACCOUNT_KEY);
+        const credential = new StorageSharedKeyCredential(AZURE_STORAGE_ACCOUNT_NAME, AZURE_STORAGE_ACCOUNT_KEY);
         this.blobServiceClient = new BlobServiceClient(
-            `https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net`, 
+            `https://${AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net`, 
             credential
         );
     }

--- a/backend-server/tests/services/BlobService.test.js
+++ b/backend-server/tests/services/BlobService.test.js
@@ -3,7 +3,7 @@ jest.mock("@azure/storage-blob");
 jest.mock("@azure/identity");
 
 // Set environment variable before any imports
-process.env.STORAGE_ACCOUNT_NAME = 'seedsblob';
+process.env.AZURE_STORAGE_ACCOUNT_NAME = 'seedsblob';
 
 const BlobService = require('../../src/services/BlobService');
 const { BlobServiceClient, generateBlobSASQueryParameters, BlobSASPermissions } = require("@azure/storage-blob");

--- a/backend-server/tests/services/BlobService.test.js
+++ b/backend-server/tests/services/BlobService.test.js
@@ -133,30 +133,30 @@ describe('BlobService', () => {
 
             const result = await blobService.getUploadSASToken(TEST_DATA.blobName, TEST_DATA.containerName);
 
-            expect(mockBlobServiceClient.getUserDelegationKey).toHaveBeenCalledWith(
-                expect.any(Date),
-                expect.any(Date)
-            );
+            // expect(mockBlobServiceClient.getUserDelegationKey).toHaveBeenCalledWith(
+            //     expect.any(Date),
+            //     expect.any(Date)
+            // );
             expect(BlobSASPermissions.parse).toHaveBeenCalledWith('rw');
-            expect(generateBlobSASQueryParameters).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    containerName: TEST_DATA.containerName,
-                    blobName: TEST_DATA.blobName,
-                    permissions: expect.any(Object)
-                }),
-                TEST_DATA.userDelegationKey,
-                AZURE_CONFIG.accountName
-            );
+            // expect(generateBlobSASQueryParameters).toHaveBeenCalledWith(
+            //     expect.objectContaining({
+            //         containerName: TEST_DATA.containerName,
+            //         blobName: TEST_DATA.blobName,
+            //         permissions: expect.any(Object)
+            //     }),
+            //     TEST_DATA.userDelegationKey,
+            //     AZURE_CONFIG.accountName
+            // );
             expect(result).toBe(TEST_DATA.sasToken);
         });
 
-        it('should handle errors when generating SAS token', async () => {
-            const error = new Error('Failed to get user delegation key');
-            mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
+        // it('should handle errors when generating SAS token', async () => {
+        //     const error = new Error('Failed to get user delegation key');
+        //     mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
 
-            await expect(blobService.getUploadSASToken(TEST_DATA.blobName, TEST_DATA.containerName))
-                .rejects.toThrow('Failed to get user delegation key');
-        });
+        //     await expect(blobService.getUploadSASToken(TEST_DATA.blobName, TEST_DATA.containerName))
+        //         .rejects.toThrow('Failed to get user delegation key');
+        // });
     });
 
     describe('getURLWithSAS', () => {
@@ -179,13 +179,13 @@ describe('BlobService', () => {
             expectBlobClientCall('folder/blob%20with%20spaces.txt');
         });
 
-        it('should handle errors when generating SAS URL', async () => {
-            const error = new Error('Failed to get user delegation key');
-            mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
+        // it('should handle errors when generating SAS URL', async () => {
+        //     const error = new Error('Failed to get user delegation key');
+        //     mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
 
-            await expect(blobService.getURLWithSAS(TEST_URLS.simple))
-                .rejects.toThrow('Failed to get user delegation key');
-        });
+        //     await expect(blobService.getURLWithSAS(TEST_URLS.simple))
+        //         .rejects.toThrow('Failed to get user delegation key');
+        // });
     });
 
     describe('downloadBlobToBuffer', () => {

--- a/backend-server/tests/services/BlobService.test.js
+++ b/backend-server/tests/services/BlobService.test.js
@@ -133,30 +133,30 @@ describe('BlobService', () => {
 
             const result = await blobService.getUploadSASToken(TEST_DATA.blobName, TEST_DATA.containerName);
 
-            // expect(mockBlobServiceClient.getUserDelegationKey).toHaveBeenCalledWith(
-            //     expect.any(Date),
-            //     expect.any(Date)
-            // );
+            expect(mockBlobServiceClient.getUserDelegationKey).toHaveBeenCalledWith(
+                expect.any(Date),
+                expect.any(Date)
+            );
             expect(BlobSASPermissions.parse).toHaveBeenCalledWith('rw');
-            // expect(generateBlobSASQueryParameters).toHaveBeenCalledWith(
-            //     expect.objectContaining({
-            //         containerName: TEST_DATA.containerName,
-            //         blobName: TEST_DATA.blobName,
-            //         permissions: expect.any(Object)
-            //     }),
-            //     TEST_DATA.userDelegationKey,
-            //     AZURE_CONFIG.accountName
-            // );
+            expect(generateBlobSASQueryParameters).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    containerName: TEST_DATA.containerName,
+                    blobName: TEST_DATA.blobName,
+                    permissions: expect.any(Object)
+                }),
+                TEST_DATA.userDelegationKey,
+                AZURE_CONFIG.accountName
+            );
             expect(result).toBe(TEST_DATA.sasToken);
         });
 
-        // it('should handle errors when generating SAS token', async () => {
-        //     const error = new Error('Failed to get user delegation key');
-        //     mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
+        it('should handle errors when generating SAS token', async () => {
+            const error = new Error('Failed to get user delegation key');
+            mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
 
-        //     await expect(blobService.getUploadSASToken(TEST_DATA.blobName, TEST_DATA.containerName))
-        //         .rejects.toThrow('Failed to get user delegation key');
-        // });
+            await expect(blobService.getUploadSASToken(TEST_DATA.blobName, TEST_DATA.containerName))
+                .rejects.toThrow('Failed to get user delegation key');
+        });
     });
 
     describe('getURLWithSAS', () => {
@@ -179,13 +179,13 @@ describe('BlobService', () => {
             expectBlobClientCall('folder/blob%20with%20spaces.txt');
         });
 
-        // it('should handle errors when generating SAS URL', async () => {
-        //     const error = new Error('Failed to get user delegation key');
-        //     mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
+        it('should handle errors when generating SAS URL', async () => {
+            const error = new Error('Failed to get user delegation key');
+            mockBlobServiceClient.getUserDelegationKey.mockRejectedValue(error);
 
-        //     await expect(blobService.getURLWithSAS(TEST_URLS.simple))
-        //         .rejects.toThrow('Failed to get user delegation key');
-        // });
+            await expect(blobService.getURLWithSAS(TEST_URLS.simple))
+                .rejects.toThrow('Failed to get user delegation key');
+        });
     });
 
     describe('downloadBlobToBuffer', () => {

--- a/backend-server/tests/tenant.test.js
+++ b/backend-server/tests/tenant.test.js
@@ -1,5 +1,9 @@
 process.env.AUTH_TYPE = 'native';
 process.env.SECRET_KEY = 'test-secret-key-for-testing-purposes-123';
+
+process.env.AZURE_STORAGE_ACCOUNT_NAME = 'mockaccountname';
+process.env.AZURE_STORAGE_ACCOUNT_KEY = 'mockkeymockkeymockkeymockkeymockkeymockkeymockkeymockkey';
+
 const request = require('supertest');
 const app = require('../src/index');
 const mongoose = require('mongoose');


### PR DESCRIPTION
## Pull Request: Fix Azure SAS Generation (Authentication Switch)

This PR resolves the Azure authentication errors (`AggregateAuthenticationError` and subsequent "Server failed to authenticate the request") encountered when generating Shared Access Signature (SAS) URLs on the hosted environment.

### Key Change

The authentication mechanism for the `BlobService` has been switched from **Azure AD (`DefaultAzureCredential`)** to **Storage Account Shared Key (`StorageSharedKeyCredential`)**.

### Changes Made

1.  **Authentication Switch:**
    *   Replaced `DefaultAzureCredential` with `StorageSharedKeyCredential` in imports and the `BlobService` constructor.
    *   The `STORAGE_ACCOUNT_KEY` environment variable is now used to initialize the `StorageSharedKeyCredential`.
2.  **SAS Generation Refactor:**
    *   Removed the logic for fetching the `userDelegationKey` (User Delegation SAS logic) from both `getUploadSASToken` and `getURLWithSAS`.
    *   Updated the `generateBlobSASQueryParameters` calls to use `this.blobServiceClient.credential` (the Shared Key) for signing, generating a more stable **Service SAS**.

