### PR TITLE
159 implement remove/disconnect participants functionality

### DIFF
--- a/ConferenceV2/app/routers/conference.py
+++ b/ConferenceV2/app/routers/conference.py
@@ -193,7 +193,7 @@ async def play_audio(conference_id: str, url: str):
 
 
 @router.put("/pauseaudio/{conference_id}")
-async def play_audio(conference_id: str):
+async def pause_audio(conference_id: str):
     conference = conference_manager.get_conference(conference_id)
     if not conference:
         raise HTTPException(status_code=404, detail="Conference not found")
@@ -202,7 +202,7 @@ async def play_audio(conference_id: str):
 
 
 @router.put("/resumeaudio/{conference_id}")
-async def play_audio(conference_id: str):
+async def resume_audio(conference_id: str):
     conference = conference_manager.get_conference(conference_id)
     if not conference:
         raise HTTPException(status_code=404, detail="Conference not found")

--- a/ConferenceV2/app/routers/conference.py
+++ b/ConferenceV2/app/routers/conference.py
@@ -107,7 +107,7 @@ async def add_participant(conference_id: str, phone_number: str):
 
 
 @router.put("/removeparticipant/{conference_id}")
-async def add_participant(conference_id: str, phone_number: str):
+async def remove_participant(conference_id: str, phone_number: str):
     conference = conference_manager.get_conference(conference_id)
     if not conference:
         raise HTTPException(status_code=404, detail="Conference not found")

--- a/Teacher-App/app/src/main/java/com/example/seeds/model/ParticipantTracker.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/model/ParticipantTracker.kt
@@ -1,0 +1,12 @@
+package com.example.seeds.model
+
+/**
+ * Tracks a participant's call state for the duration of the call.
+ * Used to determine removed/disconnected participants and reconnect eligibility.
+ */
+data class ParticipantTracker(
+    val phoneNumber: String,
+    val currentState: CallerState,
+    val previousState: CallerState?,
+    val hasBeenInCall: Boolean
+)

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
@@ -178,6 +178,8 @@ class CallViewModel @Inject constructor(
         get() = _participantDropped
 
     private val previousStudentStates = mutableMapOf<String, CallerState?>()
+    // Track participants that were in the call (for handling removals)
+    private val participantsInCall = mutableSetOf<String>()
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
@@ -422,6 +424,14 @@ class CallViewModel @Inject constructor(
                                         val currentStudentList = _callState.value ?: emptyList()
                                         val currentStudentMap = currentStudentList.associateBy { it.phoneNumber }
                                         
+                                        // Track participants from server response
+                                        val serverParticipantPhones = partialStateMap.keys.filter { it != teacherPhoneNumber }.toSet()
+                                        
+                                        // Add new participants to tracking set
+                                        serverParticipantPhones.forEach { phoneNumber ->
+                                            participantsInCall.add(phoneNumber)
+                                        }
+                                        
                                         // Check for students transitioning from CONNECTED to DISCONNECTED
                                         partialStateMap
                                             .filter { it.key != teacherPhoneNumber }
@@ -440,7 +450,8 @@ class CallViewModel @Inject constructor(
                                                 previousStudentStates[phoneNumber] = currentState
                                             }
                                         
-                                        val newStudentList = partialStateMap
+                                        // Process participants from server response
+                                        val serverParticipants = partialStateMap
                                             .filter { it.key != teacherPhoneNumber } 
                                             .map { (phoneNumber, partialUpdate) ->
                                                 val existingStudent = currentStudentMap[phoneNumber]
@@ -454,8 +465,32 @@ class CallViewModel @Inject constructor(
                                                     isMuteUnmuteDone = existingStudent?.isMuteUnmuteDone ?: true
                                                 )
                                             }
-
-                                        val sortedList = newStudentList.sortedByDescending { it.raiseHand }
+                                        
+                                        // Handle participants that are missing from server response (removed)
+                                        // Keep them as DISCONNECTED so they can be reconnected
+                                        val removedParticipants = currentStudentList
+                                            .filter { it.phoneNumber != null }
+                                            .filter { it.phoneNumber !in serverParticipantPhones }
+                                            .filter { it.phoneNumber in participantsInCall } // Only if was in call
+                                            .mapNotNull { participant ->
+                                                val phoneNumber = participant.phoneNumber ?: return@mapNotNull null
+                                                val previousState = previousStudentStates[phoneNumber]
+                                                
+                                                // If was connected, mark as disconnected and keep in list
+                                                if (previousState == CallerState.CONNECTED || 
+                                                    participant.callerState == CallerState.CONNECTED) {
+                                                    Log.d("PARTICIPANT_REMOVED", "Keeping removed participant $phoneNumber as DISCONNECTED")
+                                                    previousStudentStates[phoneNumber] = CallerState.DISCONNECTED
+                                                    participant.copy(callerState = CallerState.DISCONNECTED)
+                                                } else {
+                                                    // If already disconnected or never connected, remove from list
+                                                    null
+                                                }
+                                            }
+                                        
+                                        // Combine server participants and removed participants (as disconnected)
+                                        val combinedList = serverParticipants + removedParticipants
+                                        val sortedList = combinedList.sortedByDescending { it.raiseHand }
                                         _callState.postValue(sortedList)
                                         updateStudentsNotOnCall(sortedList)
                                     }
@@ -604,9 +639,46 @@ class CallViewModel @Inject constructor(
                     _playerState.postValue(newPlayerState)
                 }
 
-                _callState.postValue(networkCallState.sortedByDescending { it.raiseHand })
+                // Track participants from server response
+                val serverParticipantPhones = networkCallState.mapNotNull { it.phoneNumber }.filter { it != teacherPhoneNumber }.toSet()
+                
+                // Add new participants to tracking set
+                serverParticipantPhones.forEach { phoneNumber ->
+                    participantsInCall.add(phoneNumber)
+                }
+                
+                // Get current state to check for removed participants
+                val currentStudentList = _callState.value ?: emptyList()
+                
+                // Handle participants that are missing from server response (removed)
+                // Keep them as DISCONNECTED so they can be reconnected
+                val removedParticipants = currentStudentList
+                    .filter { it.phoneNumber != null }
+                    .filter { it.phoneNumber !in serverParticipantPhones }
+                    .filter { it.phoneNumber in participantsInCall } // Only if was in call
+                    .mapNotNull { participant ->
+                        val phoneNumber = participant.phoneNumber ?: return@mapNotNull null
+                        val previousState = previousStudentStates[phoneNumber]
+                        
+                        // If was connected, mark as disconnected and keep in list
+                        if (previousState == CallerState.CONNECTED || 
+                            participant.callerState == CallerState.CONNECTED) {
+                            Log.d("PARTICIPANT_REMOVED", "Keeping removed participant $phoneNumber as DISCONNECTED in refresh")
+                            previousStudentStates[phoneNumber] = CallerState.DISCONNECTED
+                            participant.copy(callerState = CallerState.DISCONNECTED)
+                        } else {
+                            // If already disconnected or never connected, remove from list
+                            null
+                        }
+                    }
+                
+                // Combine server participants and removed participants (as disconnected)
+                val combinedList = networkCallState + removedParticipants
+                val sortedList = combinedList.sortedByDescending { it.raiseHand }
+                
+                _callState.postValue(sortedList)
                 _teacherCallStatus.postValue(networkCallState.find {it.phoneNumber == teacherPhoneNumber})
-                updateStudentsNotOnCall(networkCallState)
+                updateStudentsNotOnCall(sortedList)
                 _isMutedAll.value = networkCallState.filter { it.phoneNumber != teacherPhoneNumber }.all { it.isMuted }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh call state", e)
@@ -759,6 +831,10 @@ class CallViewModel @Inject constructor(
     fun connectParticipant(name: String, phoneNumber: String) {
         val confId = _callToken.value?.confId ?: return
         val currentList = _callState.value?.toMutableList() ?: return
+        
+        // Add to tracking set when attempting to connect
+        participantsInCall.add(phoneNumber)
+        
         val studentIndex = currentList.indexOfFirst { it.phoneNumber == phoneNumber }
         if (studentIndex != -1) {
             currentList[studentIndex] = currentList[studentIndex].copy(callerState = CallerState.RINGING)
@@ -769,7 +845,7 @@ class CallViewModel @Inject constructor(
             try {
                 val fullUrl = "$conferenceUrl/conference/addparticipant/$confId"
                 val response = network.connectParticipant(fullUrl, phoneNumber)
-                if (!response.isSuccessful) refreshCallState()
+                if (!response.isSuccessful) refreshCallState() 
             } catch (e: Exception) {
                 refreshCallState() 
             }
@@ -780,9 +856,13 @@ class CallViewModel @Inject constructor(
     fun disconnectParticipant(phoneNumber: String) {
         val confId = _callToken.value?.confId ?: return
         val currentList = _callState.value?.toMutableList() ?: return
+        
+        // Optimistic update: Mark as DISCONNECTED (not TIMEOUT) so reconnect button appears
         val updatedList = currentList.map { participant ->
             if (participant.phoneNumber == phoneNumber) {
-                participant.copy(callerState = CallerState.TIMEOUT)
+                // Update previous state tracking
+                previousStudentStates[phoneNumber] = CallerState.DISCONNECTED
+                participant.copy(callerState = CallerState.DISCONNECTED)
             } else {
                 participant
             }
@@ -793,8 +873,14 @@ class CallViewModel @Inject constructor(
             try {
                 val fullUrl = "$conferenceUrl/conference/removeparticipant/$confId"
                 val response = network.disconnectParticipant(fullUrl, phoneNumber)
-                if (!response.isSuccessful) refreshCallState() 
+                if (!response.isSuccessful) {
+                    // On failure, refresh to get server state
+                    refreshCallState()
+                }
+                // On success, next polling cycle will handle the state correctly
+                // The participant will be kept as DISCONNECTED by the polling logic
             } catch (e: Exception) {
+                // On exception, refresh to get server state
                 refreshCallState()
             }
         }

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
@@ -72,8 +72,7 @@ class CallViewModel @Inject constructor(
     val leader = args.leader.toString()
 
     private var callStarted = false
-    private var phoneNumbers: List<String> = args.phoneNumbers.toMutableList()
-
+    
     private var allStudents = listOf<Student>()
     private var teacherStudentsMap: Map<String, Student> = emptyMap()
     
@@ -83,6 +82,13 @@ class CallViewModel @Inject constructor(
     private var isPollingStarted = false
 
     val teacherPhoneNumber = "91${teacherRepository.getTeacherPhoneNumber()}"
+    
+    // Filter out teacher phone
+    // args.phoneNumbers should only contain selected students from CallSettingsFragment
+    private var phoneNumbers: List<String> = args.phoneNumbers
+        .filter { it != teacherPhoneNumber } // Remove teacher phone if present
+        .distinct()
+        .toMutableList()
 
     var content: Content? = args.classroom?.contents?.firstOrNull()
 
@@ -201,16 +207,30 @@ class CallViewModel @Inject constructor(
                 loadCorrectStudentNames()
             }
 
-            val initialCallStatuses = args.classroom.students.map { student ->
-                StudentCallStatus(
-                    name = student.name,
-                    phoneNumber = student.phoneNumber,
-                    callerState = CallerState.RINGING,
-                    isMuted = false,
-                    onHold = false,
-                    raiseHand = false
-                )
-            }
+            // Only create initial call statuses for selected students (phoneNumbers)
+            // Filter classroom students to only include those in phoneNumbers
+            val selectedStudentPhones = phoneNumbers.toSet()
+            val initialCallStatuses = args.classroom.students
+                .filter { student -> 
+                    // Normalize phone number for comparison
+                    val normalizedPhone = if (student.phoneNumber.startsWith("91")) {
+                        student.phoneNumber
+                    } else {
+                        "91${student.phoneNumber}"
+                    }
+                    selectedStudentPhones.contains(normalizedPhone) || 
+                    selectedStudentPhones.contains(student.phoneNumber)
+                }
+                .map { student ->
+                    StudentCallStatus(
+                        name = student.name,
+                        phoneNumber = student.phoneNumber,
+                        callerState = CallerState.RINGING,
+                        isMuted = false,
+                        onHold = false,
+                        raiseHand = false
+                    )
+                }
             _callState.postValue(initialCallStatuses)
             updateStudentsNotOnCall(initialCallStatuses)
 
@@ -512,12 +532,21 @@ class CallViewModel @Inject constructor(
             try {
                 val names = mutableListOf<String>()
                 names.add("Teacher")
-                for (num in args.phoneNumbers.drop(1)) {
-                    val student = args.classroom.students.find { it.phoneNumber == num }
+                // Use phoneNumbers (which only contains selected students)
+                for (num in phoneNumbers) {
+                    val student = args.classroom.students.find { 
+                        val normalizedPhone = if (it.phoneNumber.startsWith("91")) {
+                            it.phoneNumber
+                        } else {
+                            "91${it.phoneNumber}"
+                        }
+                        it.phoneNumber == num || normalizedPhone == num
+                    }
                     if (student != null) names.add(student.name)
                 }
 
                 val fullUrl = "$conferenceUrl/conference/start/$confId"
+                // Use phoneNumbers which only contains selected students (teacher phone already filtered out)
                 val response = network.startCall(fullUrl, CallDetails(confId, phoneNumbers, names))
 
                 if (response.isSuccessful) {

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
@@ -21,6 +21,7 @@ import com.example.seeds.model.Classroom
 import com.example.seeds.model.ConferenceCreateRequest
 import com.example.seeds.model.Content
 import com.example.seeds.model.Student
+import com.example.seeds.model.ParticipantTracker
 import com.example.seeds.model.StudentCallStatus
 import com.example.seeds.model.PlayerState
 import com.example.seeds.model.SessionHistoryItem
@@ -31,6 +32,7 @@ import com.example.seeds.repository.ContentRepository
 import com.example.seeds.repository.TeacherRepository
 import com.example.seeds.repository.UserPreferencesRepository
 import com.example.seeds.repository.TeacherStudentsDirectory
+import com.example.seeds.utils.CallUtils
 import com.example.seeds.utils.Constants
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -183,9 +185,8 @@ class CallViewModel @Inject constructor(
     val participantDropped: LiveData<String?>
         get() = _participantDropped
 
-    private val previousStudentStates = mutableMapOf<String, CallerState?>()
-    // Track participants that were in the call (for handling removals)
-    private val participantsInCall = mutableSetOf<String>()
+    
+    private val participantTrackers = mutableMapOf<String, ParticipantTracker>()
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
@@ -207,30 +208,11 @@ class CallViewModel @Inject constructor(
                 loadCorrectStudentNames()
             }
 
-            // Only create initial call statuses for selected students (phoneNumbers)
-            // Filter classroom students to only include those in phoneNumbers
             val selectedStudentPhones = phoneNumbers.toSet()
-            val initialCallStatuses = args.classroom.students
-                .filter { student -> 
-                    // Normalize phone number for comparison
-                    val normalizedPhone = if (student.phoneNumber.startsWith("91")) {
-                        student.phoneNumber
-                    } else {
-                        "91${student.phoneNumber}"
-                    }
-                    selectedStudentPhones.contains(normalizedPhone) || 
-                    selectedStudentPhones.contains(student.phoneNumber)
-                }
-                .map { student ->
-                    StudentCallStatus(
-                        name = student.name,
-                        phoneNumber = student.phoneNumber,
-                        callerState = CallerState.RINGING,
-                        isMuted = false,
-                        onHold = false,
-                        raiseHand = false
-                    )
-                }
+            val initialCallStatuses = CallUtils.buildInitialCallStatuses(
+                args.classroom.students,
+                selectedStudentPhones
+            )
             _callState.postValue(initialCallStatuses)
             updateStudentsNotOnCall(initialCallStatuses)
 
@@ -446,30 +428,19 @@ class CallViewModel @Inject constructor(
                                         
                                         // Track participants from server response
                                         val serverParticipantPhones = partialStateMap.keys.filter { it != teacherPhoneNumber }.toSet()
-                                        
-                                        // Add new participants to tracking set
-                                        serverParticipantPhones.forEach { phoneNumber ->
-                                            participantsInCall.add(phoneNumber)
-                                        }
-                                        
-                                        // Check for students transitioning from CONNECTED to DISCONNECTED
+
                                         partialStateMap
                                             .filter { it.key != teacherPhoneNumber }
                                             .forEach { (phoneNumber, partialUpdate) ->
-                                                val previousState = previousStudentStates[phoneNumber]
+                                                val previousState = updateTrackerFromServerState(phoneNumber, partialUpdate.callerState)
                                                 val currentState = partialUpdate.callerState
-                                                
                                                 Log.d("STUDENT_STATE", "Student $phoneNumber: $previousState -> $currentState")
-                                                
                                                 if (previousState == CallerState.CONNECTED && currentState == CallerState.DISCONNECTED) {
                                                     Log.d("STUDENT_DROP", "Student $phoneNumber disconnected, posting notification")
                                                     _participantDropped.postValue(phoneNumber)
                                                 }
-                                                
-                                                // Update previous state
-                                                previousStudentStates[phoneNumber] = currentState
                                             }
-                                        
+
                                         // Process participants from server response
                                         val serverParticipants = partialStateMap
                                             .filter { it.key != teacherPhoneNumber } 
@@ -486,28 +457,10 @@ class CallViewModel @Inject constructor(
                                                 )
                                             }
                                         
-                                        // Handle participants that are missing from server response (removed)
-                                        // Keep them as DISCONNECTED so they can be reconnected
-                                        val removedParticipants = currentStudentList
-                                            .filter { it.phoneNumber != null }
-                                            .filter { it.phoneNumber !in serverParticipantPhones }
-                                            .filter { it.phoneNumber in participantsInCall } // Only if was in call
-                                            .mapNotNull { participant ->
-                                                val phoneNumber = participant.phoneNumber ?: return@mapNotNull null
-                                                val previousState = previousStudentStates[phoneNumber]
-                                                
-                                                // If was connected, mark as disconnected and keep in list
-                                                if (previousState == CallerState.CONNECTED || 
-                                                    participant.callerState == CallerState.CONNECTED) {
-                                                    Log.d("PARTICIPANT_REMOVED", "Keeping removed participant $phoneNumber as DISCONNECTED")
-                                                    previousStudentStates[phoneNumber] = CallerState.DISCONNECTED
-                                                    participant.copy(callerState = CallerState.DISCONNECTED)
-                                                } else {
-                                                    // If already disconnected or never connected, remove from list
-                                                    null
-                                                }
-                                            }
-                                        
+                                        val removedParticipants = computeRemovedParticipantsAsDisconnected(
+                                            currentStudentList, serverParticipantPhones, fromRefresh = false
+                                        )
+
                                         // Combine server participants and removed participants (as disconnected)
                                         val combinedList = serverParticipants + removedParticipants
                                         val sortedList = combinedList.sortedByDescending { it.raiseHand }
@@ -625,6 +578,7 @@ class CallViewModel @Inject constructor(
 
     override fun onCleared() {
         closeSocket()
+        participantTrackers.clear()
     }
     
     fun rejoinTeacher() {
@@ -668,39 +622,18 @@ class CallViewModel @Inject constructor(
                     _playerState.postValue(newPlayerState)
                 }
 
-                // Track participants from server response
                 val serverParticipantPhones = networkCallState.mapNotNull { it.phoneNumber }.filter { it != teacherPhoneNumber }.toSet()
-                
-                // Add new participants to tracking set
-                serverParticipantPhones.forEach { phoneNumber ->
-                    participantsInCall.add(phoneNumber)
-                }
-                
-                // Get current state to check for removed participants
-                val currentStudentList = _callState.value ?: emptyList()
-                
-                // Handle participants that are missing from server response (removed)
-                // Keep them as DISCONNECTED so they can be reconnected
-                val removedParticipants = currentStudentList
-                    .filter { it.phoneNumber != null }
-                    .filter { it.phoneNumber !in serverParticipantPhones }
-                    .filter { it.phoneNumber in participantsInCall } // Only if was in call
-                    .mapNotNull { participant ->
-                        val phoneNumber = participant.phoneNumber ?: return@mapNotNull null
-                        val previousState = previousStudentStates[phoneNumber]
-                        
-                        // If was connected, mark as disconnected and keep in list
-                        if (previousState == CallerState.CONNECTED || 
-                            participant.callerState == CallerState.CONNECTED) {
-                            Log.d("PARTICIPANT_REMOVED", "Keeping removed participant $phoneNumber as DISCONNECTED in refresh")
-                            previousStudentStates[phoneNumber] = CallerState.DISCONNECTED
-                            participant.copy(callerState = CallerState.DISCONNECTED)
-                        } else {
-                            // If already disconnected or never connected, remove from list
-                            null
-                        }
+                networkCallState
+                    .filter { it.phoneNumber != null && it.phoneNumber != teacherPhoneNumber }
+                    .forEach { status ->
+                        status.phoneNumber?.let { updateTrackerFromServerState(it, status.callerState ?: CallerState.UNDEFINED) }
                     }
-                
+
+                val currentStudentList = _callState.value ?: emptyList()
+                val removedParticipants = computeRemovedParticipantsAsDisconnected(
+                    currentStudentList, serverParticipantPhones, fromRefresh = true
+                )
+
                 // Combine server participants and removed participants (as disconnected)
                 val combinedList = networkCallState + removedParticipants
                 val sortedList = combinedList.sortedByDescending { it.raiseHand }
@@ -713,6 +646,51 @@ class CallViewModel @Inject constructor(
                 Log.e(TAG, "Failed to refresh call state", e)
             }
         }
+    }
+
+    /**
+     * Updates [participantTrackers] with server state for [phoneNumber]. Returns the previous state for transition detection.
+     */
+    private fun updateTrackerFromServerState(phoneNumber: String, newState: CallerState): CallerState? {
+        val existing = participantTrackers[phoneNumber]
+        val previousState = existing?.currentState
+        participantTrackers[phoneNumber] = ParticipantTracker(
+            phoneNumber = phoneNumber,
+            currentState = newState,
+            previousState = previousState,
+            hasBeenInCall = true
+        )
+        return previousState
+    }
+
+    /**
+     * Participants that are in [currentStudentList] and were in the call but are no longer in [serverParticipantPhones].
+     * They are returned as DISCONNECTED so they can be reconnected. [participantTrackers] is updated as a side effect.
+     * [fromRefresh] only affects the log message (e.g. "in refresh").
+     */
+    private fun computeRemovedParticipantsAsDisconnected(
+        currentStudentList: List<StudentCallStatus>,
+        serverParticipantPhones: Set<String>,
+        fromRefresh: Boolean = false
+    ): List<StudentCallStatus> {
+        val logSuffix = if (fromRefresh) " in refresh" else ""
+        return currentStudentList
+            .filter { it.phoneNumber != null }
+            .filter { it.phoneNumber !in serverParticipantPhones }
+            .filter { participant -> participantTrackers[participant.phoneNumber]?.hasBeenInCall == true }
+            .mapNotNull { participant ->
+                val phoneNumber = participant.phoneNumber ?: return@mapNotNull null
+                val tracker = participantTrackers[phoneNumber] ?: return@mapNotNull null
+                val wasConnected = tracker.previousState == CallerState.CONNECTED || participant.callerState == CallerState.CONNECTED
+                if (wasConnected) {
+                    Log.d("PARTICIPANT_REMOVED", "Keeping removed participant $phoneNumber as DISCONNECTED$logSuffix")
+                    participantTrackers[phoneNumber] = tracker.copy(
+                        currentState = CallerState.DISCONNECTED,
+                        previousState = tracker.currentState
+                    )
+                    participant.copy(callerState = CallerState.DISCONNECTED)
+                } else null
+            }
     }
 
     private fun updateStudentsNotOnCall(currentState: List<StudentCallStatus>?) {
@@ -860,10 +838,15 @@ class CallViewModel @Inject constructor(
     fun connectParticipant(name: String, phoneNumber: String) {
         val confId = _callToken.value?.confId ?: return
         val currentList = _callState.value?.toMutableList() ?: return
-        
-        // Add to tracking set when attempting to connect
-        participantsInCall.add(phoneNumber)
-        
+
+        val existing = participantTrackers[phoneNumber]
+        participantTrackers[phoneNumber] = ParticipantTracker(
+            phoneNumber = phoneNumber,
+            currentState = CallerState.RINGING,
+            previousState = existing?.currentState,
+            hasBeenInCall = true
+        )
+
         val studentIndex = currentList.indexOfFirst { it.phoneNumber == phoneNumber }
         if (studentIndex != -1) {
             currentList[studentIndex] = currentList[studentIndex].copy(callerState = CallerState.RINGING)
@@ -886,15 +869,17 @@ class CallViewModel @Inject constructor(
         val confId = _callToken.value?.confId ?: return
         val currentList = _callState.value?.toMutableList() ?: return
         
-        // Optimistic update: Mark as DISCONNECTED (not TIMEOUT) so reconnect button appears
+        val tracker = participantTrackers[phoneNumber]
+        if (tracker != null) {
+            participantTrackers[phoneNumber] = tracker.copy(
+                currentState = CallerState.DISCONNECTED,
+                previousState = tracker.currentState
+            )
+        }
+
         val updatedList = currentList.map { participant ->
-            if (participant.phoneNumber == phoneNumber) {
-                // Update previous state tracking
-                previousStudentStates[phoneNumber] = CallerState.DISCONNECTED
-                participant.copy(callerState = CallerState.DISCONNECTED)
-            } else {
-                participant
-            }
+            if (participant.phoneNumber == phoneNumber) participant.copy(callerState = CallerState.DISCONNECTED)
+            else participant
         }.toMutableList()
         _callState.postValue(updatedList)
 

--- a/Teacher-App/app/src/main/java/com/example/seeds/utils/CallUtils.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/utils/CallUtils.kt
@@ -1,0 +1,51 @@
+package com.example.seeds.utils
+
+import com.example.seeds.model.CallerState
+import com.example.seeds.model.Student
+import com.example.seeds.model.StudentCallStatus
+
+/**
+ * Utility for call-related logic, aligned with teacher-webapp (e.g. phone normalization, initial state).
+ */
+object CallUtils {
+
+    /**
+     * Normalizes a phone number to the format expected by the conference API (91XXXXXXXXXX).
+     * Mirrors [teacher-webapp] utils/phoneUtils.js.
+     */
+    fun normalizePhoneNumber(phoneNumber: String?): String {
+        if (phoneNumber.isNullOrBlank()) return ""
+        val normalized = if (phoneNumber.startsWith("91")) phoneNumber else "91$phoneNumber"
+        return normalized
+    }
+
+    /**
+     * Returns true if [student]'s phone is in [selectedStudentPhones] (normalized comparison).
+     */
+    fun isStudentSelected(student: Student, selectedStudentPhones: Set<String>): Boolean {
+        val normalized = normalizePhoneNumber(student.phoneNumber)
+        return selectedStudentPhones.contains(normalized) || selectedStudentPhones.contains(student.phoneNumber)
+    }
+
+    /**
+     * Builds initial [StudentCallStatus] list for selected students (RINGING, not muted).
+     * Filters [students] to those in [selectedStudentPhones] and maps to call status.
+     */
+    fun buildInitialCallStatuses(
+        students: List<Student>,
+        selectedStudentPhones: Set<String>
+    ): List<StudentCallStatus> {
+        return students
+            .filter { isStudentSelected(it, selectedStudentPhones) }
+            .map { student ->
+                StudentCallStatus(
+                    name = student.name,
+                    phoneNumber = student.phoneNumber,
+                    callerState = CallerState.RINGING,
+                    isMuted = false,
+                    onHold = false,
+                    raiseHand = false
+                )
+            }
+    }
+}

--- a/teacher-webapp/src/callPage.js
+++ b/teacher-webapp/src/callPage.js
@@ -1,5 +1,14 @@
-import React, { useState, useEffect, useRef } from "react";
-import { Box, Typography } from "@mui/material";
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { useConference } from "./context/ConferenceContext";
 import {
@@ -51,6 +60,7 @@ export function DetailsPage() {
   const [audioSelectionError, setAudioSelectionError] = useState(null);
   const [isMutingAll, setIsMutingAll] = useState(false);
   const [isUnmutingAll, setIsUnmutingAll] = useState(false);
+  const [removeConfirmParticipant, setRemoveConfirmParticipant] = useState(null);
 
   // Listen for conference notifications
   useEffect(() => {
@@ -297,40 +307,36 @@ export function DetailsPage() {
     }
   };
 
-  const handleRemoveParticipant = async (participant) => {
+  const handleRemoveParticipant = (participant) => {
     if (!confId) {
       showToast.error("Conference ID is missing");
       return;
     }
-
     if (!participant || !participant.phoneNumber) {
       showToast.error("Invalid participant");
       return;
     }
+    setRemoveConfirmParticipant(participant);
+  };
 
-    // Confirmation dialog
+  const handleRemoveConfirmClose = () => setRemoveConfirmParticipant(null);
+
+  const handleRemoveConfirm = async () => {
+    const participant = removeConfirmParticipant;
+    if (!participant || !confId) return;
+
     const participantName = participant.name || participant.phoneNumber;
-    const confirmed = window.confirm(
-      `Are you sure you want to remove ${participantName} from the conference?`
-    );
-
-    if (!confirmed) {
-      return;
-    }
-
     const phoneNumber = participant.phoneNumber;
     setRemovingIds((prev) => [...prev, phoneNumber]);
+    setRemoveConfirmParticipant(null);
 
     try {
       const normalizedPhone = normalizePhoneNumber(phoneNumber);
       await removeParticipant(confId, normalizedPhone);
       showToast.success(`${participantName} removed successfully`);
-      // SSE will automatically update the UI by removing the participant from participantsMap
     } catch (error) {
       console.error("Error removing participant:", error);
-      showToast.error(
-        `Failed to remove ${participantName}: ${error.message || "Unknown error"}`
-      );
+      showToast.error(`Failed to remove ${participantName}: ${error.message || "Unknown error"}`);
     } finally {
       setRemovingIds((prev) => prev.filter((id) => id !== phoneNumber));
     }
@@ -453,6 +459,30 @@ export function DetailsPage() {
         onClose={handleCloseAudioModal}
         onSubmit={handlePlaySelectedTrack}
       />
+
+      <Dialog
+        open={Boolean(removeConfirmParticipant)}
+        onClose={handleRemoveConfirmClose}
+        maxWidth="xs"
+        fullWidth
+        aria-labelledby="remove-participant-dialog-title"
+        aria-describedby="remove-participant-dialog-description"
+      >
+        <DialogTitle id="remove-participant-dialog-title">Remove participant</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="remove-participant-dialog-description">
+            {removeConfirmParticipant
+              ? `Are you sure you want to remove ${removeConfirmParticipant.name || removeConfirmParticipant.phoneNumber} from the conference?`
+              : ""}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleRemoveConfirmClose}>Cancel</Button>
+          <Button onClick={handleRemoveConfirm} color="error" variant="contained" autoFocus>
+            Remove
+          </Button>
+        </DialogActions>
+      </Dialog>
     </PageContainer>
   );
 }

--- a/teacher-webapp/src/callPage.js
+++ b/teacher-webapp/src/callPage.js
@@ -13,6 +13,7 @@ import {
   playAudio,
   pauseAudio,
   addParticipant,
+  removeParticipant,
   resumeAudio,
   seekAudio,
 } from "./services/apiService";
@@ -39,6 +40,7 @@ export function DetailsPage() {
 
   const [loadingIds, setLoadingIds] = useState([]);
   const [reconnectingIds, setReconnectingIds] = useState([]);
+  const [removingIds, setRemovingIds] = useState([]);
   const [isLoadingCall, setIsLoadingCall] = useState(false);
   const [isSinkingConf, setIsSinkingConf] = useState(false);
   const [hasSunkConf, setHasSunkConf] = useState(false);
@@ -295,6 +297,45 @@ export function DetailsPage() {
     }
   };
 
+  const handleRemoveParticipant = async (participant) => {
+    if (!confId) {
+      showToast.error("Conference ID is missing");
+      return;
+    }
+
+    if (!participant || !participant.phoneNumber) {
+      showToast.error("Invalid participant");
+      return;
+    }
+
+    // Confirmation dialog
+    const participantName = participant.name || participant.phoneNumber;
+    const confirmed = window.confirm(
+      `Are you sure you want to remove ${participantName} from the conference?`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const phoneNumber = participant.phoneNumber;
+    setRemovingIds((prev) => [...prev, phoneNumber]);
+
+    try {
+      const normalizedPhone = normalizePhoneNumber(phoneNumber);
+      await removeParticipant(confId, normalizedPhone);
+      showToast.success(`${participantName} removed successfully`);
+      // SSE will automatically update the UI by removing the participant from participantsMap
+    } catch (error) {
+      console.error("Error removing participant:", error);
+      showToast.error(
+        `Failed to remove ${participantName}: ${error.message || "Unknown error"}`
+      );
+    } finally {
+      setRemovingIds((prev) => prev.filter((id) => id !== phoneNumber));
+    }
+  };
+
   // Filter out students who are already in the call (using centralized participantsMap)
   const allParticipants = getAllParticipants();
   const availableStudents = (allClassroomStudents || []).filter((student) => {
@@ -321,6 +362,7 @@ export function DetailsPage() {
 
   const canReconnect = (user) => user?.call_status === "disconnected" && isConfCallRunning;
   const isReconnecting = (phoneNumber) => phoneNumber && reconnectingIds.includes(phoneNumber);
+  const isRemoving = (phoneNumber) => phoneNumber && removingIds.includes(phoneNumber);
 
   useEffect(() => {
     if (hasSunkConf) {
@@ -344,8 +386,10 @@ export function DetailsPage() {
           students={activeStudents}
           onMuteToggle={handleMuteToggle}
           onReconnect={handleReconnect}
+          onRemove={handleRemoveParticipant}
           isLoading={isLoading}
           isReconnecting={isReconnecting}
+          isRemoving={isRemoving}
           canReconnect={canReconnect}
         />
 

--- a/teacher-webapp/src/components/participants/ParticipantCard.js
+++ b/teacher-webapp/src/components/participants/ParticipantCard.js
@@ -15,6 +15,7 @@ import {
   School as SchoolIcon,
   PhoneCallback as ReconnectIcon,
   WavingHand as RaisedHandIcon,
+  PersonRemove as PersonRemoveIcon,
 } from "@mui/icons-material";
 
 export const ParticipantCard = ({
@@ -22,8 +23,10 @@ export const ParticipantCard = ({
   isTeacher = false,
   onMuteToggle,
   onReconnect,
+  onRemove,
   isLoading,
   isReconnecting,
+  isRemoving,
   canReconnect,
 }) => {
   // Defensive check: return null if participant is not provided
@@ -113,6 +116,23 @@ export const ParticipantCard = ({
               aria-label="Reconnect participant"
             >
               {isReconnecting ? <CircularProgress size={20} /> : <ReconnectIcon />}
+            </IconButton>
+          </Tooltip>
+        )}
+        {/* Remove button - only for students when connected */}
+        {!isTeacher && participant.call_status === "connected" && onRemove && (
+          <Tooltip title="Remove participant">
+            <IconButton
+              onClick={() => onRemove && onRemove(participant)}
+              disabled={isRemoving}
+              sx={{ color: "#f44336" }}
+              aria-label="Remove participant"
+            >
+              {isRemoving ? (
+                <CircularProgress size={20} />
+              ) : (
+                <PersonRemoveIcon />
+              )}
             </IconButton>
           </Tooltip>
         )}

--- a/teacher-webapp/src/components/participants/ParticipantList.js
+++ b/teacher-webapp/src/components/participants/ParticipantList.js
@@ -9,8 +9,10 @@ export const ParticipantList = ({
   students,
   onMuteToggle,
   onReconnect,
+  onRemove,
   isLoading,
   isReconnecting,
+  isRemoving,
   canReconnect,
   loading = false,
 }) => {
@@ -71,8 +73,10 @@ export const ParticipantList = ({
                 isTeacher={true}
                 onMuteToggle={onMuteToggle}
                 onReconnect={onReconnect}
+                onRemove={onRemove}
                 isLoading={isLoading(teacher.phoneNumber)}
                 isReconnecting={isReconnecting(teacher.phoneNumber)}
+                isRemoving={isRemoving && isRemoving(teacher.phoneNumber)}
                 canReconnect={canReconnect(teacher)}
               />
             </Box>
@@ -93,8 +97,10 @@ export const ParticipantList = ({
                   isTeacher={false}
                   onMuteToggle={onMuteToggle}
                   onReconnect={onReconnect}
+                  onRemove={onRemove}
                   isLoading={isLoading(student.phoneNumber)}
                   isReconnecting={isReconnecting(student.phoneNumber)}
+                  isRemoving={isRemoving && isRemoving(student.phoneNumber)}
                   canReconnect={canReconnect(student)}
                 />
               ))}

--- a/teacher-webapp/src/constants/apiEndpoints.js
+++ b/teacher-webapp/src/constants/apiEndpoints.js
@@ -32,5 +32,7 @@ export const API_ENDPOINTS = {
     SEEK_AUDIO: (confId) => `${CONF_BASE}/seekaudio/${confId}`,
     ADD_PARTICIPANT: (confId, phone) =>
       `${CONF_BASE}/addparticipant/${confId}?phone_number=${phone}`,
+    REMOVE_PARTICIPANT: (confId, phone) =>
+      `${CONF_BASE}/removeparticipant/${confId}?phone_number=${phone}`,
   },
 };

--- a/teacher-webapp/src/context/ConferenceContext.js
+++ b/teacher-webapp/src/context/ConferenceContext.js
@@ -120,11 +120,13 @@ export const ConferenceProvider = ({ children }) => {
     // This directly updates the Map with the latest data from SSE events
     setParticipantsMap((prevMap) => {
       const newMap = new Map(prevMap);
+      const sseParticipantPhones = new Set();
 
-      // Check for students transitioning from connected to disconnected
+      // First, process all participants from SSE event
       for (let phoneNumber in event.participants) {
         const participantData = event.participants[phoneNumber];
         const normalizedPhone = normalizePhoneNumber(phoneNumber);
+        sseParticipantPhones.add(normalizedPhone);
         const previousStatus = previousParticipantStatusRef.current[normalizedPhone];
 
         // If it's a student transitioning from connected to disconnected, show notification
@@ -189,11 +191,40 @@ export const ConferenceProvider = ({ children }) => {
         newMap.set(normalizedPhone, participant);
       }
 
+      // Handle participants that are in our map but NOT in the SSE event
+      // This happens when a participant is removed - backend deletes them from state
+      // We mark them as disconnected so they can be reconnected
+      for (let [normalizedPhone, existingParticipant] of newMap.entries()) {
+        if (!sseParticipantPhones.has(normalizedPhone)) {
+          // Participant is missing from SSE event
+          // If it's a student (not teacher), mark as disconnected
+          if (existingParticipant.role === "Student") {
+            const previousStatus = previousParticipantStatusRef.current[normalizedPhone];
+            
+            // Only update if they were previously connected (to avoid overwriting already disconnected state)
+            if (previousStatus === "connected" || existingParticipant.call_status === "connected") {
+              const updatedParticipant = new Participant({
+                ...existingParticipant,
+                call_status: "disconnected",
+              });
+              newMap.set(normalizedPhone, updatedParticipant);
+            }
+          }
+          // Note: We keep the participant in the map even if removed, so they can be reconnected
+        }
+      }
+
       // Update previous status tracking
       const newStatusMap = {};
       for (let phoneNumber in event.participants) {
         const normalizedPhone = normalizePhoneNumber(phoneNumber);
         newStatusMap[normalizedPhone] = event.participants[phoneNumber].call_status;
+      }
+      // Also track status for participants that were removed (now disconnected)
+      for (let [normalizedPhone, participant] of newMap.entries()) {
+        if (!sseParticipantPhones.has(normalizedPhone) && participant.role === "Student") {
+          newStatusMap[normalizedPhone] = "disconnected";
+        }
       }
       previousParticipantStatusRef.current = newStatusMap;
 

--- a/teacher-webapp/src/services/apiService.js
+++ b/teacher-webapp/src/services/apiService.js
@@ -172,6 +172,34 @@ export const addParticipant = async (confId, phone_number) => {
   });
 };
 
+export const removeParticipant = async (confId, phone_number) => {
+  // Normalize phone number to ensure consistent format (91XXXXXXXXXX)
+  const normalizedPhone = normalizePhoneNumber(phone_number);
+  const response = await fetch(
+    API_ENDPOINTS.CONFERENCE.REMOVE_PARTICIPANT(confId, normalizedPhone),
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("Participant removal failed:", {
+      status: response.status,
+      statusText: response.statusText,
+      error: errorText,
+    });
+    throw new Error(
+      `Failed to remove participant: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+};
+
 export const fetchAudioContent = async () => {
   const token = localStorage.getItem("authToken");
   const response = await fetch(API_ENDPOINTS.GET_AUDIO_CONTENT, {

--- a/teacher-webapp/tests/components/ParticipantCard.test.js
+++ b/teacher-webapp/tests/components/ParticipantCard.test.js
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ParticipantCard } from "../../src/components/participants/ParticipantCard";
+
+const connectedStudent = {
+  name: "Test Student",
+  phoneNumber: "911234567890",
+  call_status: "connected",
+  is_muted: false,
+};
+
+describe("ParticipantCard - Remove participant", () => {
+  test("renders remove button for connected student when onRemove is provided", () => {
+    const onRemove = jest.fn();
+    render(
+      <ParticipantCard
+        participant={connectedStudent}
+        isTeacher={false}
+        onRemove={onRemove}
+        onMuteToggle={jest.fn()}
+      />
+    );
+    const removeButton = screen.getByRole("button", { name: /remove participant/i });
+    expect(removeButton).toBeInTheDocument();
+  });
+
+  test("does not render remove button for teacher", () => {
+    const onRemove = jest.fn();
+    render(
+      <ParticipantCard
+        participant={{ ...connectedStudent, name: "Teacher" }}
+        isTeacher={true}
+        onRemove={onRemove}
+        onMuteToggle={jest.fn()}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /remove participant/i })).not.toBeInTheDocument();
+  });
+
+  test("does not render remove button when participant is disconnected", () => {
+    const onRemove = jest.fn();
+    render(
+      <ParticipantCard
+        participant={{ ...connectedStudent, call_status: "disconnected" }}
+        isTeacher={false}
+        onRemove={onRemove}
+        onMuteToggle={jest.fn()}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /remove participant/i })).not.toBeInTheDocument();
+  });
+
+  test("does not render remove button when onRemove is not provided", () => {
+    render(
+      <ParticipantCard participant={connectedStudent} isTeacher={false} onMuteToggle={jest.fn()} />
+    );
+    expect(screen.queryByRole("button", { name: /remove participant/i })).not.toBeInTheDocument();
+  });
+
+  test("calls onRemove with participant when remove button is clicked", () => {
+    const onRemove = jest.fn();
+    render(
+      <ParticipantCard
+        participant={connectedStudent}
+        isTeacher={false}
+        onRemove={onRemove}
+        onMuteToggle={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /remove participant/i }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledWith(connectedStudent);
+  });
+
+  test("remove button is disabled and shows loading when isRemoving is true", () => {
+    const onRemove = jest.fn();
+    render(
+      <ParticipantCard
+        participant={connectedStudent}
+        isTeacher={false}
+        onRemove={onRemove}
+        onMuteToggle={jest.fn()}
+        isRemoving={true}
+      />
+    );
+    const removeButton = screen.getByRole("button", { name: /remove participant/i });
+    expect(removeButton).toBeDisabled();
+    expect(removeButton).toHaveAttribute("aria-label", "Remove participant");
+  });
+});

--- a/teacher-webapp/tests/services/apiService.test.js
+++ b/teacher-webapp/tests/services/apiService.test.js
@@ -96,6 +96,38 @@ describe("apiService", () => {
         "PUT"
       );
     });
+
+    test("removes participant from conference", async () => {
+      fetch.mockResolvedValueOnce(mockEmptyResponse());
+      const result = await apiService.removeParticipant(confId, phoneNumber);
+      expect(fetch).toHaveBeenCalledWith(
+        `${baseUrl}/conference/removeparticipant/${confId}?phone_number=${"91" + phoneNumber}`,
+        { method: "PUT", headers: { "Content-Type": "application/json" } }
+      );
+      expect(result).toEqual({});
+    });
+
+    test("removeParticipant normalizes phone number", async () => {
+      fetch.mockResolvedValueOnce(mockEmptyResponse());
+      await apiService.removeParticipant(confId, "9876543210");
+      expect(fetch).toHaveBeenCalledWith(
+        `${baseUrl}/conference/removeparticipant/${confId}?phone_number=919876543210`,
+        { method: "PUT", headers: { "Content-Type": "application/json" } }
+      );
+    });
+
+    test("removeParticipant throws on HTTP error", async () => {
+      fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: jest.fn().mockResolvedValueOnce({}),
+        text: jest.fn().mockResolvedValueOnce("Forbidden"),
+      });
+      await expect(apiService.removeParticipant(confId, phoneNumber)).rejects.toThrow(
+        "Failed to remove participant: 403 Forbidden"
+      );
+    });
   });
 
   describe("Audio Control", () => {


### PR DESCRIPTION
This pull request adds the ability to remove participants from a conference call in the teacher webapp and backend API. It updates the UI to allow teachers to remove students, handles the removal process via API, and ensures that the participant state is correctly updated in real time via SSE events. The changes also include several backend bug fixes for route handler naming.

**Backend API improvements:**

* Fixed route handler naming in `conference.py` to correctly match their purpose (e.g., `remove_participant`, `pause_audio`, `resume_audio`) for clarity and correctness. [[1]](diffhunk://#diff-17184d52196cf20cd18856c0c3ce67c65db2edb6c6cc0545da1c0641416f2941L104-R104) [[2]](diffhunk://#diff-17184d52196cf20cd18856c0c3ce67c65db2edb6c6cc0545da1c0641416f2941L146-R146) [[3]](diffhunk://#diff-17184d52196cf20cd18856c0c3ce67c65db2edb6c6cc0545da1c0641416f2941L155-R155)

**Frontend feature: Remove participant**

* Added `removeParticipant` API endpoint and service method, allowing the frontend to request participant removal from a conference. [[1]](diffhunk://#diff-853971ee113eeda9a96d9ee097e224bfd66cf0f9a98df4bb7cff057dc8ef281eR33-R34) [[2]](diffhunk://#diff-0da0db9ad87dbd387912bd10416858eb70f8248f0845495dde4a503e1b0e7f51R149-R176) [[3]](diffhunk://#diff-3157ebb9fc36a49a9275ff7bf9ac4028dd3d9fd922ac03dfac5b4a049ab98334R14)
* Implemented participant removal UI: added "Remove" buttons to `ParticipantCard` for students, with confirmation dialogs and loading indicators. [[1]](diffhunk://#diff-0ac8b38eb227b3f2273c87ffc4122c56ae8c5dc8812c9914dfdea44b832a9e01R18-R29) [[2]](diffhunk://#diff-0ac8b38eb227b3f2273c87ffc4122c56ae8c5dc8812c9914dfdea44b832a9e01R122-R138)
* Updated participant list and details page to support removal, including tracking removal state and passing callbacks through the component tree. [[1]](diffhunk://#diff-3157ebb9fc36a49a9275ff7bf9ac4028dd3d9fd922ac03dfac5b4a049ab98334R41) [[2]](diffhunk://#diff-3157ebb9fc36a49a9275ff7bf9ac4028dd3d9fd922ac03dfac5b4a049ab98334R259-R297) [[3]](diffhunk://#diff-3157ebb9fc36a49a9275ff7bf9ac4028dd3d9fd922ac03dfac5b4a049ab98334R324) [[4]](diffhunk://#diff-3157ebb9fc36a49a9275ff7bf9ac4028dd3d9fd922ac03dfac5b4a049ab98334R348-R351) [[5]](diffhunk://#diff-e383c735a97293f754019abc3e8599b68378e65dd6b4884ebadc7d607459fb2aR12-R15) [[6]](diffhunk://#diff-e383c735a97293f754019abc3e8599b68378e65dd6b4884ebadc7d607459fb2aR76-R79) [[7]](diffhunk://#diff-e383c735a97293f754019abc3e8599b68378e65dd6b4884ebadc7d607459fb2aR100-R103)

**Participant state management:**

* Enhanced SSE participant state handling in `ConferenceContext` to detect when participants are removed (i.e., missing from SSE event) and mark them as "disconnected" so they can be reconnected if needed, while maintaining accurate status tracking. [[1]](diffhunk://#diff-1f3eb8dfd5a3aeb2a90a00b9ca1d400d6a866915e4df6ce125531477129fc270R123-R129) [[2]](diffhunk://#diff-1f3eb8dfd5a3aeb2a90a00b9ca1d400d6a866915e4df6ce125531477129fc270R194-R228)