### PR TITLE
Add IVR API URL build argument to Azure deployment workflow

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -30,6 +30,7 @@ jobs:
                       azure_publish_profile: CONTENT_WEBAPP_AZURE_PUBLISH_PROFILE
                       needs_build_args: true
                       build_arg_api_url: CONTENT_WEBAPP_REACT_APP_API_BASE_URL
+                      build_arg_ivr_api_url: CONTENT_WEBAPP_REACT_APP_API_IVRV2_URL
 
                     - name: teacher-webapp-service
                       context: teacher-webapp
@@ -124,6 +125,7 @@ jobs:
                       ${{ matrix.service.build_arg_conf_uri && format('REACT_APP_CONF_SERVER_BASE_URI={0}', vars[matrix.service.build_arg_conf_uri]) || '' }}
                       ${{ matrix.service.build_arg_storage && format('REACT_APP_STORAGE_ACCOUNT_NAME={0}', vars[matrix.service.build_arg_storage]) || '' }}
                       ${{ matrix.service.build_arg_api_url && format('REACT_APP_API_BASE_URL={0}', vars[matrix.service.build_arg_api_url]) || '' }}
+                      ${{ matrix.service.build_arg_ivr_api_url && format('REACT_APP_API_IVRV2_URL={0}', vars[matrix.service.build_arg_ivr_api_url]) || '' }}
 
             - name: Normalize repo name to lowercase
               id: repo


### PR DESCRIPTION
This pull request updates the deployment workflow to support a new build argument for the IVR API URL. The changes ensure that the `CONTENT_WEBAPP_REACT_APP_API_IVRV2_URL` environment variable can be passed as a build argument during deployment, enabling services to access the IVR API endpoint if needed.

**Deployment workflow enhancements:**

* Added `build_arg_ivr_api_url` to the `jobs` matrix in `.github/workflows/deploy-main.yml`, allowing the IVR API URL to be specified as a build argument for relevant services.
* Updated the build arguments passed to the deployment job to include `REACT_APP_API_IVRV2_URL` when `build_arg_ivr_api_url` is set, ensuring the environment variable is available during the build.