### PR TITLE
feat: Add content creator role in Content WebApp

### DIFF
--- a/ContentWebApp/package-lock.json
+++ b/ContentWebApp/package-lock.json
@@ -371,7 +371,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1021,7 +1020,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
       "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1905,7 +1903,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -3396,7 +3393,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4661,7 +4657,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -5206,7 +5201,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5350,7 +5344,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -5404,7 +5397,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5788,7 +5780,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5893,7 +5884,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6883,7 +6873,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -8200,7 +8189,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9217,7 +9205,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9274,7 +9261,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11422,7 +11408,6 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12293,7 +12278,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -15066,7 +15050,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16254,7 +16237,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16373,7 +16355,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16496,7 +16477,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -16647,7 +16627,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -16720,7 +16699,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16930,7 +16908,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17061,7 +17038,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17384,8 +17360,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -17781,7 +17756,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -18027,7 +18001,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19910,7 +19883,6 @@
       "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.3.0",
         "node-gyp-build": "^4.8.4"
@@ -20046,7 +20018,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20575,7 +20546,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -20647,7 +20617,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -21054,7 +21023,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/ContentWebApp/src/components/AllContent.js
+++ b/ContentWebApp/src/components/AllContent.js
@@ -4,6 +4,7 @@ import { useAuth } from "../hooks/useAuth";
 import { useContent } from "../hooks/useContent";
 import { useContentFilters } from "../hooks/useContentFilters";
 import { useTeachers } from "../hooks/useTeachers";
+import { useContentCreators } from "../hooks/useContentCreators";
 import { ivrService } from "../services/ivrService";
 import AppHeader from "./AllContent/Header/AppHeader";
 import ContentTab from "./AllContent/ContentTab/ContentTab";
@@ -18,9 +19,10 @@ const AllContent = () => {
   const [updateIVRStatus, setUpdateIVRStatus] = useState("");
   const [isUpdatingIVR, setIsUpdatingIVR] = useState(false);
   const [currentUser, setCurrentUser] = useState("User");
+  const [currentUserRole, setCurrentUserRole] = useState("tenant");
 
   const navigate = useNavigate();
-  const { getAuthHeaders, logout, getCurrentUser } = useAuth();
+  const { getAuthHeaders, logout, getCurrentUserProfile } = useAuth();
   const {
     content,
     allContent,
@@ -54,6 +56,11 @@ const AllContent = () => {
     submitNewStudents,
     removeStudent,
   } = useTeachers(activeTab);
+  const {
+    contentCreators,
+    registerContentCreator,
+    creatorMessage,
+  } = useContentCreators(activeTab);
 
   const ivrURL = process.env.REACT_APP_API_IVRV2_URL;
 
@@ -63,15 +70,24 @@ const AllContent = () => {
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const userName = await getCurrentUser();
+        const userProfile = await getCurrentUserProfile();
+        const userName = userProfile?.name || userProfile?.tenantName || "User";
         setCurrentUser(userName);
+        setCurrentUserRole(userProfile?.role || "tenant");
       } catch (error) {
         console.error("Error fetching user:", error);
         setCurrentUser("User");
+        setCurrentUserRole("tenant");
       }
     };
     fetchUser();
-  }, [getCurrentUser]);
+  }, [getCurrentUserProfile]);
+
+  useEffect(() => {
+    if (currentUserRole === "content_creator" && ["registration", "analytics"].includes(activeTab)) {
+      setActiveTab("content");
+    }
+  }, [currentUserRole, activeTab]);
 
   /**
    * Handle IVR update
@@ -119,6 +135,7 @@ const AllContent = () => {
           activeTab={activeTab}
           onTabChange={setActiveTab}
           currentUser={currentUser}
+          currentUserRole={currentUserRole}
           onLogout={logout}
         />
 
@@ -166,9 +183,9 @@ const AllContent = () => {
 
         {activeTab === "ivr" && <IVRTab />}
 
-        {activeTab === "analytics" && <AnalyticsTab />}
+        {activeTab === "analytics" && currentUserRole === "tenant" && <AnalyticsTab />}
 
-        {activeTab === "registration" && (
+        {activeTab === "registration" && currentUserRole === "tenant" && (
           <RegistrationTab
             teachers={teachers}
             selectedTeacher={selectedTeacher}
@@ -181,6 +198,9 @@ const AllContent = () => {
             onSetNewStudentValue={setNewStudentValue}
             onSubmitNewStudents={submitNewStudents}
             onRemoveStudent={removeStudent}
+            contentCreators={contentCreators}
+            onRegisterContentCreator={registerContentCreator}
+            creatorMessage={creatorMessage}
           />
         )}
       </div>

--- a/ContentWebApp/src/components/AllContent/ContentTab/ContentTab.js
+++ b/ContentWebApp/src/components/AllContent/ContentTab/ContentTab.js
@@ -28,7 +28,7 @@ const ContentTab = ({
   const navigate = useNavigate();
 
   return (
-    <div className="card">
+    <div className="card content-tab-card">
       <div className="card-header">
         <div>
           <div className="card-title">Audio Content Library</div>

--- a/ContentWebApp/src/components/AllContent/ContentTab/css/ContentTab.css
+++ b/ContentWebApp/src/components/AllContent/ContentTab/css/ContentTab.css
@@ -1,9 +1,10 @@
 .tabs-container {
   display: flex;
-  gap: 6px;
-  background-color: #e2e8f0;
+  gap: 8px;
+  background-color: #ffffff;
+  border: 1px solid #d7deea;
   border-radius: 999px;
-  padding: 4px;
+  padding: 6px;
   align-self: stretch;
   flex-wrap: wrap;
   width: 100%;
@@ -12,55 +13,127 @@
 .tab-button {
   border: none;
   border-radius: 999px;
-  padding: 8px 16px;
+  padding: 9px 16px;
   font-size: 13px;
   font-weight: 600;
   background-color: transparent;
-  color: #475569;
+  color: #64748b;
   cursor: pointer;
   flex: 1 1 auto;
   min-width: fit-content;
   white-space: nowrap;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .tab-button.active {
-  background-color: #ffffff;
-  color: #0f172a;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
+  background-color: #0f172a;
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
   cursor: default;
+}
+
+/* Content tab styling consistency */
+.content-tab-card {
+  border: 1px solid #d7deea;
+  background: #ffffff;
+}
+
+.content-tab-card .card-header {
+  border-bottom: 1px solid #d7deea;
+  padding-bottom: 14px;
+  margin-bottom: 6px;
+}
+
+.content-tab-card .card-title {
+  letter-spacing: -0.01em;
+}
+
+.content-tab-card .button-group {
+  gap: 10px;
+}
+
+.content-tab-card .button-group .primary-button {
+  background-color: #0f172a;
+}
+
+.content-tab-card .button-group .button-add-content {
+  background-color: #059669;
+}
+
+.content-tab-card .filter-wrapper {
+  border-color: #d7deea;
+  background: #f8fafc;
+}
+
+.content-tab-card .filter-label {
+  color: #0f172a;
+  font-size: 16px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.content-tab-card .table-wrapper {
+  border-color: #d7deea;
+  background: #ffffff;
+}
+
+.content-tab-card .no-content {
+  min-height: 96px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: #64748b;
 }
 
 @media (min-width: 768px) {
   .tabs-container {
-    gap: 6px;
-    padding: 5px;
+    gap: 8px;
+    padding: 6px;
     align-self: flex-start;
     width: auto;
   }
 
   .tab-button {
-    padding: 9px 20px;
-    font-size: 13px;
+    padding: 10px 24px;
+    font-size: 14px;
     flex: 0 1 auto;
   }
 
   .tab-button.active {
-    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.07);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.2);
+  }
+
+  .content-tab-card .card-header {
+    padding-bottom: 16px;
+    margin-bottom: 10px;
+  }
+
+  .content-tab-card .filter-label {
+    font-size: 17px;
   }
 }
 
 @media (min-width: 1024px) {
   .tabs-container {
-    gap: 8px;
-    padding: 6px;
+    gap: 10px;
+    padding: 7px;
   }
 
   .tab-button {
-    padding: 10px 24px;
-    font-size: 14px;
+    padding: 11px 30px;
+    font-size: 15px;
   }
 
   .tab-button.active {
-    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.22);
+  }
+
+  .content-tab-card .filter-label {
+    font-size: 18px;
   }
 }

--- a/ContentWebApp/src/components/AllContent/Header/AppHeader.js
+++ b/ContentWebApp/src/components/AllContent/Header/AppHeader.js
@@ -6,9 +6,10 @@ import "../shared/buttons.css";
 import "../shared/cards.css";
 import "../shared/utilities.css";
 
-const AppHeader = ({ activeTab, onTabChange, currentUser, onLogout }) => {
+const AppHeader = ({ activeTab, onTabChange, currentUser, currentUserRole, onLogout }) => {
   const [showUserDropdown, setShowUserDropdown] = useState(false);
   const navigate = useNavigate();
+  const isTenant = currentUserRole === "tenant";
 
   const handleProfileClick = () => {
     setShowUserDropdown(false);
@@ -34,23 +35,30 @@ const AppHeader = ({ activeTab, onTabChange, currentUser, onLogout }) => {
           >
             Content
           </button>
-          <button
-            className={`nav-link ${activeTab === "registration" ? "active" : ""}`}
-            onClick={() => onTabChange("registration")}
-          >
-            Registration
-          </button>
-          <button
-            className={`nav-link ${activeTab === "analytics" ? "active" : ""}`}
-            onClick={() => onTabChange("analytics")}
-          >
-            Analytics
-          </button>
+          {isTenant && (
+            <>
+              <button
+                className={`nav-link ${activeTab === "registration" ? "active" : ""}`}
+                onClick={() => onTabChange("registration")}
+              >
+                Registration
+              </button>
+              <button
+                className={`nav-link ${activeTab === "analytics" ? "active" : ""}`}
+                onClick={() => onTabChange("analytics")}
+              >
+                Analytics
+              </button>
+            </>
+          )}
         </div>
       </div>
       <div className="user-dropdown-container">
         <div className="user-info-wrapper" onClick={() => setShowUserDropdown(!showUserDropdown)}>
           <span className="welcome-text">Welcome, {currentUser}</span>
+          <span className="welcome-text" style={{ fontSize: "12px", opacity: 0.85 }}>
+            Role: {currentUserRole === "content_creator" ? "Content Creator" : "Tenant"}
+          </span>
           <div className="user-avatar">{currentUser.substring(0, 2).toUpperCase()}</div>
         </div>
         {showUserDropdown && (

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorRegistrationForm.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorRegistrationForm.js
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import "./css/ContentCreatorRegistrationForm.css";
+import "../shared/buttons.css";
+import "../shared/cards.css";
+import "../shared/utilities.css";
+
+const ContentCreatorRegistrationForm = ({ onRegister, message }) => {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = async () => {
+    const success = await onRegister({ name, email, password });
+    if (success) {
+      setName("");
+      setEmail("");
+      setPassword("");
+    }
+  };
+
+  return (
+    <div className="registration-card">
+      <h3 className="registration-title">Add Content Creator</h3>
+      <label className="label" htmlFor="creator-name">
+        Name
+      </label>
+      <input
+        id="creator-name"
+        type="text"
+        placeholder="Enter full name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="input-field"
+      />
+
+      <label className="label" htmlFor="creator-email">
+        Email
+      </label>
+      <input
+        id="creator-email"
+        type="email"
+        placeholder="Enter email address"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="input-field"
+      />
+
+      <label className="label" htmlFor="creator-password">
+        Password
+      </label>
+      <input
+        id="creator-password"
+        type="password"
+        placeholder="Set a password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="input-field"
+      />
+
+      <button type="button" className="secondary-button full-width-button" onClick={handleSubmit}>
+        Save Content Creator
+      </button>
+      {message && <p className="success-message">{message}</p>}
+    </div>
+  );
+};
+
+export default ContentCreatorRegistrationForm;

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorRegistrationForm.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorRegistrationForm.js
@@ -19,47 +19,90 @@ const ContentCreatorRegistrationForm = ({ onRegister, message }) => {
   };
 
   return (
-    <div className="registration-card">
-      <h3 className="registration-title">Add Content Creator</h3>
-      <label className="label" htmlFor="creator-name">
-        Name
-      </label>
-      <input
-        id="creator-name"
-        type="text"
-        placeholder="Enter full name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        className="input-field"
-      />
+    <div className="registration-card registration-card-modern">
+      <div className="registration-header-block">
+        <h3 className="registration-title registration-title-with-icon">
+          <span className="registration-title-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" focusable="false">
+              <path d="M12 12c2.21 0 4-1.79 4-4S14.21 4 12 4 8 5.79 8 8s1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+            </svg>
+          </span>
+          Register New Creator
+        </h3>
+        <p className="registration-subtitle">Create a content creator account for this tenant.</p>
+      </div>
 
-      <label className="label" htmlFor="creator-email">
-        Email
-      </label>
-      <input
-        id="creator-email"
-        type="email"
-        placeholder="Enter email address"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        className="input-field"
-      />
+      <div className="registration-fields-grid">
+        <div className="registration-field">
+          <label className="label" htmlFor="creator-name">
+            Full Name
+          </label>
+          <div className="registration-input-wrap">
+            <span className="registration-input-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path d="M12 12c2.76 0 5-2.24 5-5S14.76 2 12 2 7 4.24 7 7s2.24 5 5 5zm0 2c-3.33 0-10 1.67-10 5v3h20v-3c0-3.33-6.67-5-10-5z" />
+              </svg>
+            </span>
+            <input
+              id="creator-name"
+              type="text"
+              placeholder="Enter full name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="input-field registration-input-with-icon"
+            />
+          </div>
+        </div>
 
-      <label className="label" htmlFor="creator-password">
-        Password
-      </label>
-      <input
-        id="creator-password"
-        type="password"
-        placeholder="Set a password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        className="input-field"
-      />
+        <div className="registration-field">
+          <label className="label" htmlFor="creator-email">
+            Contact Info
+          </label>
+          <div className="registration-input-wrap">
+            <span className="registration-input-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path d="M20 4H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V6a2 2 0 00-2-2zm0 4l-8 5L4 8V6l8 5 8-5v2z" />
+              </svg>
+            </span>
+            <input
+              id="creator-email"
+              type="email"
+              placeholder="Enter email address"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="input-field registration-input-with-icon"
+            />
+          </div>
+          <p className="registration-hint">Use a valid email for sign in.</p>
+        </div>
 
-      <button type="button" className="secondary-button full-width-button" onClick={handleSubmit}>
-        Save Content Creator
-      </button>
+        <div className="registration-field registration-field-full">
+          <label className="label" htmlFor="creator-password">
+            Password
+          </label>
+          <div className="registration-input-wrap">
+            <span className="registration-input-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path d="M12 1a5 5 0 00-5 5v3H6a2 2 0 00-2 2v9a2 2 0 002 2h12a2 2 0 002-2v-9a2 2 0 00-2-2h-1V6a5 5 0 00-5-5zm-3 8V6a3 3 0 116 0v3H9z" />
+              </svg>
+            </span>
+            <input
+              id="creator-password"
+              type="password"
+              placeholder="Set a password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="input-field registration-input-with-icon"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="registration-cta-row">
+        <button type="button" className="secondary-button full-width-button" onClick={handleSubmit}>
+          Add User
+        </button>
+      </div>
       {message && <p className="success-message">{message}</p>}
     </div>
   );

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorsList.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorsList.js
@@ -1,0 +1,26 @@
+import React from "react";
+import "./css/ContentCreatorsList.css";
+import "../shared/cards.css";
+import "../shared/utilities.css";
+
+const ContentCreatorsList = ({ creators }) => {
+  return (
+    <div className="creator-list-pane">
+      <h3 className="creator-list-title">Content Creators</h3>
+      {creators.length === 0 ? (
+        <div className="placeholder-text">No content creators added yet.</div>
+      ) : (
+        <ul className="creator-list">
+          {creators.map((creator) => (
+            <li className="creator-list-item" key={creator.id}>
+              <div className="creator-name">{creator.name}</div>
+              <div className="creator-email">{creator.email}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default ContentCreatorsList;

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorsList.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorsList.js
@@ -22,7 +22,10 @@ const ContentCreatorsList = ({ creators }) => {
                 {(creator.name || creator.email || "C").slice(0, 2).toUpperCase()}
               </div>
               <div className="creator-meta">
-                <div className="creator-name">{creator.name || "Unnamed Creator"}</div>
+                <div className="creator-name-row">
+                  <div className="creator-name">{creator.name || "Unnamed Creator"}</div>
+                  <span className="role-badge creator-role-badge">Creator</span>
+                </div>
                 <div className="creator-email">{creator.email}</div>
               </div>
             </li>

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorsList.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/ContentCreatorsList.js
@@ -4,17 +4,27 @@ import "../shared/cards.css";
 import "../shared/utilities.css";
 
 const ContentCreatorsList = ({ creators }) => {
+  const totalCreators = creators.length;
+
   return (
     <div className="creator-list-pane">
-      <h3 className="creator-list-title">Content Creators</h3>
+      <div className="creator-list-header">
+        <h3 className="creator-list-title">Creator Directory</h3>
+        <span className="creator-count-pill">{totalCreators} Total</span>
+      </div>
       {creators.length === 0 ? (
         <div className="placeholder-text">No content creators added yet.</div>
       ) : (
         <ul className="creator-list">
           {creators.map((creator) => (
             <li className="creator-list-item" key={creator.id}>
-              <div className="creator-name">{creator.name}</div>
-              <div className="creator-email">{creator.email}</div>
+              <div className="creator-avatar">
+                {(creator.name || creator.email || "C").slice(0, 2).toUpperCase()}
+              </div>
+              <div className="creator-meta">
+                <div className="creator-name">{creator.name || "Unnamed Creator"}</div>
+                <div className="creator-email">{creator.email}</div>
+              </div>
             </li>
           ))}
         </ul>

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/RegistrationTab.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/RegistrationTab.js
@@ -1,7 +1,5 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import TeacherRegistrationForm from "./TeacherRegistrationForm";
-import ContentCreatorRegistrationForm from "./ContentCreatorRegistrationForm";
-import ContentCreatorsList from "./ContentCreatorsList";
 import TeachersList from "./TeachersList";
 import TeacherDetails from "./TeacherDetails";
 import "./css/RegistrationTab.css";
@@ -26,7 +24,28 @@ const RegistrationTab = ({
   onRegisterContentCreator,
   creatorMessage,
 }) => {
-  const [actorTab, setActorTab] = useState("teacher");
+  const [registerRole, setRegisterRole] = useState("teacher");
+  const mergedDirectoryEntries = useMemo(
+    () => [
+      ...teachers.map((teacher) => ({
+        id: teacher._id,
+        role: "teacher",
+        name: teacher.name || "Unknown",
+        contact: teacher.phoneNumber || "-",
+      })),
+      ...contentCreators.map((creator) => ({
+        id: creator.id || creator._id,
+        role: "content_creator",
+        name: creator.name || "Unnamed Creator",
+        contact: creator.email || "-",
+      })),
+    ],
+    [teachers, contentCreators]
+  );
+
+  const selectedDirectoryEntry = mergedDirectoryEntries.find(
+    (entry) => String(entry.id) === String(selectedTeacherId)
+  );
 
   return (
     <div className="card registration-flex-card">
@@ -37,62 +56,42 @@ const RegistrationTab = ({
         </div>
       </div>
 
-      <div className="registration-segmented-switch">
-        <button
-          type="button"
-          className={`registration-segmented-btn ${actorTab === "teacher" ? "active" : ""}`}
-          onClick={() => setActorTab("teacher")}
-        >
-          Teacher
-        </button>
-        <button
-          type="button"
-          className={`registration-segmented-btn ${actorTab === "content_creator" ? "active" : ""}`}
-          onClick={() => setActorTab("content_creator")}
-        >
-          Creator
-        </button>
+      <div className="registration-form-panel">
+        <TeacherRegistrationForm
+          role={registerRole}
+          onRoleChange={(nextRole) => {
+            setRegisterRole(nextRole);
+          }}
+          onRegisterTeacher={onRegisterTeacher}
+          onRegisterContentCreator={onRegisterContentCreator}
+          teacherMessage={message}
+          creatorMessage={creatorMessage}
+        />
       </div>
 
-      <div className="registration-form-panel">
-        {actorTab === "teacher" ? (
-          <TeacherRegistrationForm onRegister={onRegisterTeacher} message={message} />
+      <div className="teachers-section">
+        <h3 className="teachers-section-title">Team Directory</h3>
+        {mergedDirectoryEntries.length === 0 ? (
+          <div className="no-teachers">No users available.</div>
         ) : (
-          <ContentCreatorRegistrationForm
-            onRegister={onRegisterContentCreator}
-            message={creatorMessage}
-          />
+          <div className="teachers-layout">
+            <TeachersList
+              entries={mergedDirectoryEntries}
+              selectedTeacherId={selectedTeacherId}
+              onSelectTeacher={onSelectTeacher}
+            />
+            <TeacherDetails
+              teacher={selectedTeacher}
+              selectedEntryRole={selectedDirectoryEntry?.role}
+              onAddStudentRow={onAddStudentRow}
+              onRemoveStudentRow={onRemoveStudentRow}
+              onSetNewStudentValue={onSetNewStudentValue}
+              onSubmitNewStudents={onSubmitNewStudents}
+              onRemoveStudent={onRemoveStudent}
+            />
+          </div>
         )}
       </div>
-
-      {actorTab === "teacher" ? (
-        <div className="teachers-section">
-          <h3 className="teachers-section-title">Teachers & Students</h3>
-          {teachers.length === 0 ? (
-            <div className="no-teachers">No teachers available.</div>
-          ) : (
-            <div className="teachers-layout">
-              <TeachersList
-                teachers={teachers}
-                selectedTeacherId={selectedTeacherId}
-                onSelectTeacher={onSelectTeacher}
-              />
-              <TeacherDetails
-                teacher={selectedTeacher}
-                onAddStudentRow={onAddStudentRow}
-                onRemoveStudentRow={onRemoveStudentRow}
-                onSetNewStudentValue={onSetNewStudentValue}
-                onSubmitNewStudents={onSubmitNewStudents}
-                onRemoveStudent={onRemoveStudent}
-              />
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="creator-section">
-          <ContentCreatorsList creators={contentCreators} />
-        </div>
-      )}
     </div>
   );
 };

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/RegistrationTab.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/RegistrationTab.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import TeacherRegistrationForm from "./TeacherRegistrationForm";
 import ContentCreatorRegistrationForm from "./ContentCreatorRegistrationForm";
 import ContentCreatorsList from "./ContentCreatorsList";
@@ -26,6 +26,8 @@ const RegistrationTab = ({
   onRegisterContentCreator,
   creatorMessage,
 }) => {
+  const [actorTab, setActorTab] = useState("teacher");
+
   return (
     <div className="card registration-flex-card">
       <div>
@@ -35,38 +37,62 @@ const RegistrationTab = ({
         </div>
       </div>
 
-      <div className="registration-forms-grid">
-        <TeacherRegistrationForm onRegister={onRegisterTeacher} message={message} />
-        <ContentCreatorRegistrationForm
-          onRegister={onRegisterContentCreator}
-          message={creatorMessage}
-        />
+      <div className="registration-segmented-switch">
+        <button
+          type="button"
+          className={`registration-segmented-btn ${actorTab === "teacher" ? "active" : ""}`}
+          onClick={() => setActorTab("teacher")}
+        >
+          Teacher
+        </button>
+        <button
+          type="button"
+          className={`registration-segmented-btn ${actorTab === "content_creator" ? "active" : ""}`}
+          onClick={() => setActorTab("content_creator")}
+        >
+          Creator
+        </button>
       </div>
 
-      <ContentCreatorsList creators={contentCreators} />
-
-      <div className="teachers-section">
-        <h3 className="teachers-section-title">Teachers & Students</h3>
-        {teachers.length === 0 ? (
-          <div className="no-teachers">No teachers available.</div>
+      <div className="registration-form-panel">
+        {actorTab === "teacher" ? (
+          <TeacherRegistrationForm onRegister={onRegisterTeacher} message={message} />
         ) : (
-          <div className="teachers-layout">
-            <TeachersList
-              teachers={teachers}
-              selectedTeacherId={selectedTeacherId}
-              onSelectTeacher={onSelectTeacher}
-            />
-            <TeacherDetails
-              teacher={selectedTeacher}
-              onAddStudentRow={onAddStudentRow}
-              onRemoveStudentRow={onRemoveStudentRow}
-              onSetNewStudentValue={onSetNewStudentValue}
-              onSubmitNewStudents={onSubmitNewStudents}
-              onRemoveStudent={onRemoveStudent}
-            />
-          </div>
+          <ContentCreatorRegistrationForm
+            onRegister={onRegisterContentCreator}
+            message={creatorMessage}
+          />
         )}
       </div>
+
+      {actorTab === "teacher" ? (
+        <div className="teachers-section">
+          <h3 className="teachers-section-title">Teachers & Students</h3>
+          {teachers.length === 0 ? (
+            <div className="no-teachers">No teachers available.</div>
+          ) : (
+            <div className="teachers-layout">
+              <TeachersList
+                teachers={teachers}
+                selectedTeacherId={selectedTeacherId}
+                onSelectTeacher={onSelectTeacher}
+              />
+              <TeacherDetails
+                teacher={selectedTeacher}
+                onAddStudentRow={onAddStudentRow}
+                onRemoveStudentRow={onRemoveStudentRow}
+                onSetNewStudentValue={onSetNewStudentValue}
+                onSubmitNewStudents={onSubmitNewStudents}
+                onRemoveStudent={onRemoveStudent}
+              />
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="creator-section">
+          <ContentCreatorsList creators={contentCreators} />
+        </div>
+      )}
     </div>
   );
 };

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/RegistrationTab.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/RegistrationTab.js
@@ -1,5 +1,7 @@
 import React from "react";
 import TeacherRegistrationForm from "./TeacherRegistrationForm";
+import ContentCreatorRegistrationForm from "./ContentCreatorRegistrationForm";
+import ContentCreatorsList from "./ContentCreatorsList";
 import TeachersList from "./TeachersList";
 import TeacherDetails from "./TeacherDetails";
 import "./css/RegistrationTab.css";
@@ -20,15 +22,28 @@ const RegistrationTab = ({
   onSetNewStudentValue,
   onSubmitNewStudents,
   onRemoveStudent,
+  contentCreators,
+  onRegisterContentCreator,
+  creatorMessage,
 }) => {
   return (
     <div className="card registration-flex-card">
       <div>
         <div className="card-title">Registration Management</div>
-        <div className="card-description">Register teachers for your organization.</div>
+        <div className="card-description">
+          Manage teachers, students, and content creators for your tenant.
+        </div>
       </div>
 
-      <TeacherRegistrationForm onRegister={onRegisterTeacher} message={message} />
+      <div className="registration-forms-grid">
+        <TeacherRegistrationForm onRegister={onRegisterTeacher} message={message} />
+        <ContentCreatorRegistrationForm
+          onRegister={onRegisterContentCreator}
+          message={creatorMessage}
+        />
+      </div>
+
+      <ContentCreatorsList creators={contentCreators} />
 
       <div className="teachers-section">
         <h3 className="teachers-section-title">Teachers & Students</h3>

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/TeacherDetails.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/TeacherDetails.js
@@ -8,6 +8,7 @@ import "../shared/utilities.css";
 
 const TeacherDetails = ({
   teacher,
+  selectedEntryRole,
   onAddStudentRow,
   onRemoveStudentRow,
   onSetNewStudentValue,
@@ -17,7 +18,11 @@ const TeacherDetails = ({
   if (!teacher) {
     return (
       <div className="teacher-details-pane">
-        <div className="placeholder-text">Select a teacher to view details.</div>
+        <div className="placeholder-text">
+          {selectedEntryRole === "content_creator"
+            ? "Content creators do not have student management."
+            : "Select a teacher to view details."}
+        </div>
       </div>
     );
   }

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/TeacherRegistrationForm.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/TeacherRegistrationForm.js
@@ -18,49 +18,96 @@ const TeacherRegistrationForm = ({ onRegister, message }) => {
   };
 
   return (
-    <div className="registration-card">
-      <h3 className="registration-title">Register Teacher</h3>
-      <label className="label" htmlFor="teacher-name">Name</label>
-      <input
-        id="teacher-name"
-        type="text"
-        placeholder="Enter name"
-        value={teacherName}
-        onChange={(e) => setTeacherName(e.target.value)}
-        className="input-field"
-        required
-      />
-      <label className="label" htmlFor="teacher-phone">
-        Phone Number
-      </label>
-      <input
-        id="teacher-phone"
-        type="tel"
-        placeholder="Enter phone number"
-        value={teacherPhone}
-        onChange={(e) => {
-          const value = e.target.value.replace(/\D/g, "");
-          if (value.length <= 10) {
-            setTeacherPhone(value);
-          }
-        }}
-        maxLength={10}
-        className="input-field"
-      />
-      <label className="label" htmlFor="teacher-password">
-        Password
-      </label>
-      <input
-        id="teacher-password"
-        type="password"
-        placeholder="Set a password"
-        value={teacherPassword}
-        onChange={(e) => setTeacherPassword(e.target.value)}
-        className="input-field"
-      />
-      <button type="button" className="primary-button full-width-button" onClick={handleSubmit}>
-        Save Teacher
-      </button>
+    <div className="registration-card registration-card-modern">
+      <div className="registration-header-block">
+        <h3 className="registration-title registration-title-with-icon">
+          <span className="registration-title-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" focusable="false">
+              <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zm-8 1c1.66 0 3-1.34 3-3S9.66 6 8 6 5 7.34 5 9s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V20h14v-2.5C15 15.17 10.33 14 8 14zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.98 1.97 3.45V20h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
+            </svg>
+          </span>
+          Register New Teacher
+        </h3>
+        <p className="registration-subtitle">Create a teacher account for this tenant.</p>
+      </div>
+
+      <div className="registration-fields-grid">
+        <div className="registration-field">
+          <label className="label" htmlFor="teacher-name">Full Name</label>
+          <div className="registration-input-wrap">
+            <span className="registration-input-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path d="M12 12c2.76 0 5-2.24 5-5S14.76 2 12 2 7 4.24 7 7s2.24 5 5 5zm0 2c-3.33 0-10 1.67-10 5v3h20v-3c0-3.33-6.67-5-10-5z" />
+              </svg>
+            </span>
+            <input
+              id="teacher-name"
+              type="text"
+              placeholder="Enter full name"
+              value={teacherName}
+              onChange={(e) => setTeacherName(e.target.value)}
+              className="input-field registration-input-with-icon"
+              required
+            />
+          </div>
+        </div>
+
+        <div className="registration-field">
+          <label className="label" htmlFor="teacher-phone">
+            Contact Info
+          </label>
+          <div className="registration-input-wrap">
+            <span className="registration-input-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path d="M6.62 10.79a15.46 15.46 0 006.59 6.59l2.2-2.2a1 1 0 01.95-.27 11.72 11.72 0 003.68.59 1 1 0 011 1V20a1 1 0 01-1 1A17 17 0 013 4a1 1 0 011-1h3.5a1 1 0 011 1 11.72 11.72 0 00.59 3.68 1 1 0 01-.27.95z" />
+              </svg>
+            </span>
+            <input
+              id="teacher-phone"
+              type="tel"
+              placeholder="Enter phone number"
+              value={teacherPhone}
+              onChange={(e) => {
+                const value = e.target.value.replace(/\D/g, "");
+                if (value.length <= 10) {
+                  setTeacherPhone(value);
+                }
+              }}
+              maxLength={10}
+              className="input-field registration-input-with-icon"
+            />
+          </div>
+          <p className="registration-hint">Use a valid 10-digit mobile number.</p>
+        </div>
+
+        <div className="registration-field registration-field-full">
+          <label className="label" htmlFor="teacher-password">
+            Password
+          </label>
+          <div className="registration-input-wrap">
+            <span className="registration-input-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path d="M12 1a5 5 0 00-5 5v3H6a2 2 0 00-2 2v9a2 2 0 002 2h12a2 2 0 002-2v-9a2 2 0 00-2-2h-1V6a5 5 0 00-5-5zm-3 8V6a3 3 0 116 0v3H9z" />
+              </svg>
+            </span>
+            <input
+              id="teacher-password"
+              type="password"
+              placeholder="Set a password"
+              value={teacherPassword}
+              onChange={(e) => setTeacherPassword(e.target.value)}
+              className="input-field registration-input-with-icon"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="registration-cta-row">
+        <button type="button" className="primary-button full-width-button" onClick={handleSubmit}>
+          Add User
+        </button>
+      </div>
+
       {message && <p className="success-message">{message}</p>}
     </div>
   );

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/TeacherRegistrationForm.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/TeacherRegistrationForm.js
@@ -4,16 +4,34 @@ import "../shared/buttons.css";
 import "../shared/cards.css";
 import "../shared/utilities.css";
 
-const TeacherRegistrationForm = ({ onRegister, message }) => {
-  const [teacherPhone, setTeacherPhone] = useState("");
-  const [teacherPassword, setTeacherPassword] = useState("");
-  const [teacherName, setTeacherName] = useState("");
+const TeacherRegistrationForm = ({
+  onRegisterTeacher,
+  onRegisterContentCreator,
+  teacherMessage,
+  creatorMessage,
+  role,
+  onRoleChange,
+}) => {
+  const [name, setName] = useState("");
+  const [contactValue, setContactValue] = useState("");
+  const [password, setPassword] = useState("");
+
+  const activeMessage = role === "content_creator" ? creatorMessage : teacherMessage;
+
   const handleSubmit = async () => {
-    const success = await onRegister(teacherPhone, teacherPassword, teacherName);
+    const success =
+      role === "content_creator"
+        ? await onRegisterContentCreator({
+            name,
+            email: contactValue,
+            password,
+          })
+        : await onRegisterTeacher(contactValue, password, name);
+
     if (success) {
-      setTeacherPhone("");
-      setTeacherPassword("");
-      setTeacherName("");
+      setName("");
+      setContactValue("");
+      setPassword("");
     }
   };
 
@@ -26,14 +44,35 @@ const TeacherRegistrationForm = ({ onRegister, message }) => {
               <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zm-8 1c1.66 0 3-1.34 3-3S9.66 6 8 6 5 7.34 5 9s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V20h14v-2.5C15 15.17 10.33 14 8 14zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.98 1.97 3.45V20h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
             </svg>
           </span>
-          Register New Teacher
+          Register User
         </h3>
-        <p className="registration-subtitle">Create a teacher account for this tenant.</p>
+        <p className="registration-subtitle">
+          Create teacher and content creator accounts for this tenant.
+        </p>
       </div>
 
       <div className="registration-fields-grid">
         <div className="registration-field">
-          <label className="label" htmlFor="teacher-name">Full Name</label>
+          <label className="label" htmlFor="user-role">
+            Role
+          </label>
+          <div className="registration-input-wrap">
+            <select
+              id="user-role"
+              className="input-field registration-select"
+              value={role}
+              onChange={(e) => onRoleChange(e.target.value)}
+            >
+              <option value="teacher">Teacher</option>
+              <option value="content_creator">Content Creator</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="registration-field">
+          <label className="label" htmlFor="user-name">
+            Full Name
+          </label>
           <div className="registration-input-wrap">
             <span className="registration-input-icon" aria-hidden="true">
               <svg viewBox="0 0 24 24" focusable="false">
@@ -41,11 +80,11 @@ const TeacherRegistrationForm = ({ onRegister, message }) => {
               </svg>
             </span>
             <input
-              id="teacher-name"
+              id="user-name"
               type="text"
               placeholder="Enter full name"
-              value={teacherName}
-              onChange={(e) => setTeacherName(e.target.value)}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
               className="input-field registration-input-with-icon"
               required
             />
@@ -53,35 +92,50 @@ const TeacherRegistrationForm = ({ onRegister, message }) => {
         </div>
 
         <div className="registration-field">
-          <label className="label" htmlFor="teacher-phone">
+          <label className="label" htmlFor="user-contact">
             Contact Info
           </label>
           <div className="registration-input-wrap">
             <span className="registration-input-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" focusable="false">
-                <path d="M6.62 10.79a15.46 15.46 0 006.59 6.59l2.2-2.2a1 1 0 01.95-.27 11.72 11.72 0 003.68.59 1 1 0 011 1V20a1 1 0 01-1 1A17 17 0 013 4a1 1 0 011-1h3.5a1 1 0 011 1 11.72 11.72 0 00.59 3.68 1 1 0 01-.27.95z" />
-              </svg>
+              {role === "content_creator" ? (
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path d="M20 4H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V6a2 2 0 00-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+                </svg>
+              ) : (
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path d="M6.62 10.79a15.46 15.46 0 006.59 6.59l2.2-2.2a1 1 0 01.95-.27 11.72 11.72 0 003.68.59 1 1 0 011 1V20a1 1 0 01-1 1A17 17 0 013 4a1 1 0 011-1h3.5a1 1 0 011 1 11.72 11.72 0 00.59 3.68 1 1 0 01-.27.95z" />
+                </svg>
+              )}
             </span>
             <input
-              id="teacher-phone"
-              type="tel"
-              placeholder="Enter phone number"
-              value={teacherPhone}
+              id="user-contact"
+              type={role === "content_creator" ? "email" : "tel"}
+              placeholder={role === "content_creator" ? "Enter email address" : "Enter phone number"}
+              value={contactValue}
               onChange={(e) => {
+                if (role === "content_creator") {
+                  setContactValue(e.target.value);
+                  return;
+                }
+
                 const value = e.target.value.replace(/\D/g, "");
                 if (value.length <= 10) {
-                  setTeacherPhone(value);
+                  setContactValue(value);
                 }
               }}
-              maxLength={10}
+              maxLength={role === "content_creator" ? undefined : 10}
               className="input-field registration-input-with-icon"
             />
           </div>
-          <p className="registration-hint">Use a valid 10-digit mobile number.</p>
+          <p className="registration-hint">
+            {role === "content_creator"
+              ? "Use a valid email for sign in."
+              : "Use a valid 10-digit mobile number."}
+          </p>
         </div>
 
         <div className="registration-field registration-field-full">
-          <label className="label" htmlFor="teacher-password">
+          <label className="label" htmlFor="user-password">
             Password
           </label>
           <div className="registration-input-wrap">
@@ -91,11 +145,11 @@ const TeacherRegistrationForm = ({ onRegister, message }) => {
               </svg>
             </span>
             <input
-              id="teacher-password"
+              id="user-password"
               type="password"
               placeholder="Set a password"
-              value={teacherPassword}
-              onChange={(e) => setTeacherPassword(e.target.value)}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
               className="input-field registration-input-with-icon"
             />
           </div>
@@ -104,11 +158,11 @@ const TeacherRegistrationForm = ({ onRegister, message }) => {
 
       <div className="registration-cta-row">
         <button type="button" className="primary-button full-width-button" onClick={handleSubmit}>
-          Add User
+          Add {role === "content_creator" ? "Content Creator" : "Teacher"}
         </button>
       </div>
 
-      {message && <p className="success-message">{message}</p>}
+      {activeMessage && <p className="success-message">{activeMessage}</p>}
     </div>
   );
 };

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/TeachersList.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/TeachersList.js
@@ -16,7 +16,7 @@ const TeachersList = ({ teachers, selectedTeacherId, onSelectTeacher }) => {
                 String(teacher._id) === String(selectedTeacherId) ? "selected" : ""
               }`}
             >
-              {`${teacher.name || "unknown"} — ${teacher.phoneNumber}`}
+              {`${teacher.name || "Unknown"} — ${teacher.phoneNumber}`}
             </button>
           </li>
         ))}

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/TeachersList.js
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/TeachersList.js
@@ -2,21 +2,31 @@ import React from "react";
 import "./css/TeachersList.css";
 import "../shared/buttons.css";
 
-const TeachersList = ({ teachers, selectedTeacherId, onSelectTeacher }) => {
+const TeachersList = ({ entries, selectedTeacherId, onSelectTeacher }) => {
   return (
     <div className="teachers-list-pane">
-      <div className="teachers-list-title">Teachers</div>
+      <div className="teachers-list-title">Users</div>
       <ul className="teachers-list">
-        {teachers.map((teacher) => (
-          <li key={teacher._id} className="teacher-list-item">
+        {entries.map((entry) => (
+          <li key={`${entry.role}-${entry.id}`} className="teacher-list-item">
             <button
               type="button"
-              onClick={() => onSelectTeacher(teacher._id)}
+              onClick={() => onSelectTeacher(entry.id)}
               className={`teacher-button ${
-                String(teacher._id) === String(selectedTeacherId) ? "selected" : ""
+                String(entry.id) === String(selectedTeacherId) ? "selected" : ""
               }`}
             >
-              {`${teacher.name || "Unknown"} — ${teacher.phoneNumber}`}
+              <div className="teacher-button-head">
+                <span className="teacher-name">{entry.name}</span>
+                <span
+                  className={`role-badge ${
+                    entry.role === "content_creator" ? "creator-role-badge" : "teacher-role-badge"
+                  }`}
+                >
+                  {entry.role === "content_creator" ? "Creator" : "Teacher"}
+                </span>
+              </div>
+              <div className="teacher-meta">{entry.contact}</div>
             </button>
           </li>
         ))}

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/AddStudentsForm.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/AddStudentsForm.css
@@ -1,6 +1,8 @@
 /* Add students section */
 .add-students-section {
   margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--reg-border, #d7deea);
 }
 
 .add-students-row {
@@ -21,15 +23,15 @@
 .add-students-input {
   flex: 1;
   padding: 10px 12px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--reg-border, #d7deea);
   border-radius: 8px;
   font-size: 14px;
 }
 
 .add-students-input:focus {
-  outline: 2px solid #2563eb;
+  outline: 2px solid #bfdbfe;
   outline-offset: 1px;
-  border-color: #2563eb;
+  border-color: var(--reg-accent, #2563eb);
 }
 
 .add-students-buttons {

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorRegistrationForm.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorRegistrationForm.css
@@ -1,0 +1,3 @@
+.registration-card .success-message {
+  font-size: 13px;
+}

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorsList.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorsList.css
@@ -1,13 +1,31 @@
 .creator-list-pane {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--reg-border, #d7deea);
   border-radius: 12px;
-  padding: 16px;
-  background: #fff;
+  padding: 14px;
+  background: #ffffff;
+}
+
+.creator-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
 }
 
 .creator-list-title {
-  margin: 0 0 12px;
-  color: #0f172a;
+  margin: 0;
+  color: var(--reg-text, #0f172a);
+}
+
+.creator-count-pill {
+  border: 1px solid var(--reg-border, #d7deea);
+  border-radius: 999px;
+  padding: 4px 10px;
+  color: var(--reg-subtext, #64748b);
+  background: var(--reg-panel, #f8fafc);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .creator-list {
@@ -15,23 +33,53 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 10px;
+  gap: 12px;
+}
+
+@media (min-width: 768px) {
+  .creator-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .creator-list-item {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--reg-border, #d7deea);
   border-radius: 10px;
-  padding: 10px 12px;
-  background: #f8fafc;
+  padding: 12px;
+  background: var(--reg-panel, #f8fafc);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.creator-avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-weight: 700;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.creator-meta {
+  min-width: 0;
 }
 
 .creator-name {
-  color: #0f172a;
+  color: var(--reg-text, #0f172a);
   font-weight: 600;
-  margin-bottom: 2px;
+  margin-bottom: 3px;
 }
 
 .creator-email {
-  color: #64748b;
+  color: var(--reg-subtext, #64748b);
   font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorsList.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorsList.css
@@ -68,12 +68,37 @@
 
 .creator-meta {
   min-width: 0;
+  width: 100%;
+}
+
+.creator-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .creator-name {
   color: var(--reg-text, #0f172a);
   font-weight: 600;
   margin-bottom: 3px;
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 4px 8px;
+  letter-spacing: 0.02em;
+}
+
+.creator-role-badge {
+  background: #dbeafe;
+  color: #1d4ed8;
 }
 
 .creator-email {

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorsList.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/ContentCreatorsList.css
@@ -1,0 +1,37 @@
+.creator-list-pane {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 16px;
+  background: #fff;
+}
+
+.creator-list-title {
+  margin: 0 0 12px;
+  color: #0f172a;
+}
+
+.creator-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.creator-list-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #f8fafc;
+}
+
+.creator-name {
+  color: #0f172a;
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.creator-email {
+  color: #64748b;
+  font-size: 13px;
+}

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/RegistrationTab.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/RegistrationTab.css
@@ -8,7 +8,7 @@
   --reg-subtext: #64748b;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 16px;
 }
 
 .registration-segmented-switch {
@@ -37,20 +37,15 @@
 }
 
 .registration-form-panel {
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  padding: 0;
-  display: flex;
-  justify-content: center;
+  margin-top: 4px;
 }
 
 .teachers-section {
-  margin-top: 8px;
+  margin-top: 4px;
 }
 
 .creator-section {
-  margin-top: 8px;
+  margin-top: 4px;
 }
 
 .teachers-section-title {
@@ -103,14 +98,10 @@
 
 .registration-form-panel .registration-card {
   width: 100%;
-  max-width: 760px;
+  max-width: 100%;
 }
 
 @media (min-width: 768px) {
-  .registration-form-panel {
-    padding: 0;
-  }
-
   .teachers-layout {
     flex-direction: row;
     gap: 14px;

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/RegistrationTab.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/RegistrationTab.css
@@ -1,23 +1,61 @@
 /* Registration layout */
 .registration-flex-card {
+  --reg-primary: #0f172a;
+  --reg-accent: #2563eb;
+  --reg-border: #d7deea;
+  --reg-panel: #f8fafc;
+  --reg-text: #0f172a;
+  --reg-subtext: #64748b;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
-
-.registration-forms-grid {
-  display: grid;
-  grid-template-columns: 1fr;
   gap: 14px;
 }
 
+.registration-segmented-switch {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid var(--reg-border);
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+.registration-segmented-btn {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-weight: 600;
+  color: var(--reg-subtext);
+  background: transparent;
+  cursor: pointer;
+}
+
+.registration-segmented-btn.active {
+  background: var(--reg-primary);
+  color: #ffffff;
+}
+
+.registration-form-panel {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+}
+
 .teachers-section {
-  margin-top: 24px;
+  margin-top: 8px;
+}
+
+.creator-section {
+  margin-top: 8px;
 }
 
 .teachers-section-title {
   margin-bottom: 12px;
-  color: #0f172a;
+  color: var(--reg-text);
 }
 
 .teachers-layout {
@@ -27,14 +65,50 @@
 }
 
 .no-teachers {
-  padding: 12px;
-  color: #94a3b8;
+  padding: 14px;
+  color: var(--reg-subtext);
+  border: 1px dashed var(--reg-border);
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+.registration-flex-card .primary-button,
+.registration-flex-card .secondary-button {
+  background-color: var(--reg-primary);
+}
+
+.registration-flex-card .action-ghost-button {
+  border-color: var(--reg-border);
+  color: var(--reg-text);
+}
+
+.registration-flex-card .input-field {
+  border-color: var(--reg-border);
+  border-radius: 12px;
+  background: #ffffff;
+  font-size: 15px;
+}
+
+.registration-flex-card .input-field:focus,
+.registration-flex-card .add-students-input:focus {
+  outline: 2px solid #bfdbfe;
+  border-color: var(--reg-accent);
+}
+
+.registration-flex-card .label {
+  color: var(--reg-subtext);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.registration-form-panel .registration-card {
+  width: 100%;
+  max-width: 760px;
 }
 
 @media (min-width: 768px) {
-  .registration-forms-grid {
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
+  .registration-form-panel {
+    padding: 0;
   }
 
   .teachers-layout {

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/RegistrationTab.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/RegistrationTab.css
@@ -5,6 +5,12 @@
   gap: 16px;
 }
 
+.registration-forms-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+
 .teachers-section {
   margin-top: 24px;
 }
@@ -26,6 +32,11 @@
 }
 
 @media (min-width: 768px) {
+  .registration-forms-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+
   .teachers-layout {
     flex-direction: row;
     gap: 14px;

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeacherDetails.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeacherDetails.css
@@ -1,10 +1,10 @@
 /* Teacher details pane */
 .teacher-details-pane {
   flex: 1;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  padding: 12px;
-  background: #fff;
+  border: 1px solid var(--reg-border, #d7deea);
+  border-radius: 12px;
+  padding: 14px;
+  background: #ffffff;
   max-height: 400px;
   overflow-y: auto;
   width: 100%;
@@ -21,8 +21,7 @@
 
 @media (min-width: 768px) {
   .teacher-details-pane {
-    border-radius: 10px;
-    max-height: 480px;
+    max-height: 500px;
   }
 
   .teacher-details-header {
@@ -35,21 +34,21 @@
 
 @media (min-width: 1024px) {
   .teacher-details-pane {
-    border-radius: 12px;
     max-height: 560px;
   }
 }
 
 .students-title {
   font-weight: 700;
+  color: var(--reg-text, #0f172a);
 }
 
 .teacher-info-text {
-  color: #64748b;
+  color: var(--reg-subtext, #64748b);
   font-size: 13px;
 }
 
 .placeholder-text {
-  color: #94a3b8;
+  color: var(--reg-subtext, #94a3b8);
   font-size: 14px;
 }

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeacherRegistrationForm.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeacherRegistrationForm.css
@@ -1,7 +1,7 @@
 /* Teacher registration card */
 .registration-card {
   margin-top: 0;
-  padding: 16px;
+  padding: 14px;
   border: 1px solid var(--reg-border, #dbe2ef);
   border-radius: 12px;
   background: #ffffff;
@@ -12,14 +12,14 @@
 
 @media (min-width: 768px) {
   .registration-card {
-    padding: 18px;
+    padding: 16px;
   }
 }
 
 .registration-title {
   margin: 0;
   color: var(--reg-text, #0f172a);
-  font-size: 20px;
+  font-size: 18px;
   letter-spacing: -0.01em;
 }
 
@@ -80,13 +80,13 @@
 .registration-card-modern .registration-fields-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 10px 12px;
+  gap: 8px 12px;
 }
 
 .registration-card-modern .registration-field {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .registration-card-modern .registration-field-full {
@@ -103,14 +103,14 @@
 .registration-subtitle {
   margin: 0;
   color: var(--reg-subtext, #64748b);
-  font-size: 13px;
+  font-size: 12px;
   text-align: left;
 }
 
 .registration-hint {
   margin: -2px 0 0;
   color: #94a3b8;
-  font-size: 12px;
+  font-size: 11px;
   text-align: left;
 }
 
@@ -122,6 +122,20 @@
   color: #16a34a;
   font-size: 14px;
   margin: 8px 0 0;
+}
+
+.registration-select {
+  height: 44px;
+  padding: 0 12px;
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #64748b 50%),
+    linear-gradient(135deg, #64748b 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) calc(50% - 3px),
+    calc(100% - 12px) calc(50% - 3px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
 }
 
 @media (min-width: 900px) {

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeacherRegistrationForm.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeacherRegistrationForm.css
@@ -1,36 +1,135 @@
 /* Teacher registration card */
 .registration-card {
-  margin-top: 12px;
-  padding: 12px;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  background: #fff;
+  margin-top: 0;
+  padding: 16px;
+  border: 1px solid var(--reg-border, #dbe2ef);
+  border-radius: 12px;
+  background: #ffffff;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 @media (min-width: 768px) {
   .registration-card {
-    border-radius: 10px;
-    padding: 14px;
-  }
-}
-
-@media (min-width: 1024px) {
-  .registration-card {
-    border-radius: 12px;
-    padding: 16px;
+    padding: 18px;
   }
 }
 
 .registration-title {
-  margin: 0 0 4px;
-  color: #0f172a;
+  margin: 0;
+  color: var(--reg-text, #0f172a);
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.registration-title-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.registration-title-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--reg-accent, #2563eb);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #dbeafe;
+  padding: 5px;
+  box-sizing: content-box;
+}
+
+.registration-title-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
+.registration-input-wrap {
+  position: relative;
+}
+
+.registration-input-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  color: #94a3b8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.registration-input-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
+.registration-input-with-icon {
+  padding-left: 42px !important;
+  height: 44px;
+}
+
+.registration-card-modern .registration-fields-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px 12px;
+}
+
+.registration-card-modern .registration-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.registration-card-modern .registration-field-full {
+  grid-column: 1 / -1;
+}
+
+.registration-header-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.registration-subtitle {
+  margin: 0;
+  color: var(--reg-subtext, #64748b);
+  font-size: 13px;
+  text-align: left;
+}
+
+.registration-hint {
+  margin: -2px 0 0;
+  color: #94a3b8;
+  font-size: 12px;
+  text-align: left;
+}
+
+.registration-cta-row {
+  padding-top: 4px;
 }
 
 .success-message {
   color: #16a34a;
   font-size: 14px;
   margin: 8px 0 0;
+}
+
+@media (min-width: 900px) {
+  .registration-card-modern .registration-fields-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .registration-card-modern .registration-field-full {
+    grid-column: 1 / -1;
+  }
 }

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeachersList.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeachersList.css
@@ -1,33 +1,32 @@
 /* Teachers list pane */
 .teachers-list-pane {
   width: 100%;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  padding: 12px;
-  background: #fff;
+  border: 1px solid var(--reg-border, #d7deea);
+  border-radius: 12px;
+  padding: 14px;
+  background: #ffffff;
   max-height: 300px;
   overflow-y: auto;
 }
 
 @media (min-width: 768px) {
   .teachers-list-pane {
-    width: 280px;
-    border-radius: 10px;
-    max-height: 480px;
+    width: 300px;
+    max-height: 500px;
   }
 }
 
 @media (min-width: 1024px) {
   .teachers-list-pane {
-    width: 320px;
-    border-radius: 12px;
+    width: 330px;
     max-height: 560px;
   }
 }
 
 .teachers-list-title {
   font-weight: 700;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
+  color: var(--reg-text, #0f172a);
 }
 
 .teachers-list {
@@ -43,11 +42,11 @@
 .teacher-button {
   width: 100%;
   text-align: left;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-  border-radius: 8px;
-  padding: 8px 10px;
-  color: #0f172a;
+  border: 1px solid var(--reg-border, #d7deea);
+  background: var(--reg-panel, #f8fafc);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: var(--reg-text, #0f172a);
   transition:
     background-color 0.2s ease,
     border-color 0.2s ease,
@@ -55,11 +54,11 @@
 }
 
 .teacher-button:hover {
-  background: #e2e8f0;
+  background: #eef2ff;
 }
 
 .teacher-button.selected {
-  border-color: #2563eb;
+  border-color: var(--reg-accent, #2563eb);
   background: #eff6ff;
   color: #1e3a8a;
 }

--- a/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeachersList.css
+++ b/ContentWebApp/src/components/AllContent/RegistrationTab/css/TeachersList.css
@@ -51,6 +51,47 @@
     background-color 0.2s ease,
     border-color 0.2s ease,
     color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.teacher-button-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.teacher-name {
+  font-weight: 600;
+}
+
+.teacher-meta {
+  color: var(--reg-subtext, #64748b);
+  font-size: 13px;
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 4px 8px;
+  letter-spacing: 0.02em;
+}
+
+.teacher-role-badge {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.creator-role-badge {
+  background: #dbeafe;
+  color: #1d4ed8;
 }
 
 .teacher-button:hover {

--- a/ContentWebApp/src/components/Login.js
+++ b/ContentWebApp/src/components/Login.js
@@ -122,10 +122,28 @@ const Login = () => {
 
     try {
       setIsSubmitting(true);
-      const response = await axios.post(`${baseURL}/tenant/login`, {
-        email: formData.email,
-        password: formData.password,
-      });
+      const loginEndpoints = ["/tenant/login", "/content-creator/login"];
+      let response = null;
+
+      for (const endpoint of loginEndpoints) {
+        try {
+          response = await axios.post(`${baseURL}${endpoint}`, {
+            email: formData.email,
+            password: formData.password,
+          });
+          break;
+        } catch (endpointError) {
+          if (endpointError?.response?.status === 401) {
+            continue;
+          }
+          throw endpointError;
+        }
+      }
+
+      if (!response) {
+        setShowError("Invalid credentials. Please try again.");
+        return;
+      }
 
       if (response.status === 200) {
         const { tenantName, token } = response.data;
@@ -136,7 +154,8 @@ const Login = () => {
       }
     } catch (error) {
       console.error("Login error:", error);
-      setShowError("Login failed. Please verify your details.");
+      const message = error?.response?.data?.message;
+      setShowError(message || "Login failed. Please verify your details.");
     } finally {
       setIsSubmitting(false);
     }
@@ -147,7 +166,7 @@ const Login = () => {
       <div style={cardStyle}>
         <header style={headerStyle}>
           <h1 style={titleStyle}>SEEDS</h1>
-          <p style={descriptionStyle}>Educational App for Visually Impaired Students</p>
+          <p style={descriptionStyle}>Sign in with your registered email and password.</p>
         </header>
 
         <div style={tabsStyle}>

--- a/ContentWebApp/src/components/Profile.js
+++ b/ContentWebApp/src/components/Profile.js
@@ -11,7 +11,7 @@ import "./Profile.css";
 
 const Profile = () => {
   const navigate = useNavigate();
-  const { getAuthHeaders, logout, getCurrentUser } = useAuth();
+  const { getAuthHeaders, logout, getCurrentUserProfile } = useAuth();
 
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -24,6 +24,7 @@ const Profile = () => {
   const [passwordError, setPasswordError] = useState("");
   const [passwordSuccess, setPasswordSuccess] = useState("");
   const [currentUser, setCurrentUser] = useState("User");
+  const [currentUserRole, setCurrentUserRole] = useState("tenant");
 
   const handleTabChange = (tab) => {
     navigate("/content", { state: { activeTab: tab } });
@@ -55,16 +56,18 @@ const Profile = () => {
   useEffect(() => {
     const loadUser = async () => {
       try {
-        const name = await getCurrentUser();
-        setCurrentUser(name);
+        const profile = await getCurrentUserProfile();
+        setCurrentUser(profile?.name || profile?.tenantName || "User");
+        setCurrentUserRole(profile?.role || "tenant");
       } catch (error) {
         console.error("Error fetching user:", error);
         setCurrentUser("User");
+        setCurrentUserRole("tenant");
       }
     };
 
     loadUser();
-  }, [getCurrentUser]);
+  }, [getCurrentUserProfile]);
 
   useEffect(() => {
     fetchProfile();
@@ -136,6 +139,7 @@ const Profile = () => {
           activeTab="profile"
           onTabChange={handleTabChange}
           currentUser={currentUser}
+          currentUserRole={currentUserRole}
           onLogout={logout}
         />
 
@@ -179,7 +183,12 @@ const Profile = () => {
                   <p className="card-description">Update your account password</p>
                 </div>
               </div>
-              <form onSubmit={handlePasswordChange} className="profile-form">
+              {currentUserRole !== "tenant" ? (
+                <div className="profile-hint">
+                  Password changes are currently available for tenant accounts only.
+                </div>
+              ) : (
+                <form onSubmit={handlePasswordChange} className="profile-form">
                 <div className="profile-field">
                   <label className="profile-label" htmlFor="current-password">
                     Current Password
@@ -247,7 +256,8 @@ const Profile = () => {
                     {isChangingPassword ? "Updating..." : "Update Password"}
                   </button>
                 </div>
-              </form>
+                </form>
+              )}
             </div>
           </div>
         )}

--- a/ContentWebApp/src/components/Register.js
+++ b/ContentWebApp/src/components/Register.js
@@ -162,12 +162,7 @@ const Register = () => {
     event.preventDefault();
     setError("");
 
-    if (
-      !formData.email ||
-      !formData.password ||
-      !formData.tenantName ||
-      !formData.confirmPassword
-    ) {
+    if (!formData.tenantName || !formData.email || !formData.password || !formData.confirmPassword) {
       setError("All fields are required.");
       return;
     }
@@ -200,7 +195,12 @@ const Register = () => {
       }
     } catch (err) {
       console.error("Registration error:", err);
-      setError("Failed to register. Please try again.");
+      const responseData = err?.response?.data;
+      const message =
+        (typeof responseData === "string" && responseData) ||
+        responseData?.message ||
+        err?.message;
+      setError(message || "Failed to register. Please try again.");
     } finally {
       setIsSubmitting(false);
     }

--- a/ContentWebApp/src/hooks/useAuth.js
+++ b/ContentWebApp/src/hooks/useAuth.js
@@ -1,14 +1,16 @@
-import { useCallback, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { SEEDS_URL } from "../Constants";
 import { getAuthHeaders, isAuthenticated, clearAuth } from "../utils/authHelpers";
 import { apiFetch } from "../services/api";
 
 let cachedTenantName = null;
+let cachedUserProfile = null;
 let cachedUserPromise = null;
 
 const resetUserCache = () => {
   cachedTenantName = null;
+  cachedUserProfile = null;
   cachedUserPromise = null;
 };
 
@@ -49,7 +51,8 @@ export const useAuth = () => {
     })
       .then((req) => {
         console.log("Current User Info:", req);
-        cachedTenantName = req.tenantName || "User";
+        cachedUserProfile = req;
+        cachedTenantName = req.name || req.tenantName || "User";
         cachedUserPromise = null;
         return cachedTenantName;
       })
@@ -61,10 +64,19 @@ export const useAuth = () => {
     return cachedUserPromise;
   }, []);
 
+  const getCurrentUserProfile = useCallback(async () => {
+    if (cachedUserProfile) {
+      return cachedUserProfile;
+    }
+    await getCurrentUser();
+    return cachedUserProfile;
+  }, [getCurrentUser]);
+
   return {
     getAuthHeaders: getHeaders,
     logout,
     getCurrentUser,
+    getCurrentUserProfile,
     isAuthenticated: isAuthenticated(),
   };
 };

--- a/ContentWebApp/src/hooks/useContentCreators.js
+++ b/ContentWebApp/src/hooks/useContentCreators.js
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from "react";
+import { contentCreatorService } from "../services/contentCreatorService";
+import { useAuth } from "./useAuth";
+
+const isValidEmail = (email) => {
+  if (!email) return false;
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email.trim());
+};
+
+export const useContentCreators = (activeTab) => {
+  const [contentCreators, setContentCreators] = useState([]);
+  const [creatorMessage, setCreatorMessage] = useState("");
+  const { getAuthHeaders } = useAuth();
+
+  const fetchContentCreators = useCallback(
+    async (signal = null) => {
+      try {
+        const creators = await contentCreatorService.getContentCreators(getAuthHeaders(), signal);
+        setContentCreators(Array.isArray(creators) ? creators : []);
+      } catch (error) {
+        if (error.name !== "AbortError") {
+          console.error("Fetch content creators error:", error);
+        }
+      }
+    },
+    [getAuthHeaders]
+  );
+
+  useEffect(() => {
+    const ac = new AbortController();
+    if (activeTab === "registration") {
+      fetchContentCreators(ac.signal);
+    }
+    return () => ac.abort();
+  }, [activeTab, fetchContentCreators]);
+
+  const registerContentCreator = useCallback(
+    async ({ name, email, password }) => {
+      if (!name || !email || !password) {
+        setCreatorMessage("Name, email, and password are required.");
+        setTimeout(() => setCreatorMessage(""), 3000);
+        return false;
+      }
+
+      if (!isValidEmail(email)) {
+        setCreatorMessage("Please provide a valid email.");
+        setTimeout(() => setCreatorMessage(""), 3000);
+        return false;
+      }
+
+      try {
+        await contentCreatorService.registerContentCreator(
+          {
+            name: name.trim(),
+            email: email.trim().toLowerCase(),
+            password,
+          },
+          getAuthHeaders()
+        );
+        setCreatorMessage("Content creator added successfully.");
+        await fetchContentCreators();
+        setTimeout(() => setCreatorMessage(""), 3000);
+        return true;
+      } catch (error) {
+        console.error("Content creator registration error:", error);
+        const message = error?.message || "Failed to register content creator.";
+        setCreatorMessage(message);
+        setTimeout(() => setCreatorMessage(""), 3000);
+        return false;
+      }
+    },
+    [fetchContentCreators, getAuthHeaders]
+  );
+
+  return {
+    contentCreators,
+    registerContentCreator,
+    creatorMessage,
+  };
+};

--- a/ContentWebApp/src/services/contentCreatorService.js
+++ b/ContentWebApp/src/services/contentCreatorService.js
@@ -1,0 +1,23 @@
+import { SEEDS_URL } from "../Constants";
+import { apiFetch } from "./api";
+
+export const contentCreatorService = {
+  async getContentCreators(headers = {}, signal = null) {
+    const url = `${SEEDS_URL}/content-creator`;
+    const response = await apiFetch(url, {
+      method: "GET",
+      headers,
+      signal,
+    });
+    return response || [];
+  },
+
+  async registerContentCreator({ name, email, password }, headers = {}) {
+    const url = `${SEEDS_URL}/content-creator/tenant/register`;
+    return await apiFetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name, email, password }),
+    });
+  },
+};

--- a/backend-server/package-lock.json
+++ b/backend-server/package-lock.json
@@ -1147,7 +1147,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1685,6 +1684,7 @@
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -1704,6 +1704,7 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1717,6 +1718,7 @@
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1727,6 +1729,7 @@
       "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -1742,6 +1745,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1753,6 +1757,7 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1766,6 +1771,7 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -1779,6 +1785,7 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1792,6 +1799,7 @@
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -1815,7 +1823,8 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1823,6 +1832,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1834,6 +1844,7 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1847,6 +1858,7 @@
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1860,6 +1872,7 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1886,6 +1899,7 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1896,6 +1910,7 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -2210,6 +2225,7 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -2220,6 +2236,7 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -2234,6 +2251,7 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2248,6 +2266,7 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -3614,7 +3633,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -4195,6 +4215,7 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -4231,6 +4252,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4683,7 +4705,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5316,7 +5337,8 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -5717,7 +5739,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5765,6 +5786,7 @@
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -5782,6 +5804,7 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5795,6 +5818,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5806,6 +5830,7 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5819,6 +5844,7 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -5836,6 +5862,7 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5849,6 +5876,7 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -5865,6 +5893,7 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5878,6 +5907,7 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -5894,6 +5924,7 @@
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -5926,6 +5957,7 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -5939,6 +5971,7 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -5952,6 +5985,7 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6066,7 +6100,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6211,7 +6244,8 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -6307,6 +6341,7 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -6470,6 +6505,7 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -6483,7 +6519,8 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/fluent-ffmpeg": {
       "version": "2.1.3",
@@ -7133,6 +7170,7 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -7150,6 +7188,7 @@
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -7167,6 +7206,7 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8160,7 +8200,8 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -8174,14 +8215,16 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8304,6 +8347,7 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -8324,6 +8368,7 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -8424,7 +8469,8 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -9482,6 +9528,7 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -9559,6 +9606,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -9715,6 +9763,7 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -9725,7 +9774,6 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11019,6 +11067,7 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -11179,6 +11228,7 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -11304,6 +11354,7 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/backend-server/package.json
+++ b/backend-server/package.json
@@ -7,6 +7,8 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "lint": "npx eslint src/",
+    "migrate:content-tenantid:dry": "node scripts/backfillContentTenantId.js",
+    "migrate:content-tenantid:apply": "node scripts/backfillContentTenantId.js --apply",
     "lint:fix": "npx eslint src/ --fix && npx prettier src/ --write",
     "fix:file": "npx eslint --fix && npx prettier --write"
   },

--- a/backend-server/scripts/backfillContentTenantId.js
+++ b/backend-server/scripts/backfillContentTenantId.js
@@ -1,0 +1,110 @@
+"use strict";
+
+const mongoose = require("mongoose");
+const mongo = require("../src/config/mongo");
+const Tenant = require("../src/models/Tenant");
+const { ContentV3 } = require("../src/models/ContentV3");
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    tenantId: null,
+    limit: null,
+  };
+
+  argv.forEach((arg) => {
+    if (arg === "--apply") {
+      args.apply = true;
+    } else if (arg.startsWith("--tenantId=")) {
+      args.tenantId = arg.split("=")[1] || null;
+    } else if (arg.startsWith("--limit=")) {
+      const raw = arg.split("=")[1];
+      const parsed = Number.parseInt(raw, 10);
+      args.limit = Number.isNaN(parsed) ? null : parsed;
+    }
+  });
+
+  return args;
+}
+
+function normalizeName(value) {
+  return (value || "").trim().toLowerCase();
+}
+
+async function run() {
+  const { apply, tenantId: overrideTenantId, limit } = parseArgs(process.argv.slice(2));
+
+  await mongo();
+
+  const missingTenantQuery = {
+    $or: [
+      { tenantId: { $exists: false } },
+      { tenantId: null },
+      { tenantId: "" },
+    ],
+  };
+
+  const cursor = ContentV3.find(missingTenantQuery).select("_id createdBy tenantId").lean();
+  if (typeof limit === "number" && limit > 0) {
+    cursor.limit(limit);
+  }
+  const docs = await cursor.exec();
+
+  const tenants = await Tenant.find({}).select("_id tenantName").lean().exec();
+  const tenantByName = new Map(
+    tenants
+      .filter((t) => t.tenantName)
+      .map((t) => [normalizeName(t.tenantName), String(t._id)]),
+  );
+
+  let matchedByOverride = 0;
+  let matchedByCreatedBy = 0;
+  let skipped = 0;
+  let updated = 0;
+
+  for (const doc of docs) {
+    let targetTenantId = null;
+
+    if (overrideTenantId) {
+      targetTenantId = overrideTenantId;
+      matchedByOverride += 1;
+    } else {
+      const key = normalizeName(doc.createdBy);
+      if (key && tenantByName.has(key)) {
+        targetTenantId = tenantByName.get(key);
+        matchedByCreatedBy += 1;
+      }
+    }
+
+    if (!targetTenantId) {
+      skipped += 1;
+      continue;
+    }
+
+    if (apply) {
+      await ContentV3.updateOne({ _id: doc._id }, { $set: { tenantId: targetTenantId } }).exec();
+      updated += 1;
+    }
+  }
+
+  console.log("--- backfillContentTenantId summary ---");
+  console.log(`mode: ${apply ? "APPLY" : "DRY_RUN"}`);
+  console.log(`documents_missing_tenantId: ${docs.length}`);
+  console.log(`matched_by_override: ${matchedByOverride}`);
+  console.log(`matched_by_createdBy_tenantName: ${matchedByCreatedBy}`);
+  console.log(`skipped_unresolved: ${skipped}`);
+  console.log(`updated: ${apply ? updated : 0}`);
+
+  if (!apply) {
+    console.log("No data was changed. Re-run with --apply to persist updates.");
+  }
+}
+
+run()
+  .catch((error) => {
+    console.error("Migration failed:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.disconnect();
+  });

--- a/backend-server/src/auth/authenticateToken.js
+++ b/backend-server/src/auth/authenticateToken.js
@@ -29,7 +29,11 @@ function authenticateToken(req, res, next) {
     req.user = user;
     req.userId = user.id;
     req.userRole = user.role || "tenant";
-    req.tenantId = user.tenantId || user.id;
+    if (req.userRole === "tenant") {
+      req.tenantId = user.id;
+    } else {
+      req.tenantId = user.tenantId;
+    }
     next();
   });
 }

--- a/backend-server/src/auth/authenticateToken.js
+++ b/backend-server/src/auth/authenticateToken.js
@@ -28,6 +28,8 @@ function authenticateToken(req, res, next) {
     if (err) return res.sendStatus(STATUS.FORBIDDEN);
     req.user = user;
     req.userId = user.id;
+    req.userRole = user.role || "tenant";
+    req.tenantId = user.tenantId || user.id;
     next();
   });
 }

--- a/backend-server/src/auth/contentCreator/contentCreatorAuthProviderMiddleware.js
+++ b/backend-server/src/auth/contentCreator/contentCreatorAuthProviderMiddleware.js
@@ -1,0 +1,153 @@
+const {
+  authType,
+  secretKey,
+  jwtExpiresIn,
+  passwordSaltRounds,
+} = require("../../config/env");
+const { STATUS, PASSWORD_POLICY } = require("../../config/constants");
+const validator = require("validator");
+const jwt = require("jsonwebtoken");
+const bcrypt = require("bcryptjs");
+
+const nativeDb = require("../dbAdapters/nativeDb");
+const firebaseDb = require("../dbAdapters/firebaseDb");
+
+const dbAdapter = authType === "firebase" ? firebaseDb : nativeDb;
+
+function generateToken(payload) {
+  return jwt.sign(payload, secretKey, {
+    expiresIn: jwtExpiresIn,
+    issuer: "content-creator",
+  });
+}
+
+async function registerWithTenantId(tenantId, { email, password, name }, res) {
+  if (!email || !password || !tenantId || !name) {
+    return res.status(STATUS.BAD_REQUEST).json({
+      message: "Email, password, tenantId, and name are required",
+    });
+  }
+
+  if (!validator.isEmail(email)) {
+    return res
+      .status(STATUS.BAD_REQUEST)
+      .json({ message: "Invalid email format" });
+  }
+
+  if (!validator.isStrongPassword(password, PASSWORD_POLICY)) {
+    return res.status(STATUS.BAD_REQUEST).json({
+      message:
+        "Password must be at least 8 characters, and include uppercase, lowercase, number, and special character",
+    });
+  }
+
+  try {
+    const tenant = await dbAdapter.getTenantById(tenantId);
+    if (!tenant) {
+      return res.status(STATUS.NOT_FOUND).json({
+        message: "Tenant not found",
+      });
+    }
+
+    const existingCreator = await dbAdapter.getContentCreatorByEmail(email);
+    if (existingCreator) {
+      return res.status(STATUS.CONFLICT).json({
+        message: "Email already exists",
+      });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, parseInt(passwordSaltRounds, 10));
+    const created = await dbAdapter.insertContentCreator({
+      email,
+      password: hashedPassword,
+      tenantId,
+      name,
+    });
+
+    return res.status(STATUS.CREATED).json({
+      message: "Content creator registered successfully",
+      id: created._id || created.id,
+    });
+  } catch (error) {
+    console.error("Content creator registration error:", error);
+    return res
+      .status(STATUS.INTERNAL_ERROR)
+      .json({ message: "Internal server error" });
+  }
+}
+
+module.exports = {
+  async register(req, res) {
+    const { email, password, tenantId, name } = req.body;
+    return registerWithTenantId(tenantId, { email, password, name }, res);
+  },
+
+  async registerForTenant(req, res) {
+    const { email, password, name } = req.body;
+    return registerWithTenantId(req.tenantId, { email, password, name }, res);
+  },
+
+  async login(req, res) {
+    const { email, password } = req.body;
+
+    if (!email || !password) {
+      return res
+        .status(STATUS.BAD_REQUEST)
+        .json({ message: "Email and password are required" });
+    }
+
+    try {
+      const creator = await dbAdapter.getContentCreatorByEmail(email);
+      if (!creator) {
+        return res
+          .status(STATUS.UNAUTHORIZED)
+          .json({ message: "Invalid credentials" });
+      }
+
+      const passwordMatch = await bcrypt.compare(password, creator.password);
+      if (!passwordMatch) {
+        return res
+          .status(STATUS.UNAUTHORIZED)
+          .json({ message: "Invalid credentials" });
+      }
+
+      const tenant = await dbAdapter.getTenantById(creator.tenantId);
+      if (!tenant) {
+        return res.status(STATUS.UNAUTHORIZED).json({
+          message: "Tenant for this content creator no longer exists",
+        });
+      }
+
+      const token = generateToken({
+        id: creator._id || creator.id,
+        email: creator.email,
+        name: creator.name,
+        tenantId: creator.tenantId,
+        role: "content_creator",
+      });
+
+      return res.status(STATUS.OK).json({
+        token,
+        id: creator._id || creator.id,
+        name: creator.name,
+        email: creator.email,
+        tenantId: creator.tenantId,
+        tenantName: tenant.tenantName,
+        role: "content_creator",
+      });
+    } catch (error) {
+      console.error("Content creator login error:", error);
+      return res
+        .status(STATUS.INTERNAL_ERROR)
+        .json({ message: "Internal server error" });
+    }
+  },
+
+  async getContentCreatorById(id) {
+    return dbAdapter.getContentCreatorById(id);
+  },
+
+  async getContentCreatorsByTenantId(tenantId) {
+    return dbAdapter.getContentCreatorsByTenantId(tenantId);
+  },
+};

--- a/backend-server/src/auth/dbAdapters/firebaseDb.js
+++ b/backend-server/src/auth/dbAdapters/firebaseDb.js
@@ -72,4 +72,35 @@ module.exports = {
     await tenantRef.update({ password: newPassword });
     return;
   },
+  async getContentCreatorByEmail(email) {
+    const creatorsRef = db.collection("ContentCreators");
+    const snapshot = await creatorsRef.where("email", "==", email).get();
+    if (snapshot.empty) {
+      return null;
+    }
+    const doc = snapshot.docs[0];
+    return { id: doc.id, ...doc.data() };
+  },
+  async getContentCreatorById(id) {
+    const creatorRef = db.collection("ContentCreators").doc(id);
+    const doc = await creatorRef.get();
+    if (!doc.exists) {
+      return null;
+    }
+    return { id: doc.id, ...doc.data() };
+  },
+  async getContentCreatorsByTenantId(tenantId) {
+    const creatorsRef = db.collection("ContentCreators");
+    const snapshot = await creatorsRef.where("tenantId", "==", tenantId).get();
+    if (snapshot.empty) {
+      return [];
+    }
+    return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+  },
+  async insertContentCreator({ email, password, name, tenantId }) {
+    const creatorsRef = db.collection("ContentCreators");
+    const newCreatorRef = creatorsRef.doc();
+    await newCreatorRef.set({ email, password, name, tenantId });
+    return { id: newCreatorRef.id, email, password, name, tenantId };
+  },
 };

--- a/backend-server/src/auth/dbAdapters/nativeDb.js
+++ b/backend-server/src/auth/dbAdapters/nativeDb.js
@@ -1,5 +1,6 @@
 const Tenant = require("../../models/Tenant");
 const Teacher = require("../../models/Teacher");
+const ContentCreator = require("../../models/ContentCreator");
 
 module.exports = {
   async getAllTenants() {
@@ -27,5 +28,17 @@ module.exports = {
   },
   async updateTenantPassword(tenantId, newPassword) {
     return Tenant.findByIdAndUpdate(tenantId, { password: newPassword });
+  },
+  async getContentCreatorByEmail(email) {
+    return ContentCreator.findOne({ email });
+  },
+  async getContentCreatorById(id) {
+    return ContentCreator.findById(id);
+  },
+  async getContentCreatorsByTenantId(tenantId) {
+    return ContentCreator.find({ tenantId }).lean().exec();
+  },
+  async insertContentCreator({ email, password, name, tenantId }) {
+    return ContentCreator.create({ email, password, name, tenantId });
   },
 };

--- a/backend-server/src/auth/teacher/teacherAuthProviderMiddleware.js
+++ b/backend-server/src/auth/teacher/teacherAuthProviderMiddleware.js
@@ -39,6 +39,8 @@ module.exports = {
         id: teacher._id || teacher.id,
         phoneNumber: teacher.phoneNumber,
         name: teacher.name,
+        tenantId: teacher.tenantId,
+        role: "teacher",
       });
       return res.status(STATUS.OK).json({ token, phoneNumber });
     } catch (error) {

--- a/backend-server/src/auth/tenant/tenantAuthProviderMiddleware.js
+++ b/backend-server/src/auth/tenant/tenantAuthProviderMiddleware.js
@@ -48,11 +48,14 @@ module.exports = {
         id: tenant._id || tenant.id,
         email: tenant.email,
         name: tenant.tenantName,
+        tenantId: tenant._id || tenant.id,
+        role: "tenant",
       });
       return res.status(STATUS.OK).json({
         token,
         id: tenant._id || tenant.id,
         tenantName: tenant.tenantName,
+        role: "tenant",
       });
     } catch (error) {
       console.error("Login error:", error);

--- a/backend-server/src/index.js
+++ b/backend-server/src/index.js
@@ -18,6 +18,7 @@ const logRouter = require("./routes/logRouter.js");
 const { constants } = require("zlib");
 const setupSwagger = require("./swagger");
 const tenantRouter = require("./routes/tenantRouter.js");
+const contentCreatorRouter = require("./routes/contentCreatorRouter.js");
 const mongo = require("./config/mongo");
 const app = express();
 
@@ -49,6 +50,7 @@ app.use("/user", authenticateToken, userRouter);
 app.use("/teacher", teacherRouter);
 app.use("/v1/teacher", v1TeacherRouter);
 app.use("/tenant", tenantRouter);
+app.use("/content-creator", contentCreatorRouter);
 if (require.main === module) {
   mongo()
     .then(() => {

--- a/backend-server/src/models/ContentCreator.js
+++ b/backend-server/src/models/ContentCreator.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const mongoose = require("mongoose");
+
+const contentCreatorSchema = new mongoose.Schema(
+  {
+    email: { type: String, required: true, unique: true, index: true },
+    password: { type: String, required: true },
+    name: { type: String, required: true },
+    tenantId: { type: String, required: true, index: true },
+  },
+  { timestamps: true },
+);
+
+const ContentCreator = mongoose.model("ContentCreator", contentCreatorSchema);
+module.exports = ContentCreator;

--- a/backend-server/src/models/ContentV3.js
+++ b/backend-server/src/models/ContentV3.js
@@ -35,6 +35,7 @@ const ContentSchema = new mongoose.Schema(
     isTeacherApp: { type: Boolean, default: false },
     isDeleted: { type: Boolean, default: false },
     creation_time: { type: Number, default: -1 },
+    tenantId: { type: String, required: true, index: true },
   },
   { collection: "contentsV3" }
 );

--- a/backend-server/src/routes/contentCreatorRouter.js
+++ b/backend-server/src/routes/contentCreatorRouter.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const express = require("express");
+const authenticateToken = require("../auth/authenticateToken");
+const contentCreatorAuthProvider = require("../auth/contentCreator/contentCreatorAuthProviderMiddleware");
+const { STATUS } = require("../config/constants");
+
+const router = express.Router();
+
+router.post("/register", contentCreatorAuthProvider.register);
+router.post("/login", contentCreatorAuthProvider.login);
+router.post("/tenant/register", authenticateToken, async (req, res) => {
+  if (req.userRole !== "tenant") {
+    return res.status(STATUS.FORBIDDEN).json({
+      message: "Only tenant accounts can add content creators",
+    });
+  }
+  return contentCreatorAuthProvider.registerForTenant(req, res);
+});
+
+router.get("/", authenticateToken, async (req, res) => {
+  try {
+    const creators = await contentCreatorAuthProvider.getContentCreatorsByTenantId(req.tenantId);
+    return res.status(STATUS.OK).json(
+      creators.map((creator) => ({
+        id: creator._id || creator.id,
+        email: creator.email,
+        name: creator.name,
+        tenantId: creator.tenantId,
+      })),
+    );
+  } catch (error) {
+    console.error("List content creators error:", error);
+    return res
+      .status(STATUS.INTERNAL_ERROR)
+      .json({ message: "Internal server error" });
+  }
+});
+
+router.get("/me", authenticateToken, async (req, res) => {
+  if (req.userRole !== "content_creator") {
+    return res.status(STATUS.FORBIDDEN).json({ message: "Forbidden" });
+  }
+
+  try {
+    const creator = await contentCreatorAuthProvider.getContentCreatorById(req.userId);
+    if (!creator) {
+      return res.status(STATUS.NOT_FOUND).json({ message: "Content creator not found" });
+    }
+    return res.status(STATUS.OK).json({
+      email: creator.email,
+      name: creator.name,
+      tenantId: creator.tenantId,
+      role: "content_creator",
+    });
+  } catch (error) {
+    console.error("Get content creator profile error:", error);
+    return res
+      .status(STATUS.INTERNAL_ERROR)
+      .json({ message: "Internal server error" });
+  }
+});
+
+module.exports = router;

--- a/backend-server/src/routes/contentRouter.js
+++ b/backend-server/src/routes/contentRouter.js
@@ -18,11 +18,7 @@ const fetch = (...args) =>
 
 // Project modules
 const Content = require("../models/Content.js");
-const {
-  ContentV3,
-  getContent,
-  getContentById,
-} = require("../models/ContentV3.js");
+const { ContentV3 } = require("../models/ContentV3.js");
 const QuizCreateRequest = require("../models/QuizCreateRequest.js");
 const { QuizData, fromQuizCreateRequest } = require("../models/QuizData.js");
 const BlobService = require("../services/BlobService.js");
@@ -282,10 +278,15 @@ router.get(
 router.get(
   "/themes",
   tryCatchWrapper(async (req, res) => {
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(400).json({ error: "tenantId not found in token" });
+    }
     const language = req.query.language;
     const content = await ContentV3.find({
       language: language,
       isPullModel: true,
+      tenantId,
     }).sort({ _id: -1 });
     const themeSet = new Set();
     const themes = [];
@@ -381,6 +382,11 @@ router.get(
 router.get(
   "/",
   tryCatchWrapper(async (req, res) => {
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(400).json({ error: "tenantId not found in token" });
+    }
+
     const limit = parseInt(req.query.limit) || 15;
     const cursor = req.query.cursor;
 
@@ -390,14 +396,14 @@ router.get(
         ? req.query.ids
         : req.query.ids.split(",");
       const contents = await ContentV3.collection
-        .find({ _id: { $in: idsArray }, isDeleted: { $ne: true } })
+        .find({ _id: { $in: idsArray }, isDeleted: { $ne: true }, tenantId })
         .sort({ creation_time: -1 })
         .toArray();
       return res.json(contents);
     }
 
     // Base query always excludes deleted content
-    let query = { isDeleted: { $ne: true } };
+    let query = { isDeleted: { $ne: true }, tenantId };
 
     if (req.query.onlyTeacherApp) {
       query.isTeacherApp = true;
@@ -508,7 +514,11 @@ router.get(
 router.get(
   "/:contentId",
   tryCatchWrapper(async (req, res) => {
-    const content = await getContentById(req.params.contentId);
+    const content = await ContentV3.findOne({
+      _id: req.params.contentId,
+      tenantId: req.tenantId,
+      isDeleted: { $ne: true },
+    }).exec();
     if (!content) {
       return res.status(404).json({ error: "Content not found" });
     }
@@ -561,9 +571,12 @@ router.delete(
   "/:contentId",
   tryCatchWrapper(async (req, res) => {
     const result = await ContentV3.updateOne(
-      { _id: req.params.contentId },
+      { _id: req.params.contentId, tenantId: req.tenantId },
       { $set: { isDeleted: true } },
     );
+    if (!result.matchedCount) {
+      return res.status(404).json({ error: "Content not found" });
+    }
     return res.json(result);
   }),
 );
@@ -573,6 +586,7 @@ router.post(
   tryCatchWrapper(async (req, res) => {
     let content = new ContentV3(req.body);
     content.creation_time = Math.floor(Date.now() / 1000);
+    content.tenantId = req.tenantId;
 
     const savedContent = await content.save();
 

--- a/backend-server/src/routes/contentRouter.js
+++ b/backend-server/src/routes/contentRouter.js
@@ -600,6 +600,40 @@ router.post(
   }),
 );
 
+router.patch(
+  "/",
+  tryCatchWrapper(async (req, res) => {
+    const isAudioUploaded = req.query.isAudioUploaded === "true";
+    const contentId = req.body?._id;
+
+    if (!contentId) {
+      return res.status(400).json({ error: "Content _id is required" });
+    }
+
+    const updatePayload = { ...req.body };
+    delete updatePayload._id;
+    delete updatePayload.tenantId;
+    delete updatePayload.creation_time;
+
+    // If a new audio file was uploaded, force re-processing in the background job.
+    if (isAudioUploaded) {
+      updatePayload.isProcessed = false;
+    }
+
+    const updated = await ContentV3.findOneAndUpdate(
+      { _id: contentId, tenantId: req.tenantId, isDeleted: { $ne: true } },
+      { $set: updatePayload },
+      { new: true },
+    ).exec();
+
+    if (!updated) {
+      return res.status(404).json({ error: "Content not found" });
+    }
+
+    return res.json(updated);
+  }),
+);
+
 // router.patch("/",tryCatchWrapper(async (req,res) => {
 //     const isAudioUploaded = req.query.isAudioUploaded === "true"
 //     if(!req.body.isPullModel){

--- a/backend-server/src/routes/tenantRouter.js
+++ b/backend-server/src/routes/tenantRouter.js
@@ -173,6 +173,12 @@ router.post("/register", tenantAuthProvider.register);
  */
 router.post("/analytics", authenticateToken, async (req, res) => {
   try {
+    if (req.userRole !== "tenant") {
+      return res
+        .status(STATUS.FORBIDDEN)
+        .json({ message: "Only tenant accounts can access analytics" });
+    }
+
     const { startDate, endDate } = req.body;
     const tenantId = req.tenantId;
     if (!startDate || !endDate) {

--- a/backend-server/src/routes/tenantRouter.js
+++ b/backend-server/src/routes/tenantRouter.js
@@ -1,9 +1,9 @@
 const express = require("express");
 const tenantAuthProvider = require("../auth/tenant/tenantAuthProviderMiddleware");
+const contentCreatorAuthProvider = require("../auth/contentCreator/contentCreatorAuthProviderMiddleware");
 const { STATUS } = require("../config/constants");
 const authenticateToken = require("../auth/authenticateToken");
 const IvrV2Log = require("../models/IvrV2Log");
-const { route } = require("..");
 /**
  *  @swagger
  * tags:
@@ -174,7 +174,7 @@ router.post("/register", tenantAuthProvider.register);
 router.post("/analytics", authenticateToken, async (req, res) => {
   try {
     const { startDate, endDate } = req.body;
-    const tenantId = req.userId;
+    const tenantId = req.tenantId;
     if (!startDate || !endDate) {
       return res.status(STATUS.BAD_REQUEST).json({
         message: "Both startDate and endDate are required",
@@ -254,7 +254,14 @@ router.post("/analytics", authenticateToken, async (req, res) => {
 router.post(
   "/change-password",
   authenticateToken,
-  tenantAuthProvider.changePassword,
+  (req, res, next) => {
+    if (req.userRole !== "tenant") {
+      return res
+        .status(STATUS.FORBIDDEN)
+        .json({ message: "Only tenant accounts can change tenant password" });
+    }
+    return tenantAuthProvider.changePassword(req, res, next);
+  },
 );
 
 /**
@@ -287,17 +294,37 @@ router.post(
  *         description: Internal server error
  */
 router.get("/me", authenticateToken, async (req, res) => {
-  const tenantId = req.userId;
   try {
+    const tenantId = req.tenantId;
     const tenant = await tenantAuthProvider.getTenantById(tenantId);
     if (!tenant) {
       return res.status(STATUS.NOT_FOUND).json({ message: "Tenant not found" });
     }
-    const tenantData = {
+
+    if (req.userRole === "content_creator") {
+      const creator = await contentCreatorAuthProvider.getContentCreatorById(req.userId);
+      if (!creator) {
+        return res
+          .status(STATUS.NOT_FOUND)
+          .json({ message: "Content creator not found" });
+      }
+
+      return res.status(STATUS.OK).json({
+        email: creator.email,
+        name: creator.name,
+        role: "content_creator",
+        tenantId,
+        tenantName: tenant.tenantName,
+      });
+    }
+
+    return res.status(STATUS.OK).json({
       email: tenant.email,
       tenantName: tenant.tenantName,
-    };
-    return res.status(STATUS.OK).json(tenantData);
+      role: "tenant",
+      tenantId,
+      name: tenant.tenantName,
+    });
   } catch (error) {
     console.error("Get tenant error:", error);
     return res

--- a/backend-server/src/routes/v1TeacherRouter.js
+++ b/backend-server/src/routes/v1TeacherRouter.js
@@ -96,7 +96,7 @@ router.get("/teachers", authenticateToken, async (req, res) => {
   if (!tenantId) return res.sendStatus(STATUS.BAD_REQUEST);
   console.log("Fetching teachers for tenantId:", tenantId);
   try {
-    const teachers = await Teacher.find({ tenantId }, "_id phoneNumber studentId").lean();
+    const teachers = await Teacher.find({ tenantId }, "_id name phoneNumber studentId").lean();
 
     if (!teachers || teachers.length === 0) return res.json([]);
 

--- a/backend-server/tests/contentCreatorAuthProvider.test.js
+++ b/backend-server/tests/contentCreatorAuthProvider.test.js
@@ -1,0 +1,116 @@
+process.env.AUTH_TYPE = 'native';
+process.env.SECRET_KEY = 'test_secret_key';
+process.env.JWT_EXPIRES_IN = '1h';
+process.env.PASSWORD_SALT_ROUNDS = '4';
+
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+
+jest.mock('../src/auth/dbAdapters/nativeDb', () => ({
+  getTenantById: jest.fn(),
+  getContentCreatorByEmail: jest.fn(),
+  insertContentCreator: jest.fn(),
+  getContentCreatorById: jest.fn(),
+  getContentCreatorsByTenantId: jest.fn(),
+}));
+
+const nativeDb = require('../src/auth/dbAdapters/nativeDb');
+const provider = require('../src/auth/contentCreator/contentCreatorAuthProviderMiddleware');
+
+function mockRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.body = null;
+  res.status = function status(code) {
+    this.statusCode = code;
+    return this;
+  };
+  res.json = function json(payload) {
+    this.body = payload;
+    return this;
+  };
+  return res;
+}
+
+describe('contentCreatorAuthProviderMiddleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('register hashes password and stores content creator', async () => {
+    nativeDb.getTenantById.mockResolvedValue({ _id: 'tenant-1', tenantName: 'Tenant One' });
+    nativeDb.getContentCreatorByEmail.mockResolvedValue(null);
+    nativeDb.insertContentCreator.mockImplementation(async (payload) => ({ ...payload, _id: 'creator-1' }));
+
+    const req = {
+      body: {
+        email: 'creator@example.com',
+        password: 'StrongPass1!',
+        tenantId: 'tenant-1',
+        name: 'Creator Name',
+      },
+    };
+    const res = mockRes();
+
+    await provider.register(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.id).toBe('creator-1');
+    expect(nativeDb.insertContentCreator).toHaveBeenCalledTimes(1);
+
+    const inserted = nativeDb.insertContentCreator.mock.calls[0][0];
+    expect(inserted.email).toBe('creator@example.com');
+    expect(inserted.tenantId).toBe('tenant-1');
+    expect(inserted.name).toBe('Creator Name');
+    expect(inserted.password).not.toBe('StrongPass1!');
+    await expect(bcrypt.compare('StrongPass1!', inserted.password)).resolves.toBe(true);
+  });
+
+  test('login returns token containing role and tenantId', async () => {
+    const hashedPassword = await bcrypt.hash('StrongPass1!', 4);
+    nativeDb.getContentCreatorByEmail.mockResolvedValue({
+      _id: 'creator-1',
+      email: 'creator@example.com',
+      tenantId: 'tenant-1',
+      name: 'Creator Name',
+      password: hashedPassword,
+    });
+    nativeDb.getTenantById.mockResolvedValue({ _id: 'tenant-1', tenantName: 'Tenant One' });
+
+    const req = {
+      body: {
+        email: 'creator@example.com',
+        password: 'StrongPass1!',
+      },
+    };
+    const res = mockRes();
+
+    await provider.login(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.role).toBe('content_creator');
+    expect(res.body.tenantId).toBe('tenant-1');
+
+    const decoded = jwt.verify(res.body.token, process.env.SECRET_KEY);
+    expect(decoded.role).toBe('content_creator');
+    expect(decoded.tenantId).toBe('tenant-1');
+    expect(decoded.id).toBe('creator-1');
+  });
+
+  test('login fails with invalid credentials', async () => {
+    nativeDb.getContentCreatorByEmail.mockResolvedValue(null);
+
+    const req = {
+      body: {
+        email: 'creator@example.com',
+        password: 'WrongPass1!',
+      },
+    };
+    const res = mockRes();
+
+    await provider.login(req, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.message).toBe('Invalid credentials');
+  });
+});

--- a/backend-server/tests/contentCreatorRouter.test.js
+++ b/backend-server/tests/contentCreatorRouter.test.js
@@ -1,0 +1,176 @@
+process.env.AUTH_TYPE = 'native';
+process.env.SECRET_KEY = 'test_secret_key';
+process.env.JWT_EXPIRES_IN = '1h';
+process.env.PASSWORD_SALT_ROUNDS = '4';
+
+jest.mock('../src/auth/authenticateToken', () => (_req, _res, next) => next());
+
+jest.mock('../src/auth/contentCreator/contentCreatorAuthProviderMiddleware', () => ({
+  register: jest.fn((req, res) => res.status(201).json({ id: 'creator-1', ...req.body })),
+  registerForTenant: jest.fn((req, res) =>
+    res.status(201).json({ id: 'creator-tenant', tenantId: req.tenantId, ...req.body }),
+  ),
+  login: jest.fn((req, res) => res.status(200).json({ token: 'jwt-token', ...req.body })),
+  getContentCreatorById: jest.fn(),
+  getContentCreatorsByTenantId: jest.fn(),
+}));
+
+const provider = require('../src/auth/contentCreator/contentCreatorAuthProviderMiddleware');
+const router = require('../src/routes/contentCreatorRouter');
+
+function mockRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.body = null;
+  res.status = function status(code) {
+    this.statusCode = code;
+    return this;
+  };
+  res.json = function json(payload) {
+    this.body = payload;
+    return this;
+  };
+  return res;
+}
+
+function getRouteHandlers(method, path) {
+  const layer = router.stack.find(
+    (entry) => entry.route && entry.route.path === path && entry.route.methods[method],
+  );
+  if (!layer) {
+    throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+  }
+  return layer.route.stack.map((stackEntry) => stackEntry.handle);
+}
+
+describe('contentCreatorRouter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('POST /register registers a content creator', async () => {
+    const [registerHandler] = getRouteHandlers('post', '/register');
+    const req = {
+      body: {
+        email: 'creator@example.com',
+        password: 'StrongPass1!',
+        tenantId: 'tenant-1',
+        name: 'Creator Name',
+      },
+    };
+    const res = mockRes();
+
+    await registerHandler(req, res);
+
+    expect(provider.register).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(201);
+    expect(res.body.email).toBe('creator@example.com');
+  });
+
+  test('POST /login logs in a content creator', async () => {
+    const [loginHandler] = getRouteHandlers('post', '/login');
+    const req = {
+      body: {
+        email: 'creator@example.com',
+        password: 'StrongPass1!',
+      },
+    };
+    const res = mockRes();
+
+    await loginHandler(req, res);
+
+    expect(provider.login).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBe('jwt-token');
+  });
+
+  test('POST /tenant/register blocks non-tenant users', async () => {
+    const [, tenantRegisterHandler] = getRouteHandlers('post', '/tenant/register');
+    const req = {
+      userRole: 'content_creator',
+      tenantId: 'tenant-1',
+      body: {
+        email: 'creator@example.com',
+        name: 'Creator',
+        password: 'StrongPass1!',
+      },
+    };
+    const res = mockRes();
+
+    await tenantRegisterHandler(req, res);
+
+    expect(provider.registerForTenant).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('POST /tenant/register creates content creator for tenant users', async () => {
+    const [, tenantRegisterHandler] = getRouteHandlers('post', '/tenant/register');
+    const req = {
+      userRole: 'tenant',
+      tenantId: 'tenant-1',
+      body: {
+        email: 'creator@example.com',
+        name: 'Creator',
+        password: 'StrongPass1!',
+      },
+    };
+    const res = mockRes();
+
+    await tenantRegisterHandler(req, res);
+
+    expect(provider.registerForTenant).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(201);
+    expect(res.body.tenantId).toBe('tenant-1');
+  });
+
+  test('GET / returns creators scoped by tenantId', async () => {
+    const [, listHandler] = getRouteHandlers('get', '/');
+    provider.getContentCreatorsByTenantId.mockResolvedValue([
+      { _id: 'creator-1', email: 'one@example.com', name: 'One', tenantId: 'tenant-1' },
+      { _id: 'creator-2', email: 'two@example.com', name: 'Two', tenantId: 'tenant-1' },
+    ]);
+
+    const req = { tenantId: 'tenant-1' };
+    const res = mockRes();
+
+    await listHandler(req, res);
+
+    expect(provider.getContentCreatorsByTenantId).toHaveBeenCalledWith('tenant-1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].tenantId).toBe('tenant-1');
+  });
+
+  test('GET /me blocks non-content-creator roles', async () => {
+    const [, meHandler] = getRouteHandlers('get', '/me');
+    const req = { userRole: 'tenant' };
+    const res = mockRes();
+
+    await meHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toBe('Forbidden');
+  });
+
+  test('GET /me returns content creator profile', async () => {
+    const [, meHandler] = getRouteHandlers('get', '/me');
+    provider.getContentCreatorById.mockResolvedValue({
+      _id: 'creator-1',
+      email: 'creator@example.com',
+      name: 'Creator Name',
+      tenantId: 'tenant-1',
+    });
+
+    const req = {
+      userRole: 'content_creator',
+      userId: 'creator-1',
+    };
+    const res = mockRes();
+
+    await meHandler(req, res);
+
+    expect(provider.getContentCreatorById).toHaveBeenCalledWith('creator-1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.role).toBe('content_creator');
+  });
+});

--- a/backend-server/tests/contentRouterTenantScope.test.js
+++ b/backend-server/tests/contentRouterTenantScope.test.js
@@ -1,0 +1,210 @@
+process.env.AUTH_TYPE = 'native';
+process.env.SECRET_KEY = 'test_secret_key';
+process.env.JWT_EXPIRES_IN = '1h';
+process.env.PASSWORD_SALT_ROUNDS = '4';
+process.env.DB_CONNECTION = 'mongodb://example/test';
+
+const mockFind = jest.fn();
+const mockFindOne = jest.fn();
+const mockUpdateOne = jest.fn();
+const mockCollectionFind = jest.fn();
+const mockSave = jest.fn();
+
+class MockContentV3 {
+  constructor(data) {
+    Object.assign(this, data);
+  }
+
+  async save() {
+    return mockSave(this);
+  }
+}
+MockContentV3.find = mockFind;
+MockContentV3.findOne = mockFindOne;
+MockContentV3.updateOne = mockUpdateOne;
+MockContentV3.collection = {
+  find: mockCollectionFind,
+};
+
+jest.mock('../src/models/ContentV3.js', () => ({
+  ContentV3: MockContentV3,
+  TextContentSchema: {},
+}));
+
+jest.mock('agenda', () => {
+  return jest.fn().mockImplementation(() => ({
+    define: jest.fn(),
+    start: jest.fn().mockResolvedValue(undefined),
+    now: jest.fn().mockResolvedValue({ attrs: { _id: 'job-1' } }),
+    jobs: jest.fn().mockResolvedValue([]),
+  }));
+});
+
+jest.mock('../src/services/BlobService.js', () => {
+  return jest.fn().mockImplementation(() => ({
+    getUploadSASToken: jest.fn().mockResolvedValue('sas-token'),
+    getContainerClient: jest.fn().mockReturnValue({
+      getBlockBlobClient: jest.fn().mockReturnValue({ url: 'https://blob/url' }),
+      listBlobsFlat: jest.fn(),
+    }),
+    getURLWithSAS: jest.fn().mockResolvedValue('https://blob/url?sas'),
+  }));
+});
+
+jest.mock('../src/jobs/processAudioContent.js', () => jest.fn(async () => undefined));
+jest.mock('../src/jobs/processQuizContent.js', () => jest.fn(async () => undefined));
+
+const router = require('../src/routes/contentRouter');
+
+function mockRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.body = null;
+  res.status = function status(code) {
+    this.statusCode = code;
+    return this;
+  };
+  res.json = function json(payload) {
+    this.body = payload;
+    return this;
+  };
+  res.send = function send(payload) {
+    this.body = payload;
+    return this;
+  };
+  return res;
+}
+
+function makeFindChain(result) {
+  return {
+    sort: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(result),
+      }),
+    }),
+  };
+}
+
+function makeCollectionFindChain(result) {
+  return {
+    sort: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue(result),
+    }),
+  };
+}
+
+function getRouteHandlers(method, path) {
+  const layer = router.stack.find(
+    (entry) => entry.route && entry.route.path === path && entry.route.methods[method],
+  );
+  if (!layer) {
+    throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+  }
+  return layer.route.stack.map((stackEntry) => stackEntry.handle);
+}
+
+describe('contentRouter tenant scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFind.mockReturnValue(makeFindChain([]));
+    mockCollectionFind.mockReturnValue(makeCollectionFindChain([]));
+    mockFindOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+    mockUpdateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+    mockSave.mockImplementation(async (doc) => ({
+      ...doc,
+      _id: doc._id || 'content-1',
+      toObject: () => ({ ...doc, _id: doc._id || 'content-1' }),
+    }));
+  });
+
+  test('GET / uses tenantId in query', async () => {
+    const [handler] = getRouteHandlers('get', '/');
+    const req = {
+      tenantId: 'tenant-abc',
+      query: { limit: '5' },
+    };
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'tenant-abc', isDeleted: { $ne: true } }),
+    );
+  });
+
+  test('GET / with ids applies tenant filter', async () => {
+    const [handler] = getRouteHandlers('get', '/');
+    const req = {
+      tenantId: 'tenant-abc',
+      query: { ids: 'id-1,id-2' },
+    };
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(mockCollectionFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _id: { $in: ['id-1', 'id-2'] },
+        tenantId: 'tenant-abc',
+      }),
+    );
+  });
+
+  test('GET /:contentId queries by tenantId', async () => {
+    const [handler] = getRouteHandlers('get', '/:contentId');
+    mockFindOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({ _id: 'content-1', tenantId: 'tenant-abc' }),
+    });
+
+    const req = {
+      tenantId: 'tenant-abc',
+      params: { contentId: 'content-1' },
+    };
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'content-1', tenantId: 'tenant-abc' }),
+    );
+  });
+
+  test('DELETE /:contentId scopes delete by tenantId', async () => {
+    const [handler] = getRouteHandlers('delete', '/:contentId');
+    const req = {
+      tenantId: 'tenant-abc',
+      params: { contentId: 'content-1' },
+    };
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: 'content-1', tenantId: 'tenant-abc' },
+      { $set: { isDeleted: true } },
+    );
+  });
+
+  test('POST / sets tenantId from auth context', async () => {
+    const [handler] = getRouteHandlers('post', '/');
+    const req = {
+      tenantId: 'tenant-abc',
+      body: {
+        type: 'story',
+        language: 'en',
+        title: { english: 'Hello', local: '', audioUrl: '' },
+        theme: { english: 'Theme', local: '', audioUrl: '' },
+      },
+    };
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSave.mock.calls[0][0].tenantId).toBe('tenant-abc');
+  });
+});

--- a/backend-server/tests/contentRouterTenantScope.test.js
+++ b/backend-server/tests/contentRouterTenantScope.test.js
@@ -6,6 +6,7 @@ process.env.DB_CONNECTION = 'mongodb://example/test';
 
 const mockFind = jest.fn();
 const mockFindOne = jest.fn();
+const mockFindOneAndUpdate = jest.fn();
 const mockUpdateOne = jest.fn();
 const mockCollectionFind = jest.fn();
 const mockSave = jest.fn();
@@ -21,6 +22,7 @@ class MockContentV3 {
 }
 MockContentV3.find = mockFind;
 MockContentV3.findOne = mockFindOne;
+MockContentV3.findOneAndUpdate = mockFindOneAndUpdate;
 MockContentV3.updateOne = mockUpdateOne;
 MockContentV3.collection = {
   find: mockCollectionFind,
@@ -109,6 +111,7 @@ describe('contentRouter tenant scoping', () => {
     mockFind.mockReturnValue(makeFindChain([]));
     mockCollectionFind.mockReturnValue(makeCollectionFindChain([]));
     mockFindOne.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+    mockFindOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
     mockUpdateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
     mockSave.mockImplementation(async (doc) => ({
       ...doc,
@@ -206,5 +209,30 @@ describe('contentRouter tenant scoping', () => {
     expect(res.statusCode).toBe(200);
     expect(mockSave).toHaveBeenCalledTimes(1);
     expect(mockSave.mock.calls[0][0].tenantId).toBe('tenant-abc');
+  });
+
+  test('PATCH / scopes updates by tenantId and content id', async () => {
+    const [handler] = getRouteHandlers('patch', '/');
+    const updatedDoc = { _id: 'content-1', tenantId: 'tenant-abc', title: { english: 'Updated' } };
+    mockFindOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updatedDoc) });
+
+    const req = {
+      tenantId: 'tenant-abc',
+      query: { isAudioUploaded: 'true' },
+      body: {
+        _id: 'content-1',
+        title: { english: 'Updated', local: '', audioUrl: '' },
+      },
+    };
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'content-1', tenantId: 'tenant-abc', isDeleted: { $ne: true } },
+      { $set: expect.objectContaining({ isProcessed: false }) },
+      { new: true },
+    );
   });
 });


### PR DESCRIPTION
# NOTE: THIS PR IS DEPRECATED AND HAS BEEN ROLLED BACK
This PR introduces content creator authentication, enforces tenant-based content scoping, and strengthens data isolation across tenants.

## Key Changes

### Authentication
- Added content creator registration with `email`, `password`, `tenantId`, and `name`
- Implemented login for content creators
- JWT now includes `role` and `tenantId`
- Supports multiple creators per tenant

### Content Management
- Tenant-scoped content listing, detail, upload, and delete
- Ensured content visibility across creators within the same tenant
- Frontend wired for edit (`PATCH /content`), but backend route is currently missing

### Security
- Passwords hashed using bcrypt
- All content operations strictly scoped via `tenantId` from JWT
- Prevented cross-tenant access
- Restricted tenant analytics route to tenant role only