### PR TITLE
refactor: remove unused imports from callPage.js to clean up code

### DIFF
--- a/teacher-webapp/src/callPage.js
+++ b/teacher-webapp/src/callPage.js
@@ -9,7 +9,6 @@ import {
   DialogActions,
   Button,
 } from "@mui/material";
-import { Box, Typography } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { useConference } from "./context/ConferenceContext";
 import {


### PR DESCRIPTION
<img width="707" height="251" alt="image" src="https://github.com/user-attachments/assets/03c29589-29db-4b0a-a96d-0b11ef807cd9" />
https://github.com/A4i-tech/SEEDS/actions/runs/21855473769


happened due to merge conflicts