### PR TITLE
feat: include teacher name in teacher retrieval response

### DIFF
--- a/backend-server/src/routes/v1TeacherRouter.js
+++ b/backend-server/src/routes/v1TeacherRouter.js
@@ -96,7 +96,7 @@ router.get("/teachers", authenticateToken, async (req, res) => {
   if (!tenantId) return res.sendStatus(STATUS.BAD_REQUEST);
   console.log("Fetching teachers for tenantId:", tenantId);
   try {
-    const teachers = await Teacher.find({ tenantId }, "_id phoneNumber studentId").lean();
+    const teachers = await Teacher.find({ tenantId }, "_id name phoneNumber studentId").lean();
 
     if (!teachers || teachers.length === 0) return res.json([]);
 


### PR DESCRIPTION
This pull request makes a small but important change to the `/teachers` endpoint in the backend server. Now, when fetching teachers, the response will include the `name` field in addition to `_id`, `phoneNumber`, and `studentId`.

- The `name` field is now included in the list of fields returned for each teacher in the `/teachers` route (`v1TeacherRouter.js`).