### PR TITLE
Android review bugs

### DIFF
--- a/Teacher-App/app/src/main/java/com/example/seeds/MainActivity.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/MainActivity.kt
@@ -106,6 +106,17 @@ class MainActivity : AppCompatActivity() {
             drawerLayout
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
+
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            if (destination.id == R.id.callFragment) {
+                supportActionBar?.setDisplayHomeAsUpEnabled(false)
+                supportActionBar?.setHomeButtonEnabled(false)
+                binding.mainToolbar.navigationIcon = null
+                drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
+            } else {
+                drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
+            }
+        }
         navView.setupWithNavController(navController)
     }
 

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/classroom/ClassroomFragment.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/classroom/ClassroomFragment.kt
@@ -14,6 +14,7 @@ import com.example.seeds.databinding.FragmentClassroomBinding
 import com.example.seeds.model.Classroom
 import com.example.seeds.ui.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
 @AndroidEntryPoint
 class ClassroomFragment : BaseFragment() {
@@ -98,10 +99,10 @@ class ClassroomFragment : BaseFragment() {
             }
         }
 
-        // 2. Choose Audio (New - Optional, goes to Home/Library)
         viewModel.navigateToLibrary.observe(viewLifecycleOwner) { shouldNavigate ->
             if (shouldNavigate) {
-                findNavController().navigate(R.id.homeFragment)
+                val bottomNav = requireActivity().findViewById<BottomNavigationView>(R.id.nav_view)
+                bottomNav.selectedItemId = R.id.homeFragment 
                 viewModel.onNavigationComplete()
             }
         }

--- a/Teacher-App/app/src/main/res/layout/student_call_item_row.xml
+++ b/Teacher-App/app/src/main/res/layout/student_call_item_row.xml
@@ -105,7 +105,7 @@
                 android:onClick="@{() -> viewModel.connectParticipant(studentCallStatus.name, studentCallStatus.phoneNumber)}"
                 android:padding="8dp"
                 android:src="@drawable/ic_retry"
-                android:visibility="@{studentCallStatus.callerState == CallerState.UNANSWERED || studentCallStatus.callerState == CallerState.BUSY || studentCallStatus.callerState == CallerState.TIMEOUT || studentCallStatus.callerState == CallerState.COMPLETED || studentCallStatus.callerState == CallerState.FAILED || studentCallStatus.callerState == CallerState.CANCELLED || studentCallStatus.callerState == CallerState.REJECTED ? View.VISIBLE: View.GONE}"
+                android:visibility="@{studentCallStatus.callerState == CallerState.DISCONNECTED || studentCallStatus.callerState == CallerState.UNANSWERED || studentCallStatus.callerState == CallerState.BUSY || studentCallStatus.callerState == CallerState.TIMEOUT || studentCallStatus.callerState == CallerState.COMPLETED || studentCallStatus.callerState == CallerState.FAILED || studentCallStatus.callerState == CallerState.CANCELLED || studentCallStatus.callerState == CallerState.REJECTED ? View.VISIBLE: View.GONE}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
These were the bugs that were noticed during the demo run of the seeds app:

| Bug | Fix | Files |
|:-------------:|:--------------:|:--------------:|
| Retry button disappeared     |  Added Callstatus.Disconnected to the responsible view  |    res/layout/student_call_item_row.xml    |
| UI would get stuck on choose audio menu if navigated thru last played menu     | Replaced `findNavController().navigate()` with `requireActivity().findViewById<BottomNavigationView>(R.id.nav_view).selectedItemId = R.id.homeFragment`  to correctly switch tabs instead of pushing a screen onto the current stack.        |   ui/classroom/ClassroomFragment.kt    |
| Back button was still present in the call fragment | Removed back button from call fragment |MainActivity.kt |


