### PR TITLE
unused permissions removed

### DIFF
--- a/Teacher-App/app/src/main/AndroidManifest.xml
+++ b/Teacher-App/app/src/main/AndroidManifest.xml
@@ -5,10 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS"/>
-    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
-
-    
 
     <application
         android:name=".SeedsApplication"

--- a/Teacher-App/app/src/main/java/com/example/seeds/utils/ContactUtils.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/utils/ContactUtils.kt
@@ -101,19 +101,4 @@ class ContactUtils constructor(private val context: Context) {
     fun getNameFromString(studentString: String): String {
         return contactsMap[studentString]?.name ?: studentString
     }
-
-
-    fun getDevicePhoneNumber(): String? {
-        val tm = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
-        if (ActivityCompat.checkSelfPermission(
-                context,
-                Manifest.permission.READ_PHONE_NUMBERS
-            )
-            != PackageManager.PERMISSION_GRANTED
-        ) {
-            // Permission not granted
-            return null
-        }
-        return tm.line1Number
-    }
 }


### PR DESCRIPTION

### 1. Manifest Cleanup
- Removed two unnecessary permissions from:
  ```
  AndroidManifest.xml
  ```
- This helps reduce the app’s permission footprint and enhances overall security.

### 2. Code Refactor
- Deleted the method:
  ```
  getDevicePhoneNumber()
  ```
  located in:
  ```
  ContactUtils.kt
  ```
, as it was using **READ_PHONE_NUMBERS** permission.

