### PR TITLE
fix add students

### DIFF
--- a/teacher-webapp/src/callPage.js
+++ b/teacher-webapp/src/callPage.js
@@ -27,8 +27,15 @@ const getPhoneNumber = (user) => user?.phoneNumber;
 
 export function DetailsPage() {
   const navigate = useNavigate();
-  const { userList, confId, isConfCallRunning, audioContentState, conferenceStudents } =
-    useConference();
+  const {
+    userList,
+    confId,
+    isConfCallRunning,
+    audioContentState,
+    conferenceStudents,
+    selectedTeacher,
+    allClassroomStudents,
+  } = useConference();
 
   const [users, setUsers] = useState(userList);
   const [loadingIds, setLoadingIds] = useState([]);
@@ -241,7 +248,7 @@ export function DetailsPage() {
   };
 
   // Filter out students who are already in the userList
-  const availableStudents = conferenceStudents.filter(
+  const availableStudents = allClassroomStudents.filter(
     (student) =>
       !userList.some(
         (user) =>

--- a/teacher-webapp/src/context/ConferenceContext.js
+++ b/teacher-webapp/src/context/ConferenceContext.js
@@ -15,6 +15,7 @@ export const ConferenceProvider = ({ children }) => {
   const [confId, setConfId] = useState("");
   const [loading, setLoading] = useState(false);
   const [conferenceStudents, setConferenceStudents] = useState([]);
+  const [allClassroomStudents, setAllClassroomStudents] = useState([]);
   const previousParticipantStatusRef = useRef({});
 
   // Updates the `userList` whenever teacher or students are selected
@@ -140,6 +141,8 @@ export const ConferenceProvider = ({ children }) => {
         handleStudentToggle,
         setConferenceStudents,
         conferenceStudents,
+        allClassroomStudents,
+        setAllClassroomStudents,
       }}
     >
       {children}

--- a/teacher-webapp/src/pages/ClassroomDetail.js
+++ b/teacher-webapp/src/pages/ClassroomDetail.js
@@ -59,6 +59,7 @@ const ClassroomDetail = () => {
     handleStudentToggle,
     handleTeacherSelect,
     setConferenceStudents,
+    setAllClassroomStudents,
   } = useConference();
 
   // Main data loading effect - handles sequential and parallel fetching
@@ -222,7 +223,18 @@ const ClassroomDetail = () => {
       const conferenceId = data.id;
       setConfId(conferenceId);
       setConferenceId(conferenceId);
+
       setConferenceStudents(selectedStudents);
+
+      // Pass ALL students with both property name formats for "Add Participant" modal
+      // This allows adding unselected students later
+      const allStudentsFormatted = teacherStudentsList.map((student) => ({
+        name: student.name,
+        phoneNumber: student.phoneNumber,
+        phone_number: student.phoneNumber, // For AddParticipantModal compatibility
+      }));
+      setAllClassroomStudents(allStudentsFormatted);
+
       console.log("Conference created successfully. Conf ID:", conferenceId);
       console.log("Student phones sent:", studentPhonesFormatted);
 


### PR DESCRIPTION
This pull request enhances the conference call functionality by introducing a new state, `allClassroomStudents`, making it possible to add students who were not initially selected to join an ongoing conference. The changes ensure that the list of all students in the classroom is available throughout relevant components, enabling more flexible participant management.

Key changes include:

**State Management Enhancements:**

* Added `allClassroomStudents` state and its setter to `ConferenceContext` to keep track of all students in the classroom, not just those currently in the conference. [[1]](diffhunk://#diff-1f3eb8dfd5a3aeb2a90a00b9ca1d400d6a866915e4df6ce125531477129fc270R18) [[2]](diffhunk://#diff-1f3eb8dfd5a3aeb2a90a00b9ca1d400d6a866915e4df6ce125531477129fc270R144-R145)

**Data Flow Improvements:**

* In `ClassroomDetail`, after creating a conference, the code now formats and sets the complete list of classroom students (with both `phoneNumber` and `phone_number` properties) into `allClassroomStudents` for compatibility with other components like the "Add Participant" modal.
* Passed `setAllClassroomStudents` from context into `ClassroomDetail` to enable this update.

**UI Logic Updates:**

* In `DetailsPage`, switched the source of available students for adding to the conference from `conferenceStudents` to `allClassroomStudents`, allowing users to add any classroom student who is not already a participant.
* Updated the destructuring from `useConference` in `DetailsPage` to include `allClassroomStudents` and `selectedTeacher`, ensuring all necessary data is available.