### PR TITLE
Remove caching step from Poetry setup

### DIFF
--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -24,14 +24,6 @@ runs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ${{ inputs.directory }}/.venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
     - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: cd ${{ inputs.directory }} && poetry install --with test
       shell: bash

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -24,6 +24,13 @@ runs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ inputs.directory }}/.venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
     - name: Install dependencies
       run: cd ${{ inputs.directory }} && poetry install --with test
       shell: bash


### PR DESCRIPTION
Eliminate the caching step in the Poetry setup to ensure fresh installations of dependencies each time. This change aims to avoid potential issues with stale dependencies.