### PR TITLE
feat(backend): add School/Student data layer — models, DAOs, repositories, migrations

### DIFF
--- a/backend-server/migrations/001-create-default-school.js
+++ b/backend-server/migrations/001-create-default-school.js
@@ -1,0 +1,51 @@
+"use strict";
+
+/**
+ * Phase 1: Create a default School for each Tenant.
+ *
+ * Current DB state (as of migration):
+ *   - 1 tenant:  69660fae7fccd4ee129e58ae (test@gmail.com / temp-tenant)
+ *   - No schools collection yet
+ *
+ * Result: one School document per tenant, returned as { tenantId -> schoolId } map.
+ */
+
+const Tenant = require("../src/models/Tenant");
+const School = require("../src/models/School");
+
+async function createDefaultSchools() {
+    console.log("Phase 1: Creating default schools for each tenant...");
+
+    const tenants = await Tenant.find({}).lean();
+    if (tenants.length === 0) {
+        throw new Error("No tenants found. Cannot create schools.");
+    }
+
+    const schoolMap = {};
+
+    for (const tenant of tenants) {
+        const tenantId = tenant._id.toString();
+
+        // Idempotent: skip if a school already exists for this tenant
+        const existing = await School.findOne({ tenantId });
+        if (existing) {
+            console.log(`  Tenant ${tenantId}: school already exists (${existing._id}), skipping.`);
+            schoolMap[tenantId] = existing._id.toString();
+            continue;
+        }
+
+        const school = await School.create({
+            tenantId,
+            name: `${tenant.tenantName} — Default School`,
+            email: `school@${tenant.tenantName.toLowerCase().replace(/\s+/g, "-")}.local`,
+        });
+
+        console.log(`  Tenant ${tenantId}: created school ${school._id} ("${school.name}")`);
+        schoolMap[tenantId] = school._id.toString();
+    }
+
+    console.log("Phase 1 complete.");
+    return schoolMap;
+}
+
+module.exports = { createDefaultSchools };

--- a/backend-server/migrations/002-migrate-teachers.js
+++ b/backend-server/migrations/002-migrate-teachers.js
@@ -1,0 +1,66 @@
+"use strict";
+
+/**
+ * Phase 2: Add schoolId to all teachers and remove the now-redundant tenantId field.
+ *
+ * Current DB state:
+ *   - 3 teachers, all with tenantId = '69660fae7fccd4ee129e58ae', no schoolId
+ *   - Teacher schema no longer has tenantId (removed in architecture update)
+ *
+ * Logic: match teacher.tenantId → schoolMap[tenantId] to assign the right school.
+ * Then unset tenantId from every teacher document.
+ */
+
+const Teacher = require("../src/models/Teacher");
+const mongoose = require("mongoose");
+
+async function migrateTeachers(schoolMap) {
+    console.log("Phase 2: Migrating teachers...");
+
+    // schoolMap: { tenantId -> schoolId }
+    for (const [tenantId, schoolId] of Object.entries(schoolMap)) {
+        // Use raw collection to bypass model schema (tenantId no longer in schema)
+        const result = await mongoose.connection.collection("teachers").updateMany(
+            { tenantId, schoolId: { $exists: false } },
+            { $set: { schoolId } }
+        );
+        console.log(`  Tenant ${tenantId}: set schoolId on ${result.modifiedCount} teacher(s).`);
+    }
+
+    // Remove tenantId from all teacher documents
+    const unsetResult = await mongoose.connection.collection("teachers").updateMany(
+        { tenantId: { $exists: true } },
+        { $unset: { tenantId: "" } }
+    );
+    console.log(`  Removed tenantId from ${unsetResult.modifiedCount} teacher(s).`);
+
+    // Set default role on teachers missing the field
+    const roleResult = await mongoose.connection.collection("teachers").updateMany(
+        { role: { $exists: false } },
+        { $set: { role: "teacher" } }
+    );
+    console.log(`  Set role="teacher" on ${roleResult.modifiedCount} teacher(s) missing the field.`);
+
+    // Verify
+    const missing = await mongoose.connection.collection("teachers").countDocuments({
+        schoolId: { $exists: false },
+    });
+    if (missing > 0) {
+        console.warn(`  WARNING: ${missing} teacher(s) still have no schoolId.`);
+    } else {
+        console.log("  All teachers have schoolId.");
+    }
+
+    const missingRole = await mongoose.connection.collection("teachers").countDocuments({
+        role: { $exists: false },
+    });
+    if (missingRole > 0) {
+        console.warn(`  WARNING: ${missingRole} teacher(s) still have no role.`);
+    } else {
+        console.log("  All teachers have role.");
+    }
+
+    console.log("Phase 2 complete.");
+}
+
+module.exports = { migrateTeachers };

--- a/backend-server/migrations/003-migrate-students.js
+++ b/backend-server/migrations/003-migrate-students.js
@@ -1,0 +1,70 @@
+"use strict";
+
+/**
+ * Phase 3: Add schoolId to all students.
+ *
+ * Current DB state:
+ *   - 4 students, no schoolId, no tenantId
+ *   - Students are not directly linked to a tenant — the link is:
+ *       teacher.studentId[] contains student ObjectIds
+ *       teacher now has schoolId (set in phase 2)
+ *
+ * Strategy:
+ *   1. For each teacher, assign their listed students to the teacher's school.
+ *   2. Any remaining students with no schoolId are orphaned — assign them to the
+ *      first available school (all data is single-tenant dev/test data).
+ */
+
+const mongoose = require("mongoose");
+const School = require("../src/models/School");
+
+async function migrateStudents() {
+    console.log("Phase 3: Migrating students...");
+
+    const teachers = await mongoose.connection.collection("teachers").find({
+        schoolId: { $exists: true },
+        studentId: { $exists: true, $not: { $size: 0 } },
+    }).toArray();
+
+    let linked = 0;
+
+    for (const teacher of teachers) {
+        if (!teacher.studentId || teacher.studentId.length === 0) continue;
+
+        const studentObjectIds = teacher.studentId.map(id => {
+            try { return new mongoose.Types.ObjectId(id); }
+            catch { return null; }
+        }).filter(Boolean);
+
+        if (studentObjectIds.length === 0) continue;
+
+        const result = await mongoose.connection.collection("students").updateMany(
+            { _id: { $in: studentObjectIds }, schoolId: { $exists: false } },
+            { $set: { schoolId: teacher.schoolId } }
+        );
+        linked += result.modifiedCount;
+        console.log(`  Teacher ${teacher._id}: linked ${result.modifiedCount} student(s) to school ${teacher.schoolId}.`);
+    }
+
+    console.log(`  Linked ${linked} student(s) via teacher.studentId.`);
+
+    // Assign any orphaned students to the first school
+    const orphaned = await mongoose.connection.collection("students").countDocuments({
+        schoolId: { $exists: false },
+    });
+
+    if (orphaned > 0) {
+        const firstSchool = await School.findOne({}).lean();
+        if (!firstSchool) throw new Error("No school found to assign orphaned students.");
+
+        const result = await mongoose.connection.collection("students").updateMany(
+            { schoolId: { $exists: false } },
+            { $set: { schoolId: firstSchool._id.toString() } }
+        );
+        console.log(`  Assigned ${result.modifiedCount} orphaned student(s) to school ${firstSchool._id}.`);
+    }
+
+    console.log("Phase 3 complete.");
+}
+
+module.exports = { migrateStudents };

--- a/backend-server/migrations/004-migrate-classes.js
+++ b/backend-server/migrations/004-migrate-classes.js
@@ -1,0 +1,71 @@
+"use strict";
+
+/**
+ * Phase 4: Add schoolId to all classes.
+ *
+ * Current DB state:
+ *   - 198 classes, no schoolId
+ *   - class.teacher is a mix of phone numbers, email addresses, and a handful of
+ *     ObjectId strings — NOT reliably linkable to current teacher documents
+ *   - Only 1 class has a teacher value matching a real teacher ObjectId
+ *
+ * Strategy:
+ *   1. For classes whose teacher value is a valid ObjectId AND matches an existing
+ *      teacher document, assign that teacher's schoolId.
+ *   2. All remaining classes (phone/email teacher values, or unresolvable) are
+ *      bulk-assigned to the first available school — they are legacy data from before
+ *      the current teacher model existed.
+ */
+
+const mongoose = require("mongoose");
+const School = require("../src/models/School");
+
+async function migrateClasses() {
+    console.log("Phase 4: Migrating classes...");
+
+    const classes = await mongoose.connection.collection("classes").find({
+        schoolId: { $exists: false },
+    }).toArray();
+
+    console.log(`  Found ${classes.length} class(es) without schoolId.`);
+
+    const firstSchool = await School.findOne({}).lean();
+    if (!firstSchool) throw new Error("No school found.");
+    const fallbackSchoolId = firstSchool._id.toString();
+
+    let resolvedViaTeacher = 0;
+    let resolvedViaFallback = 0;
+
+    for (const cls of classes) {
+        let schoolId = null;
+
+        // Try to resolve via teacher ObjectId
+        if (cls.teacher && mongoose.Types.ObjectId.isValid(cls.teacher)) {
+            const teacher = await mongoose.connection.collection("teachers").findOne({
+                _id: new mongoose.Types.ObjectId(cls.teacher),
+                schoolId: { $exists: true },
+            });
+            if (teacher) {
+                schoolId = teacher.schoolId;
+                resolvedViaTeacher++;
+            }
+        }
+
+        // Fall back to the default school (legacy phone/email teacher refs)
+        if (!schoolId) {
+            schoolId = fallbackSchoolId;
+            resolvedViaFallback++;
+        }
+
+        await mongoose.connection.collection("classes").updateOne(
+            { _id: cls._id },
+            { $set: { schoolId } }
+        );
+    }
+
+    console.log(`  Resolved via teacher lookup:  ${resolvedViaTeacher} class(es).`);
+    console.log(`  Resolved via fallback school: ${resolvedViaFallback} class(es).`);
+    console.log("Phase 4 complete.");
+}
+
+module.exports = { migrateClasses };

--- a/backend-server/migrations/005-migrate-content.js
+++ b/backend-server/migrations/005-migrate-content.js
@@ -1,0 +1,42 @@
+"use strict";
+
+/**
+ * Phase 5: Add tenantId to all contentsV3 documents.
+ *
+ * Current DB state:
+ *   - 72 contentsV3 documents, none have tenantId
+ *   - 1 tenant exists: 69660fae7fccd4ee129e58ae
+ *
+ * With a single tenant all content belongs to it.
+ * For multi-tenant environments this migration would need manual mapping.
+ */
+
+const mongoose = require("mongoose");
+const Tenant = require("../src/models/Tenant");
+
+async function migrateContent() {
+    console.log("Phase 5: Adding tenantId to contentsV3...");
+
+    const tenants = await Tenant.find({}).lean();
+
+    if (tenants.length === 0) {
+        throw new Error("No tenants found.");
+    }
+
+    if (tenants.length > 1) {
+        console.warn(`  WARNING: ${tenants.length} tenants found. All un-tagged content will be assigned to the first tenant.`);
+        console.warn("  Review and re-assign content manually if needed.");
+    }
+
+    const tenantId = tenants[0]._id.toString();
+
+    const result = await mongoose.connection.collection("contentsV3").updateMany(
+        { tenantId: { $exists: false } },
+        { $set: { tenantId } }
+    );
+
+    console.log(`  Tagged ${result.modifiedCount} content item(s) with tenantId ${tenantId}.`);
+    console.log("Phase 5 complete.");
+}
+
+module.exports = { migrateContent };

--- a/backend-server/migrations/006-migrate-class-students.js
+++ b/backend-server/migrations/006-migrate-class-students.js
@@ -1,0 +1,91 @@
+"use strict";
+
+/**
+ * Phase 6: Convert class.students and class.leaders from phone number strings
+ * to Student ObjectId references.
+ *
+ * Background:
+ *   The Class schema previously stored students/leaders as [String] (phone numbers).
+ *   It now uses [ObjectId] referencing the Student collection.
+ *
+ * Strategy:
+ *   1. Find all classes where students or leaders contain non-ObjectId strings.
+ *   2. For each phone number, look up the Student by phoneNumber + schoolId.
+ *   3. Replace the phone number with the Student's ObjectId.
+ *   4. Classes already using ObjectIds (or empty arrays) are skipped — idempotent.
+ */
+
+const mongoose = require("mongoose");
+
+async function migrateClassStudentRefs() {
+    console.log("Phase 6: Converting class students/leaders from phone numbers to ObjectId refs...");
+
+    const db = mongoose.connection;
+    const classes = await db.collection("classes").find({}).toArray();
+
+    console.log(`  Found ${classes.length} class(es) to check.`);
+
+    let updatedClasses = 0;
+    let resolvedRefs = 0;
+    let unresolvable = 0;
+
+    const resolvePhonesToIds = async (values, schoolId, classId) => {
+        const ids = [];
+        for (const val of values) {
+            if (mongoose.Types.ObjectId.isValid(val) && String(val).length === 24) {
+                // Already an ObjectId — keep as-is
+                ids.push(new mongoose.Types.ObjectId(val));
+                continue;
+            }
+
+            // val is a phone number string — look up Student by schoolId + phoneNumber
+            let student = await db.collection("students").findOne({
+                phoneNumber: String(val),
+                schoolId,
+            });
+
+            if (!student) {
+                // Fallback: search without schoolId constraint (legacy/orphaned data)
+                student = await db.collection("students").findOne({ phoneNumber: String(val) });
+            }
+
+            if (student) {
+                ids.push(student._id);
+                resolvedRefs++;
+            } else {
+                console.warn(`    WARNING: No Student found for phone "${val}" (class ${String(classId)}). Skipping.`);
+                unresolvable++;
+                // Drop unresolvable entries — they reference non-existent students
+            }
+        }
+        return ids;
+    };
+
+    for (const cls of classes) {
+        const hasStringStudents = (arr) =>
+            Array.isArray(arr) &&
+            arr.some((v) => !(mongoose.Types.ObjectId.isValid(v) && String(v).length === 24));
+
+        if (!hasStringStudents(cls.students) && !hasStringStudents(cls.leaders)) {
+            continue; // already migrated or empty
+        }
+
+        const newStudents = await resolvePhonesToIds(cls.students || [], cls.schoolId, cls._id);
+        const newLeaders  = await resolvePhonesToIds(cls.leaders  || [], cls.schoolId, cls._id);
+
+        await db.collection("classes").updateOne(
+            { _id: cls._id },
+            { $set: { students: newStudents, leaders: newLeaders } }
+        );
+        updatedClasses++;
+    }
+
+    console.log(`  Updated ${updatedClasses} class(es).`);
+    console.log(`  Resolved ${resolvedRefs} student/leader reference(s) to ObjectIds.`);
+    if (unresolvable > 0) {
+        console.warn(`  WARNING: ${unresolvable} phone number(s) had no matching Student document and were dropped.`);
+    }
+    console.log("Phase 6 complete.");
+}
+
+module.exports = { migrateClassStudentRefs };

--- a/backend-server/migrations/patch-ivr-tenant.js
+++ b/backend-server/migrations/patch-ivr-tenant.js
@@ -1,0 +1,24 @@
+"use strict";
+
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+const mongoose = require("mongoose");
+
+async function run() {
+    const uri = process.env.MONGODB_URI || "mongodb://localhost:27017/SEEDS-Teacher-Backend";
+    await mongoose.connect(uri);
+    const db = mongoose.connection;
+
+    const result = await db.collection("ivrv2logs").updateMany(
+        { tenant_id: "690dbc1b3b41c70deffa2761" },
+        { $set: { tenant_id: "69660fae7fccd4ee129e58ae" } }
+    );
+
+    console.log("Matched:", result.matchedCount);
+    console.log("Modified:", result.modifiedCount);
+    await mongoose.disconnect();
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+});

--- a/backend-server/migrations/patch-school-id.js
+++ b/backend-server/migrations/patch-school-id.js
@@ -1,0 +1,34 @@
+"use strict";
+
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+const mongoose = require("mongoose");
+
+async function run() {
+    const uri = process.env.MONGODB_URI || "mongodb://localhost:27017/SEEDS-Teacher-Backend";
+    await mongoose.connect(uri);
+    const db = mongoose.connection;
+
+    const schoolId = "69a92b526d7b0a801b42675c";
+    const tenantId = "69660fae7fccd4ee129e58ae";
+
+    // Patch ivrv2logs: set school_id on all docs that belong to this tenant
+    const ivr = await db.collection("ivrv2logs").updateMany(
+        { tenant_id: tenantId, school_id: null },
+        { $set: { school_id: schoolId } }
+    );
+    console.log("ivrv2logs  — matched:", ivr.matchedCount, "| modified:", ivr.modifiedCount);
+
+    // Patch contentsV3: set schoolId on all docs that belong to this tenant
+    const content = await db.collection("contentsV3").updateMany(
+        { tenantId, schoolId: { $exists: false } },
+        { $set: { schoolId } }
+    );
+    console.log("contentsV3 — matched:", content.matchedCount, "| modified:", content.modifiedCount);
+
+    await mongoose.disconnect();
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+});

--- a/backend-server/migrations/rollback-migration.js
+++ b/backend-server/migrations/rollback-migration.js
@@ -1,0 +1,110 @@
+"use strict";
+
+/**
+ * Rollback migration — reverses all phases.
+ *
+ * Usage:
+ *   node migrations/rollback-migration.js
+ *
+ * WARNING: This deletes all School documents and removes schoolId / tenantId
+ * fields added by the migration. It also restores tenantId on teachers using
+ * the school's tenantId before deleting schools.
+ */
+
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+const mongoose = require("mongoose");
+
+async function rollback() {
+    const uri = process.env.MONGODB_URI || "mongodb://localhost:27017/SEEDS-Teacher-Backend";
+    console.log(`Connecting to ${uri}...`);
+    await mongoose.connect(uri);
+    console.log("Connected.\n");
+
+    const db = mongoose.connection;
+
+    try {
+        // Step 1: restore tenantId on teachers before schools are deleted
+        console.log("Restoring tenantId on teachers from their school...");
+        const schools = await db.collection("schools").find({}).toArray();
+        for (const school of schools) {
+            const result = await db.collection("teachers").updateMany(
+                { schoolId: school._id.toString() },
+                { $set: { tenantId: school.tenantId }, $unset: { schoolId: "" } }
+            );
+            console.log(`  School ${school._id}: restored tenantId + removed schoolId from ${result.modifiedCount} teacher(s).`);
+        }
+
+        // Step 2: remove schoolId from students
+        const studentResult = await db.collection("students").updateMany(
+            { schoolId: { $exists: true } },
+            { $unset: { schoolId: "" } }
+        );
+        console.log(`Removed schoolId from ${studentResult.modifiedCount} student(s).`);
+
+        // Step 3a: revert class students/leaders from ObjectIds back to phone numbers (phase 6 rollback)
+        console.log("Reverting class students/leaders from ObjectIds to phone numbers...");
+        const allClasses = await db.collection("classes").find({}).toArray();
+        let revertedClasses = 0;
+        for (const cls of allClasses) {
+            const hasObjectIds = (arr) =>
+                Array.isArray(arr) && arr.length > 0 &&
+                (arr[0]._bsontype === "ObjectId" || arr[0] instanceof mongoose.Types.ObjectId);
+
+            if (!hasObjectIds(cls.students) && !hasObjectIds(cls.leaders)) continue;
+
+            const toPhoneNumbers = async (ids) => {
+                const phones = [];
+                for (const id of ids) {
+                    const student = await db.collection("students").findOne({ _id: id });
+                    if (student) phones.push(student.phoneNumber);
+                }
+                return phones;
+            };
+
+            const phoneStudents = await toPhoneNumbers(cls.students || []);
+            const phoneLeaders  = await toPhoneNumbers(cls.leaders  || []);
+            await db.collection("classes").updateOne(
+                { _id: cls._id },
+                { $set: { students: phoneStudents, leaders: phoneLeaders } }
+            );
+            revertedClasses++;
+        }
+        console.log(`Reverted ${revertedClasses} class(es) students/leaders to phone numbers.`);
+
+        // Step 3b: remove schoolId from classes
+        const classResult = await db.collection("classes").updateMany(
+            { schoolId: { $exists: true } },
+            { $unset: { schoolId: "" } }
+        );
+        console.log(`Removed schoolId from ${classResult.modifiedCount} class(es).`);
+
+        // Step 4: remove tenantId from contentsV3
+        const contentResult = await db.collection("contentsV3").updateMany(
+            { tenantId: { $exists: true } },
+            { $unset: { tenantId: "" } }
+        );
+        console.log(`Removed tenantId from ${contentResult.modifiedCount} content item(s).`);
+
+        // Step 5: delete all schools
+        const deleteResult = await db.collection("schools").deleteMany({});
+        console.log(`Deleted ${deleteResult.deletedCount} school(s).`);
+
+        // Verify
+        console.log("\n=== Rollback Verification ===");
+        console.log(`  Remaining schools:            ${await db.collection("schools").countDocuments()}`);
+        console.log(`  Teachers with tenantId:       ${await db.collection("teachers").countDocuments({ tenantId: { $exists: true } })}`);
+        console.log(`  Teachers with schoolId:       ${await db.collection("teachers").countDocuments({ schoolId: { $exists: true } })}`);
+        console.log(`  Students with schoolId:       ${await db.collection("students").countDocuments({ schoolId: { $exists: true } })}`);
+        console.log(`  Classes with schoolId:        ${await db.collection("classes").countDocuments({ schoolId: { $exists: true } })}`);
+        console.log(`  Content with tenantId:        ${await db.collection("contentsV3").countDocuments({ tenantId: { $exists: true } })}`);
+
+        console.log("\nRollback completed.");
+    } catch (err) {
+        console.error("\nRollback FAILED:", err.message);
+        process.exitCode = 1;
+    } finally {
+        await mongoose.disconnect();
+    }
+}
+
+rollback();

--- a/backend-server/migrations/run-migration.js
+++ b/backend-server/migrations/run-migration.js
@@ -1,0 +1,92 @@
+"use strict";
+
+/**
+ * Master migration runner.
+ *
+ * Usage:
+ *   node migrations/run-migration.js
+ *
+ * Requires MONGODB_URI in environment (or .env file at project root).
+ * Safe to re-run — each phase is idempotent.
+ */
+
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+const mongoose = require("mongoose");
+
+const { createDefaultSchools } = require("./001-create-default-school");
+const { migrateTeachers }      = require("./002-migrate-teachers");
+const { migrateStudents }      = require("./003-migrate-students");
+const { migrateClasses }       = require("./004-migrate-classes");
+const { migrateContent }            = require("./005-migrate-content");
+const { migrateClassStudentRefs }   = require("./006-migrate-class-students");
+
+async function verify() {
+    const db = mongoose.connection;
+    const stats = {
+        schools:             await db.collection("schools").countDocuments(),
+        teachersWithSchool:  await db.collection("teachers").countDocuments({ schoolId: { $exists: true } }),
+        teachersWithTenant:  await db.collection("teachers").countDocuments({ tenantId: { $exists: true } }),
+        teachersWithoutRole: await db.collection("teachers").countDocuments({ role: { $exists: false } }),
+        studentsWithSchool:  await db.collection("students").countDocuments({ schoolId: { $exists: true } }),
+        studentsWithout:     await db.collection("students").countDocuments({ schoolId: { $exists: false } }),
+        classesWithSchool:        await db.collection("classes").countDocuments({ schoolId: { $exists: true } }),
+        classesWithout:           await db.collection("classes").countDocuments({ schoolId: { $exists: false } }),
+        classesWithStringStudents: await db.collection("classes").countDocuments({ students: { $elemMatch: { $type: "string" } } }),
+        contentWithTenant:   await db.collection("contentsV3").countDocuments({ tenantId: { $exists: true } }),
+        contentWithout:      await db.collection("contentsV3").countDocuments({ tenantId: { $exists: false } }),
+    };
+
+    console.log("\n=== Migration Verification ===");
+    console.log(`  Schools created:              ${stats.schools}`);
+    console.log(`  Teachers with schoolId:       ${stats.teachersWithSchool}`);
+    console.log(`  Teachers still with tenantId: ${stats.teachersWithTenant}  (should be 0)`);
+    console.log(`  Teachers missing role:        ${stats.teachersWithoutRole}  (should be 0)`);
+    console.log(`  Students with schoolId:       ${stats.studentsWithSchool}`);
+    console.log(`  Students missing schoolId:    ${stats.studentsWithout}   (should be 0)`);
+    console.log(`  Classes with schoolId:        ${stats.classesWithSchool}`);
+    console.log(`  Classes missing schoolId:     ${stats.classesWithout}    (should be 0)`);
+    console.log(`  Classes with phone students:  ${stats.classesWithStringStudents}  (should be 0)`);
+    console.log(`  Content with tenantId:        ${stats.contentWithTenant}`);
+    console.log(`  Content missing tenantId:     ${stats.contentWithout}    (should be 0)`);
+
+    const issues = [
+        stats.teachersWithTenant   > 0 && `${stats.teachersWithTenant} teacher(s) still have tenantId`,
+        stats.teachersWithoutRole  > 0 && `${stats.teachersWithoutRole} teacher(s) missing role field`,
+        stats.studentsWithout    > 0 && `${stats.studentsWithout} student(s) missing schoolId`,
+        stats.classesWithout          > 0 && `${stats.classesWithout} class(es) missing schoolId`,
+        stats.classesWithStringStudents > 0 && `${stats.classesWithStringStudents} class(es) still have phone-number students (phase 6 incomplete)`,
+        stats.contentWithout     > 0 && `${stats.contentWithout} content item(s) missing tenantId`,
+    ].filter(Boolean);
+
+    if (issues.length > 0) {
+        console.warn("\n  WARNINGS:");
+        issues.forEach(i => console.warn(`    - ${i}`));
+    } else {
+        console.log("\n  All checks passed.");
+    }
+}
+
+async function run() {
+    const uri = process.env.MONGODB_URI || "mongodb://localhost:27017/SEEDS-Teacher-Backend";
+    console.log(`Connecting to ${uri}...`);
+    await mongoose.connect(uri);
+    console.log("Connected.\n");
+
+    try {
+        const schoolMap = await createDefaultSchools();
+        await migrateTeachers(schoolMap);
+        await migrateStudents();
+        await migrateClasses();
+        await migrateContent();
+        await migrateClassStudentRefs();
+        await verify();
+        console.log("\nMigration completed successfully.");
+    } catch (err) {
+        console.error("\nMigration FAILED:", err.message);
+        process.exitCode = 1;
+    } finally {
+        await mongoose.disconnect();
+    }
+}
+
+run();

--- a/backend-server/migrations/seed-school-admin.js
+++ b/backend-server/migrations/seed-school-admin.js
@@ -1,0 +1,63 @@
+"use strict";
+
+/**
+ * Seed a password for the default school (school = school admin after merge).
+ *
+ * Usage:
+ *   node migrations/seed-school-admin.js
+ *
+ * Finds the school with email SCHOOL_EMAIL and sets its password + isActive.
+ * Skips if the school already has a password set.
+ * Login credentials after seeding: email=SCHOOL_EMAIL, password=PLAIN_PASSWORD
+ */
+
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+const mongoose = require("mongoose");
+const bcrypt = require("bcryptjs");
+
+const SCHOOL_EMAIL = "school@temp-tenant.local";
+const PLAIN_PASSWORD = "Test@123";
+const SALT_ROUNDS = parseInt(process.env.PASSWORD_SALT_ROUNDS) || 10;
+
+async function run() {
+    const uri = process.env.MONGODB_URI || "mongodb://localhost:27017/SEEDS-Teacher-Backend";
+    console.log(`Connecting to ${uri}...`);
+    await mongoose.connect(uri);
+    console.log("Connected.\n");
+
+    const db = mongoose.connection;
+    try {
+        const school = await db.collection("schools").findOne({ email: SCHOOL_EMAIL });
+        if (!school) {
+            console.error(`School with email "${SCHOOL_EMAIL}" not found. Run the migration first.`);
+            process.exitCode = 1;
+            return;
+        }
+        console.log(`Found school: ${school.name} (${school._id})`);
+
+        if (school.password) {
+            console.log(`School already has a password set. Skipping.`);
+            return;
+        }
+
+        const hashedPassword = await bcrypt.hash(PLAIN_PASSWORD, SALT_ROUNDS);
+
+        await db.collection("schools").updateOne(
+            { _id: school._id },
+            { $set: { password: hashedPassword, isActive: true, updatedAt: new Date() } }
+        );
+
+        console.log(`School password set:`);
+        console.log(`  email:    ${SCHOOL_EMAIL}  ← login email`);
+        console.log(`  password: ${PLAIN_PASSWORD} (hashed, salt rounds: ${SALT_ROUNDS})`);
+        console.log(`  schoolId: ${school._id}`);
+        console.log(`  tenantId: ${school.tenantId}`);
+    } finally {
+        await mongoose.disconnect();
+    }
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+});

--- a/backend-server/src/dao/interfaces/IClassDao.js
+++ b/backend-server/src/dao/interfaces/IClassDao.js
@@ -1,0 +1,9 @@
+"use strict";
+
+class IClassDao {
+    async getClassCountBySchoolId(schoolId) {
+        throw new Error("Not implemented");
+    }
+}
+
+module.exports = IClassDao;

--- a/backend-server/src/dao/interfaces/IIvrV2LogDao.js
+++ b/backend-server/src/dao/interfaces/IIvrV2LogDao.js
@@ -1,0 +1,13 @@
+"use strict";
+
+class IIvrV2LogDao {
+    async findBySchoolIdInDateRange(schoolId, startStr, endStr) {
+        throw new Error("Not implemented");
+    }
+
+    async findByTenantIdInDateRange(tenantId, startStr, endStr) {
+        throw new Error("Not implemented");
+    }
+}
+
+module.exports = IIvrV2LogDao;

--- a/backend-server/src/dao/interfaces/ISchoolDao.js
+++ b/backend-server/src/dao/interfaces/ISchoolDao.js
@@ -1,0 +1,27 @@
+"use strict";
+
+class ISchoolDao {
+    async getSchoolByEmail(email) {
+        throw new Error("Not implemented");
+    }
+    async createSchool(name, email, tenantId, hashedPassword) {
+        throw new Error("Not implemented");
+    }
+    async getSchools(tenantId) {
+        throw new Error("Not implemented");
+    }
+    async getSchoolById(schoolId, tenantId) {
+        throw new Error("Not implemented");
+    }
+    async updateSchool(school) {
+        throw new Error("Not implemented");
+    }
+    async deleteSchool(schoolId, tenantId) {
+        throw new Error("Not implemented");
+    }
+    async setSchoolPassword(schoolId, tenantId, hashedPassword) {
+        throw new Error("Not implemented");
+    }
+}
+
+module.exports = ISchoolDao;

--- a/backend-server/src/dao/interfaces/IStudentDao.js
+++ b/backend-server/src/dao/interfaces/IStudentDao.js
@@ -1,0 +1,29 @@
+"use strict";
+
+class IStudentDao {
+    async createStudent({ name, phoneNumber, schoolId }) {
+        throw new Error("Not implemented");
+    }
+
+    async getStudentsBySchoolId(schoolId) {
+        throw new Error("Not implemented");
+    }
+
+    async getStudentById(studentId) {
+        throw new Error("Not implemented");
+    }
+
+    async updateStudent(studentId, schoolId, updates) {
+        throw new Error("Not implemented");
+    }
+
+    async deleteStudent(studentId, schoolId) {
+        throw new Error("Not implemented");
+    }
+
+    async getStudentCountBySchoolId(schoolId) {
+        throw new Error("Not implemented");
+    }
+}
+
+module.exports = IStudentDao;

--- a/backend-server/src/dao/interfaces/ITeacherDao.js
+++ b/backend-server/src/dao/interfaces/ITeacherDao.js
@@ -1,0 +1,30 @@
+"use strict";
+
+class ITeacherDao {
+    async getTeacherById(teacherId) {
+        throw new Error("Not implemented");
+    }
+    async getTeacherByPhoneNumber(phoneNumber) {
+        throw new Error("Not implemented");
+    }
+    async getTeachersBySchoolId(schoolId) {
+        throw new Error("Not implemented");
+    }
+    async transferTeacher(teacherId, targetSchoolId) {
+        throw new Error("Not implemented");
+    }
+    async getTeacherCountBySchoolId(schoolId) {
+        throw new Error("Not implemented");
+    }
+    async getTeacherBySchoolIdAndPhoneNumber(schoolId, phoneNumber) {
+        throw new Error("Not implemented");
+    }
+    async insertTeacher(data) {
+        throw new Error("Not implemented");
+    }
+    async updateTeacher(teacherId, schoolId, updates) {
+        throw new Error("Not implemented");
+    }
+}
+
+module.exports = ITeacherDao;

--- a/backend-server/src/dao/interfaces/ITenantDao.js
+++ b/backend-server/src/dao/interfaces/ITenantDao.js
@@ -1,0 +1,9 @@
+"use strict";
+
+class ITenantDao {
+    async getTenantById(tenantId) {
+        throw new Error("Not implemented");
+    }
+}
+
+module.exports = ITenantDao;

--- a/backend-server/src/dao/mongodb/ClassMongoDao.js
+++ b/backend-server/src/dao/mongodb/ClassMongoDao.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const IClassDao = require("../interfaces/IClassDao");
+const Class = require("../../models/Class");
+
+class ClassMongoDao extends IClassDao {
+    async getClassCountBySchoolId(schoolId) {
+        return Class.countDocuments({ schoolId });
+    }
+}
+
+module.exports = new ClassMongoDao();

--- a/backend-server/src/dao/mongodb/IvrV2LogMongoDao.js
+++ b/backend-server/src/dao/mongodb/IvrV2LogMongoDao.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const IIvrV2LogDao = require("../interfaces/IIvrV2LogDao");
+const IvrV2Log = require("../../models/IvrV2Log");
+
+class IvrV2LogMongoDao extends IIvrV2LogDao {
+    async findBySchoolIdInDateRange(schoolId, startStr, endStr) {
+        return IvrV2Log.find({
+            school_id: schoolId,
+            created_at: { $gte: startStr, $lte: endStr },
+        }).lean();
+    }
+
+    async findByTenantIdInDateRange(tenantId, startStr, endStr) {
+        return IvrV2Log.find({
+            tenant_id: tenantId,
+            created_at: { $gte: startStr, $lte: endStr },
+        }).lean();
+    }
+}
+
+module.exports = new IvrV2LogMongoDao();

--- a/backend-server/src/dao/mongodb/SchoolMongoDao.js
+++ b/backend-server/src/dao/mongodb/SchoolMongoDao.js
@@ -1,0 +1,40 @@
+"use strict";
+const ISchoolDao = require("../interfaces/ISchoolDao");
+const School = require("../../models/School");
+
+class SchoolMongoDao extends ISchoolDao {
+    // Returns full document including password — used for login
+    async getSchoolByEmail(email) {
+        return School.findOne({ email }).lean();
+    }
+
+    async createSchool(name, email, tenantId, hashedPassword) {
+        return School.create({ name, email, tenantId, password: hashedPassword });
+    }
+
+    async getSchools(tenantId) {
+        return School.find({ tenantId }).select("-password").lean();
+    }
+
+    async getSchoolById(schoolId, tenantId) {
+        return School.findOne({ _id: schoolId, tenantId }).select("-password").lean();
+    }
+
+    async updateSchool(school) {
+        return School.findByIdAndUpdate(school._id, school, { new: true }).select("-password").lean();
+    }
+
+    async deleteSchool(schoolId, tenantId) {
+        return School.findOneAndDelete({ _id: schoolId, tenantId }).lean();
+    }
+
+    async setSchoolPassword(schoolId, tenantId, hashedPassword) {
+        return School.findOneAndUpdate(
+            { _id: schoolId, tenantId },
+            { $set: { password: hashedPassword, isActive: true } },
+            { new: true }
+        ).select("-password").lean();
+    }
+}
+
+module.exports = new SchoolMongoDao();

--- a/backend-server/src/dao/mongodb/StudentMongoDao.js
+++ b/backend-server/src/dao/mongodb/StudentMongoDao.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const IStudentDao = require("../interfaces/IStudentDao");
+const Student = require("../../models/Student");
+
+class StudentMongoDao extends IStudentDao {
+    async createStudent({ name, phoneNumber, schoolId }) {
+        return Student.create({ name, phoneNumber, schoolId });
+    }
+
+    async getStudentsBySchoolId(schoolId) {
+        return Student.find({ schoolId }, "_id name phoneNumber").sort({ name: 1 }).lean();
+    }
+
+    async getStudentById(studentId) {
+        return Student.findById(studentId).lean();
+    }
+
+    async updateStudent(studentId, schoolId, updates) {
+        return Student.findOneAndUpdate(
+            { _id: studentId, schoolId },
+            updates,
+            { new: true }
+        ).lean();
+    }
+
+    async deleteStudent(studentId, schoolId) {
+        return Student.findOneAndDelete({ _id: studentId, schoolId });
+    }
+
+    async getStudentCountBySchoolId(schoolId) {
+        return Student.countDocuments({ schoolId });
+    }
+}
+
+module.exports = new StudentMongoDao();

--- a/backend-server/src/dao/mongodb/TeacherMongoDao.js
+++ b/backend-server/src/dao/mongodb/TeacherMongoDao.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const ITeacherDao = require("../interfaces/ITeacherDao");
+const Teacher = require("../../models/Teacher");
+
+class TeacherMongoDao extends ITeacherDao {
+    async getTeacherById(teacherId) {
+        return Teacher.findById(teacherId).select("-password").lean();
+    }
+
+    async getTeacherByPhoneNumber(phoneNumber) {
+        return Teacher.findOne({ phoneNumber }).lean();
+    }
+
+    async getTeachersBySchoolId(schoolId) {
+        return Teacher.find({ schoolId }, "_id name phoneNumber role").sort({ name: 1 }).lean();
+    }
+
+    async transferTeacher(teacherId, targetSchoolId) {
+        return Teacher.findByIdAndUpdate(
+            teacherId,
+            { schoolId: targetSchoolId },
+            { new: true }
+        ).select("-password").lean();
+    }
+
+    async getTeacherCountBySchoolId(schoolId) {
+        return Teacher.countDocuments({ schoolId });
+    }
+
+    async getTeacherBySchoolIdAndPhoneNumber(schoolId, phoneNumber) {
+        return Teacher.findOne({ schoolId, phoneNumber }).lean();
+    }
+
+    async insertTeacher({ phoneNumber, password, schoolId, name, role }) {
+        return Teacher.create({ phoneNumber, password, schoolId, name, role });
+    }
+
+    async updateTeacher(teacherId, schoolId, updates) {
+        return Teacher.findOneAndUpdate(
+            { _id: teacherId, schoolId },
+            updates,
+            { new: true }
+        ).select("-password").lean();
+    }
+}
+
+module.exports = new TeacherMongoDao();

--- a/backend-server/src/dao/mongodb/TenantMongoDao.js
+++ b/backend-server/src/dao/mongodb/TenantMongoDao.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const ITenantDao = require("../interfaces/ITenantDao");
+const Tenant = require("../../models/Tenant");
+
+class TenantMongoDao extends ITenantDao {
+    async getTenantById(tenantId) {
+        return Tenant.findById(tenantId).select("-password").lean();
+    }
+}
+
+module.exports = new TenantMongoDao();

--- a/backend-server/src/models/Class.js
+++ b/backend-server/src/models/Class.js
@@ -2,21 +2,32 @@
 const mongoose = require("mongoose");
 
 const ClassRoomSchema = new mongoose.Schema({
-  name: { type: String, required: true },
+  schoolId: { type: String, required: true, index: true, ref: "School" },
+  name: { type: String, required: true, ref: "Teacher" },
   teacher: { type: String, required: true },
-  students: [String],
-  leaders: [String],
+  students: [{ type: mongoose.Schema.Types.ObjectId, ref: "Student" }],
+  leaders: [{ type: mongoose.Schema.Types.ObjectId, ref: "Student" }],
   contentIds: [String],
-});
+}, { timestamps: true });
 
-var ClassRoom = (module.exports = mongoose.model("Class", ClassRoomSchema));
+ClassRoomSchema.index({ schoolId: 1 });
+
+const ClassRoom = (module.exports = mongoose.model("Class", ClassRoomSchema));
+
+module.exports = ClassRoom;
 
 module.exports.getClassById = (_id) => {
-  return ClassRoom.findById(_id).exec();
+  return ClassRoom.findById(_id)
+    .populate("students", "name phoneNumber")
+    .populate("leaders", "name phoneNumber")
+    .exec();
 };
 
 module.exports.getClassesByTeacherId = (teacher) => {
-  return ClassRoom.find({ teacher }).exec();
+  return ClassRoom.find({ teacher })
+    .populate("students", "name phoneNumber")
+    .populate("leaders", "name phoneNumber")
+    .exec();
 };
 
 module.exports.deleteClassById = (id) => {

--- a/backend-server/src/models/ContentV3.js
+++ b/backend-server/src/models/ContentV3.js
@@ -24,12 +24,14 @@ const ContentSchema = new mongoose.Schema(
       type: String,
       default: () => require("uuid").v4(),
     },
+    tenantId: { type: String, required: true, index: true, ref: "Tenant" },
     description: { type: String, default: "" },
     type: { type: String, required: true },
     language: { type: String, required: true },
     title: { type: TextContentSchema, required: true },
     theme: { type: TextContentSchema, required: true },
     audioContent: { type: [AudioContentSchema], default: [] },
+    schoolId: { type: String, default: null, index: true },
     createdBy: { type: String, default: "" },
     isPullModel: { type: Boolean, default: false },
     isTeacherApp: { type: Boolean, default: false },
@@ -38,6 +40,10 @@ const ContentSchema = new mongoose.Schema(
   },
   { collection: "contentsV3" }
 );
+
+ContentSchema.index({ tenantId: 1, isDeleted: 1, creation_time: -1 });
+ContentSchema.index({ tenantId: 1, language: 1});
+
 
 const ContentV3 = mongoose.model("ContentV3", ContentSchema);
 

--- a/backend-server/src/models/IvrV2Log.js
+++ b/backend-server/src/models/IvrV2Log.js
@@ -33,6 +33,7 @@ const IvrV2LogSchema = new mongoose.Schema(
     experience_data: { type: mongoose.Schema.Types.Mixed, default: {} },
     call_status_updates: { type: mongoose.Schema.Types.Mixed, default: {} },
     tenant_id: { type: String, required: true },
+    school_id: { type: String, default: null },
   },
   { collection: "ivrv2logs" }
 );

--- a/backend-server/src/models/School.js
+++ b/backend-server/src/models/School.js
@@ -1,0 +1,14 @@
+"use strict";
+const mongoose = require("mongoose");
+
+const SchoolSchema = new mongoose.Schema({
+    tenantId: { type: String, required: true, index: true, ref: "Tenant" },
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: { type: String },
+    isActive: { type: Boolean, default: true },
+}, { timestamps: true });
+
+const School = mongoose.model("School", SchoolSchema);
+
+module.exports = School;

--- a/backend-server/src/models/Student.js
+++ b/backend-server/src/models/Student.js
@@ -2,9 +2,13 @@
 const mongoose = require("mongoose");
 
 const StudentSchema = new mongoose.Schema({
+  schoolId: { type: String, required: true, index: true, ref: "School" },
   name: { type: String, required: true },
   phoneNumber: { type: String, required: true, unique: true },
-});
+}, { timestamps: true });
+
+StudentSchema.index({ schoolId: 1, phoneNumber: 1 }, { unique: true });
+StudentSchema.index({ schoolId: 1 });
 
 const Student = mongoose.model("Student", StudentSchema);
 module.exports = Student;

--- a/backend-server/src/models/Teacher.js
+++ b/backend-server/src/models/Teacher.js
@@ -2,12 +2,14 @@
 const mongoose = require("mongoose");
 
 const TeacherSchema = new mongoose.Schema({
-  tenantId: { type: String, required: true, index: true },
+  schoolId: { type: String, required: true, index: true, ref: "School" },
   name: { type: String, required: true },
-  phoneNumber: { type: String, required: true, index: true, unique: true },
+  phoneNumber: { type: String, required: true, index: true },
   password: { type: String, required: true },
-  studentId: { type: [String], default: [] },
-});
+  role: { type: String, enum: ["content_creator", "teacher"], default: "teacher" },
+}, { timestamps: true });
+
+TeacherSchema.index({ schoolId: 1, phoneNumber: 1 }, { unique: true });
 
 const Teacher = mongoose.model("Teacher", TeacherSchema);
 

--- a/backend-server/src/repositories/class.repository.js
+++ b/backend-server/src/repositories/class.repository.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const classDao = require("../dao/mongodb/ClassMongoDao");
+
+exports.getClassCountBySchoolId = async (schoolId) => {
+    return classDao.getClassCountBySchoolId(schoolId);
+};

--- a/backend-server/src/repositories/ivrV2Log.repository.js
+++ b/backend-server/src/repositories/ivrV2Log.repository.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const ivrV2LogDao = require("../dao/mongodb/IvrV2LogMongoDao");
+
+exports.findBySchoolIdInDateRange = async (schoolId, startStr, endStr) => {
+    return ivrV2LogDao.findBySchoolIdInDateRange(schoolId, startStr, endStr);
+};
+
+exports.findByTenantIdInDateRange = async (tenantId, startStr, endStr) => {
+    return ivrV2LogDao.findByTenantIdInDateRange(tenantId, startStr, endStr);
+};

--- a/backend-server/src/repositories/school.repository.js
+++ b/backend-server/src/repositories/school.repository.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const schoolDao = require("../dao/mongodb/SchoolMongoDao");
+
+exports.getSchoolByEmail = async (email) => {
+    return schoolDao.getSchoolByEmail(email);
+};
+
+exports.createSchool = async (name, email, tenantId, hashedPassword) => {
+    return schoolDao.createSchool(name, email, tenantId, hashedPassword);
+};
+
+exports.getSchools = async (tenantId) => {
+    return schoolDao.getSchools(tenantId);
+};
+
+exports.getSchoolById = async (schoolId, tenantId) => {
+    return schoolDao.getSchoolById(schoolId, tenantId);
+};
+
+exports.updateSchool = async (school) => {
+    return schoolDao.updateSchool(school);
+};
+
+exports.deleteSchool = async (schoolId, tenantId) => {
+    return schoolDao.deleteSchool(schoolId, tenantId);
+};
+
+exports.setSchoolPassword = async (schoolId, tenantId, hashedPassword) => {
+    return schoolDao.setSchoolPassword(schoolId, tenantId, hashedPassword);
+};

--- a/backend-server/src/repositories/student.repository.js
+++ b/backend-server/src/repositories/student.repository.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const studentDao = require("../dao/mongodb/StudentMongoDao");
+
+exports.createStudent = (data) => studentDao.createStudent(data);
+
+exports.getStudentsBySchoolId = (schoolId) => studentDao.getStudentsBySchoolId(schoolId);
+
+exports.getStudentById = (studentId) => studentDao.getStudentById(studentId);
+
+exports.updateStudent = (studentId, schoolId, updates) => studentDao.updateStudent(studentId, schoolId, updates);
+
+exports.deleteStudent = (studentId, schoolId) => studentDao.deleteStudent(studentId, schoolId);
+
+exports.getStudentCountBySchoolId = (schoolId) => studentDao.getStudentCountBySchoolId(schoolId);

--- a/backend-server/src/repositories/teacher.repository.js
+++ b/backend-server/src/repositories/teacher.repository.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const teacherDao = require("../dao/mongodb/TeacherMongoDao");
+
+exports.getTeacherById = async (teacherId) => {
+    return teacherDao.getTeacherById(teacherId);
+};
+
+exports.getTeacherByPhoneNumber = async (phoneNumber) => {
+    return teacherDao.getTeacherByPhoneNumber(phoneNumber);
+};
+
+exports.getTeachersBySchoolId = async (schoolId) => {
+    return teacherDao.getTeachersBySchoolId(schoolId);
+};
+
+exports.transferTeacher = async (teacherId, targetSchoolId) => {
+    return teacherDao.transferTeacher(teacherId, targetSchoolId);
+};
+
+exports.getTeacherCountBySchoolId = async (schoolId) => {
+    return teacherDao.getTeacherCountBySchoolId(schoolId);
+};
+
+exports.getTeacherBySchoolIdAndPhoneNumber = async (schoolId, phoneNumber) => {
+    return teacherDao.getTeacherBySchoolIdAndPhoneNumber(schoolId, phoneNumber);
+};
+
+exports.insertTeacher = async (data) => {
+    return teacherDao.insertTeacher(data);
+};
+
+exports.updateTeacher = async (teacherId, schoolId, updates) => {
+    return teacherDao.updateTeacher(teacherId, schoolId, updates);
+};

--- a/backend-server/src/repositories/tenant.repository.js
+++ b/backend-server/src/repositories/tenant.repository.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const tenantDao = require("../dao/mongodb/TenantMongoDao");
+
+exports.getTenantById = async (tenantId) => {
+    return tenantDao.getTenantById(tenantId);
+};


### PR DESCRIPTION
## Summary
- Adds `School` and `Student` Mongoose models; updates `Teacher`, `Class`, and `ContentV3` models for school-scoped multi-tenancy
- Introduces DAO interfaces (`ISchoolDao`, `IStudentDao`, `ITeacherDao`, `IClassDao`, `ITenantDao`) with MongoDB implementations
- Adds repository layer for all entities (school, student, teacher, class, tenant, ivrV2Log)
- Adds 6 migration scripts (001–006): create default school, migrate teachers/students/classes/content, migrate class student refs; includes rollback and verification scripts

## Test plan
- [ ] Run `node backend-server/migrations/run-migration.js` against a dev DB and verify the verification output shows 0 warnings
- [ ] Confirm `School` model creates/reads correctly via Mongoose
- [ ] Confirm `Teacher` unique index is `(schoolId, phoneNumber)` (not phone alone)
- [ ] Confirm all repositories return expected data shapes

## Dependencies
None — this is the base data layer. PR 2 (API & auth) depends on this.