### PR TITLE
fix: filter supported languages by IVR dialog URLs in handle_language…

### DIFF
--- a/IVRv2/app/fsm/insti.py
+++ b/IVRv2/app/fsm/insti.py
@@ -90,6 +90,9 @@ def handle_language(filtered_content, speechRate, parent_selections):
     sorted_languages = sorted(count_languages.items(), key=lambda x: x[1], reverse=True)
     sorted_langs = [lang for lang, _ in sorted_languages]
 
+    # Only include languages that have IVR dialog URLs (skip unsupported languages in content)
+    sorted_langs = [lang for lang in sorted_langs if lang in languageDialogUrls]
+
     values_to_urls = {}
     sorted_categories = []
     sorted_keys = []


### PR DESCRIPTION
This pull request makes a targeted improvement to the language handling logic in the IVR system. Now, only languages that have corresponding IVR dialog URLs will be included in the sorted list, ensuring unsupported languages in the content are skipped.

* Language handling logic: Updated the `handle_language` function in `insti.py` to filter out languages that do not have entries in `languageDialogUrls`, preventing unsupported languages from being processed.