### PR TITLE
feat(backend): Add duration extraction for IVR announcements

### DIFF
--- a/backend-server/src/jobs/jobsUtils.js
+++ b/backend-server/src/jobs/jobsUtils.js
@@ -82,6 +82,25 @@ function generateTempPaths(contentId, ip_url) {
 }
 
 /**
+ * Extracts the duration of an audio file using ffprobe.
+ * @param {string} filePath - Path to the audio file.
+ * @returns {Promise<number|null>} - Duration in seconds, or null on failure.
+ */
+function extractAudioDuration(filePath) {
+  return new Promise((resolve) => {
+    ffmpeg.ffprobe(filePath, (err, metadata) => {
+      if (err) {
+        console.error("Error extracting audio duration:", err);
+        resolve(null);
+      } else {
+        const duration = metadata?.format?.duration;
+        resolve(duration ? parseFloat(duration) : null);
+      }
+    });
+  });
+}
+
+/**
  * Adjusts an option string based on language.
  * For example, for Kannada, "option" becomes "optionಗಾಗಿ".
  * @param {string} lang - The language (e.g., "kannada", "english").
@@ -117,5 +136,6 @@ module.exports = {
   processAudioWithFfmpeg,
   cleanupTempFiles,
   generateTempPaths,
+  extractAudioDuration,
   addForInOptionAudio,
 };

--- a/backend-server/src/jobs/jobsUtils.js
+++ b/backend-server/src/jobs/jobsUtils.js
@@ -92,24 +92,30 @@ function withTimeout(promise, ms, label) {
 
 /**
  * Extracts the duration of an audio file using ffprobe.
+ * Uses a `cancelled` flag so that if the timeout fires first, the ffprobe
+ * callback becomes a no-op (prevents zombie callbacks from resolving/rejecting
+ * an already-settled promise race).
  * @param {string} filePath - Path to the audio file.
  * @returns {Promise<number|null>} - Duration in seconds, or null on failure.
  */
 function extractAudioDuration(filePath) {
-  return withTimeout(
-    new Promise((resolve, reject) => {
-      ffmpeg.ffprobe(filePath, (err, metadata) => {
-        if (err) {
-          reject(err);
-        } else {
-          const parsed = parseFloat(metadata?.format?.duration);
-          resolve(Number.isFinite(parsed) ? parsed : null);
-        }
-      });
-    }),
-    FFPROBE_TIMEOUT_MS,
-    "ffprobe"
-  );
+  let cancelled = false;
+  const ffprobePromise = new Promise((resolve, reject) => {
+    ffmpeg.ffprobe(filePath, (err, metadata) => {
+      if (cancelled) return;
+      if (err) {
+        reject(err);
+      } else {
+        const parsed = parseFloat(metadata?.format?.duration);
+        resolve(Number.isFinite(parsed) ? parsed : null);
+      }
+    });
+  });
+
+  return withTimeout(ffprobePromise, FFPROBE_TIMEOUT_MS, "ffprobe").catch((err) => {
+    cancelled = true;
+    throw err;
+  });
 }
 
 /**

--- a/backend-server/src/jobs/jobsUtils.js
+++ b/backend-server/src/jobs/jobsUtils.js
@@ -81,23 +81,35 @@ function generateTempPaths(contentId, ip_url) {
   return { tempInputPath, tempOutputPath };
 }
 
+const FFPROBE_TIMEOUT_MS = 5 * 60 * 1000;
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`${label} timed out`)), ms)),
+  ]);
+}
+
 /**
  * Extracts the duration of an audio file using ffprobe.
  * @param {string} filePath - Path to the audio file.
  * @returns {Promise<number|null>} - Duration in seconds, or null on failure.
  */
 function extractAudioDuration(filePath) {
-  return new Promise((resolve) => {
-    ffmpeg.ffprobe(filePath, (err, metadata) => {
-      if (err) {
-        console.error("Error extracting audio duration:", err);
-        resolve(null);
-      } else {
-        const duration = metadata?.format?.duration;
-        resolve(duration ? parseFloat(duration) : null);
-      }
-    });
-  });
+  return withTimeout(
+    new Promise((resolve, reject) => {
+      ffmpeg.ffprobe(filePath, (err, metadata) => {
+        if (err) {
+          reject(err);
+        } else {
+          const parsed = parseFloat(metadata?.format?.duration);
+          resolve(Number.isFinite(parsed) ? parsed : null);
+        }
+      });
+    }),
+    FFPROBE_TIMEOUT_MS,
+    "ffprobe"
+  );
 }
 
 /**
@@ -138,4 +150,5 @@ module.exports = {
   generateTempPaths,
   extractAudioDuration,
   addForInOptionAudio,
+  withTimeout,
 };

--- a/backend-server/src/jobs/processAudioContent.js
+++ b/backend-server/src/jobs/processAudioContent.js
@@ -68,7 +68,6 @@ async function generateWAVFileAndUploadToOutputContainer(ip_url, contentId) {
     } catch (err) {
       console.warn("Failed to extract audio duration:", err);
     }
-    if (duration !== null) console.log(`Audio duration: ${duration} seconds`);
 
     const outputBlobName = `${blobService.extractBlobPathWithoutExtension(ip_url)}.wav`;
     console.log(`Uploading processed file as: ${outputBlobName}`);

--- a/backend-server/src/jobs/processAudioContent.js
+++ b/backend-server/src/jobs/processAudioContent.js
@@ -15,10 +15,12 @@ const {
   generateTempPaths,
   extractAudioDuration,
   addForInOptionAudio,
+  withTimeout,
 } = require("./jobsUtils.js");
 
 // Maximum job runtime: 5 minutes.
 const JOB_TIMEOUT_MS = 5 * 60 * 1000;
+const BLOB_TIMEOUT_MS = 5 * 60 * 1000;
 
 // Instantiate BlobService and get container clients.
 const blobService = new BlobService();
@@ -38,7 +40,11 @@ async function generateWAVFileAndUploadToOutputContainer(ip_url, contentId) {
   const { tempInputPath, tempOutputPath } = generateTempPaths(contentId, ip_url);
   try {
     console.log(`Downloading blob from: ${ip_url}`);
-    const inputBuffer = await blobService.downloadBlobToBuffer(ip_url);
+    const inputBuffer = await withTimeout(
+      blobService.downloadBlobToBuffer(ip_url),
+      BLOB_TIMEOUT_MS,
+      "blobDownload"
+    );
     if (!inputBuffer || inputBuffer.length === 0) {
       throw new Error("Input buffer is empty!");
     }
@@ -51,24 +57,27 @@ async function generateWAVFileAndUploadToOutputContainer(ip_url, contentId) {
     await processAudioWithFfmpeg(tempInputPath, tempOutputPath);
     console.log("ffmpeg processing completed.");
 
-    const processedBuffer = fs.readFileSync(tempOutputPath);
+    const processedBuffer = await fs.promises.readFile(tempOutputPath);
     console.log(`Processed file size: ${processedBuffer.length} bytes`);
 
     // Extract audio duration
     console.log("Extracting audio duration...");
-    const duration = await extractAudioDuration(tempOutputPath);
-    if (duration !== null) {
-      console.log(`Audio duration: ${duration} seconds`);
-    } else {
-      console.warn("Failed to extract audio duration");
+    let duration = null;
+    try {
+      duration = await extractAudioDuration(tempOutputPath);
+    } catch (err) {
+      console.warn("Failed to extract audio duration:", err);
     }
+    if (duration !== null) console.log(`Audio duration: ${duration} seconds`);
 
     const outputBlobName = `${blobService.extractBlobPathWithoutExtension(ip_url)}.wav`;
     console.log(`Uploading processed file as: ${outputBlobName}`);
     const outputBlockBlobClient = outputContainerClient.getBlockBlobClient(outputBlobName);
-    await outputBlockBlobClient.uploadData(processedBuffer, {
-      blobHTTPHeaders: { blobContentType: "audio/wav" },
-    });
+    await withTimeout(
+      outputBlockBlobClient.uploadData(processedBuffer, { blobHTTPHeaders: { blobContentType: "audio/wav" } }),
+      BLOB_TIMEOUT_MS,
+      "blobUpload"
+    );
     console.log(`Processed blob uploaded: ${outputBlobName}`);
     return { url: outputBlockBlobClient.url, duration };
   } catch (err) {

--- a/backend-server/src/jobs/processAudioContent.js
+++ b/backend-server/src/jobs/processAudioContent.js
@@ -13,6 +13,7 @@ const {
   processAudioWithFfmpeg,
   cleanupTempFiles,
   generateTempPaths,
+  extractAudioDuration,
   addForInOptionAudio,
 } = require("./jobsUtils.js");
 
@@ -27,10 +28,10 @@ const themeContainerClient = blobService.getContainerClient("theme-titles");
 
 /**
  * Converts an audio blob to WAV using ffmpeg, uploads it to Azure Blob Storage,
- * and returns the uploaded file URL.
+ * and returns the uploaded file URL and duration.
  * @param {string} ip_url - The input blob URL.
  * @param {string} contentId - The content identifier.
- * @returns {Promise<string>} - URL of the processed blob.
+ * @returns {Promise<{url: string, duration: number|null}>} - Object with URL and duration.
  */
 async function generateWAVFileAndUploadToOutputContainer(ip_url, contentId) {
   console.log(`Starting processing for: ${ip_url}`);
@@ -53,6 +54,15 @@ async function generateWAVFileAndUploadToOutputContainer(ip_url, contentId) {
     const processedBuffer = fs.readFileSync(tempOutputPath);
     console.log(`Processed file size: ${processedBuffer.length} bytes`);
 
+    // Extract audio duration
+    console.log("Extracting audio duration...");
+    const duration = await extractAudioDuration(tempOutputPath);
+    if (duration !== null) {
+      console.log(`Audio duration: ${duration} seconds`);
+    } else {
+      console.warn("Failed to extract audio duration");
+    }
+
     const outputBlobName = `${blobService.extractBlobPathWithoutExtension(ip_url)}.wav`;
     console.log(`Uploading processed file as: ${outputBlobName}`);
     const outputBlockBlobClient = outputContainerClient.getBlockBlobClient(outputBlobName);
@@ -60,7 +70,7 @@ async function generateWAVFileAndUploadToOutputContainer(ip_url, contentId) {
       blobHTTPHeaders: { blobContentType: "audio/wav" },
     });
     console.log(`Processed blob uploaded: ${outputBlobName}`);
-    return outputBlockBlobClient.url;
+    return { url: outputBlockBlobClient.url, duration };
   } catch (err) {
     console.error(`Error processing ${ip_url}:`, err);
     throw err;
@@ -105,10 +115,12 @@ async function processNewContent(job) {
           continue;
         }
 
-        audioContentItem.audioUrl = await generateWAVFileAndUploadToOutputContainer(
+        const { url, duration } = await generateWAVFileAndUploadToOutputContainer(
           ip_url,
           contentDoc.id
         );
+        audioContentItem.audioUrl = url;
+        audioContentItem.durationSeconds = duration;
       } catch (err) {
         console.error(`Failed to process audio content item ${ip_url}:`, err);
         throw err;

--- a/backend-server/src/migrations/migrateDurations.js
+++ b/backend-server/src/migrations/migrateDurations.js
@@ -1,0 +1,211 @@
+/**
+ * @module migrateDurations
+ * @description Migration script to extract and populate audio duration for existing content.
+ * This script downloads existing audio files, extracts their duration using ffprobe,
+ * and updates the MongoDB database with the duration values.
+ *
+ * Usage:
+ *   node backend-server/src/migrations/migrateDurations.js
+ *
+ * Environment Variables:
+ *   DB_CONNECTION - MongoDB connection string (optional, uses default from config)
+ */
+
+const mongoose = require("mongoose");
+const config = require("../config/env.js");
+const { ContentV3 } = require("../models/ContentV3.js");
+const BlobService = require("../services/BlobService.js");
+const {
+  extractAudioDuration,
+  writeBufferToFile,
+  cleanupTempFiles,
+  generateTempPaths,
+} = require("../jobs/jobsUtils.js");
+
+// MongoDB connection URI (use environment variable or default)
+const MONGO_URI = config.dbConnection;
+
+// Statistics tracking
+const stats = {
+  total: 0,
+  processed: 0,
+  skipped: 0,
+  failed: 0,
+  updated: 0,
+};
+
+/**
+ * Extracts duration for a single audio content item.
+ * @param {object} audioContentItem - The audio content item.
+ * @param {string} contentId - The content ID.
+ * @param {BlobService} blobService - The blob service instance.
+ * @returns {Promise<number|null>} - Duration in seconds, or null on failure.
+ */
+async function extractDurationForAudioItem(audioContentItem, contentId, blobService) {
+  const audioUrl = audioContentItem.audioUrl;
+  if (!audioUrl) {
+    console.warn(`  ⚠ No audio URL found, skipping`);
+    return null;
+  }
+
+  const { tempInputPath } = generateTempPaths(contentId, audioUrl);
+
+  try {
+    console.log(`  Downloading: ${audioUrl}`);
+    const audioBuffer = await blobService.downloadBlobToBuffer(audioUrl);
+
+    if (!audioBuffer || audioBuffer.length === 0) {
+      console.error(`  ✗ Failed to download audio file`);
+      return null;
+    }
+
+    await writeBufferToFile(audioBuffer, tempInputPath);
+    console.log(`  Extracting duration...`);
+
+    const duration = await extractAudioDuration(tempInputPath);
+
+    if (duration !== null) {
+      console.log(`  ✓ Duration: ${duration} seconds`);
+    } else {
+      console.error(`  ✗ Failed to extract duration`);
+    }
+
+    return duration;
+  } catch (error) {
+    console.error(`  ✗ Error processing audio: ${error.message}`);
+    return null;
+  } finally {
+    cleanupTempFiles([tempInputPath]);
+  }
+}
+
+/**
+ * Main migration function.
+ */
+async function migrateDurations() {
+  console.log("=".repeat(80));
+  console.log("Starting Duration Migration");
+  console.log("=".repeat(80));
+  console.log(`MongoDB URI: ${MONGO_URI}\n`);
+
+  if (!MONGO_URI) {
+    throw new Error(
+      "DB_CONNECTION is not set. Add it to your environment or backend-server/.env file."
+    );
+  }
+
+  try {
+    // Connect to MongoDB
+    console.log("Connecting to MongoDB...");
+    await mongoose.connect(MONGO_URI);
+    console.log("✓ Connected to MongoDB\n");
+
+    // Initialize blob service
+    const blobService = new BlobService();
+
+    // Fetch all content documents with audio content
+    console.log("Fetching content documents with audio...");
+    const contentDocs = await ContentV3.find({
+      audioContent: { $exists: true, $ne: [] },
+    }).exec();
+
+    console.log(`Found ${contentDocs.length} content documents with audio\n`);
+
+    // Process each content document
+    for (const contentDoc of contentDocs) {
+      console.log(`\nProcessing Content ID: ${contentDoc._id}`);
+      console.log(`  Language: ${contentDoc.language}`);
+      console.log(`  Audio items: ${contentDoc.audioContent.length}`);
+
+      let documentUpdated = false;
+
+      for (let i = 0; i < contentDoc.audioContent.length; i++) {
+        const audioContentItem = contentDoc.audioContent[i];
+        stats.total++;
+
+        console.log(`\n  Audio Item ${i + 1}/${contentDoc.audioContent.length}:`);
+
+        // Skip if duration already exists (idempotent)
+        if (
+          audioContentItem.durationSeconds !== null &&
+          audioContentItem.durationSeconds !== undefined
+        ) {
+          console.log(
+            `  ⊘ Duration already exists (${audioContentItem.durationSeconds}s), skipping`
+          );
+          stats.skipped++;
+          continue;
+        }
+
+        // Extract duration
+        const duration = await extractDurationForAudioItem(
+          audioContentItem,
+          contentDoc._id,
+          blobService
+        );
+
+        if (duration !== null) {
+          audioContentItem.durationSeconds = duration;
+          documentUpdated = true;
+          stats.processed++;
+        } else {
+          stats.failed++;
+        }
+      }
+
+      // Save document if any audio items were updated
+      if (documentUpdated) {
+        try {
+          await contentDoc.save();
+          console.log(`\n  ✓ Saved content document ${contentDoc._id}`);
+          stats.updated++;
+        } catch (error) {
+          console.error(`\n  ✗ Failed to save content document: ${error.message}`);
+        }
+      }
+    }
+
+    // Print final statistics
+    console.log("\n" + "=".repeat(80));
+    console.log("Migration Complete");
+    console.log("=".repeat(80));
+    console.log(`Total audio items:       ${stats.total}`);
+    console.log(`Successfully processed:  ${stats.processed}`);
+    console.log(`Skipped (already exist): ${stats.skipped}`);
+    console.log(`Failed:                  ${stats.failed}`);
+    console.log(`Documents updated:       ${stats.updated}`);
+    console.log("=".repeat(80));
+
+    // Calculate success rate
+    const successRate =
+      stats.total > 0 ? ((stats.processed / (stats.total - stats.skipped)) * 100).toFixed(2) : 0;
+    console.log(`Success rate: ${successRate}%`);
+
+    if (stats.failed > 0) {
+      console.warn(`\n⚠ Warning: ${stats.failed} items failed to process`);
+    }
+  } catch (error) {
+    console.error("\n✗ Migration failed with error:", error);
+    process.exit(1);
+  } finally {
+    // Disconnect from MongoDB
+    console.log("\nDisconnecting from MongoDB...");
+    await mongoose.disconnect();
+    console.log("✓ Disconnected\n");
+  }
+}
+
+// Run migration if executed directly
+if (require.main === module) {
+  migrateDurations()
+    .then(() => {
+      console.log("Migration script completed successfully");
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error("Migration script failed:", error);
+      process.exit(1);
+    });
+}
+
+module.exports = migrateDurations;

--- a/backend-server/src/models/ContentV3.js
+++ b/backend-server/src/models/ContentV3.js
@@ -14,6 +14,7 @@ const AudioContentSchema = new mongoose.Schema(
   {
     description: { type: String, default: "" },
     audioUrl: { type: String, required: true },
+    durationSeconds: { type: Number, default: null },
   },
   { _id: false }
 );

--- a/backend-server/tests/jobs/jobsUtils.test.js
+++ b/backend-server/tests/jobs/jobsUtils.test.js
@@ -5,7 +5,11 @@ const ffmpeg = require('fluent-ffmpeg');
 
 // Mock the dependencies
 jest.mock('fs');
-jest.mock('fluent-ffmpeg');
+jest.mock('fluent-ffmpeg', () => {
+    const mockFn = jest.fn();
+    mockFn.ffprobe = jest.fn();
+    return mockFn;
+});
 jest.mock('ffmpeg-static', () => '/mocked/path/to/ffmpeg');
 
 const {
@@ -14,6 +18,8 @@ const {
     cleanupTempFiles,
     generateTempPaths,
     addForInOptionAudio,
+    withTimeout,
+    extractAudioDuration,
 } = require('../../src/jobs/jobsUtils');
 
 describe('jobsUtils', () => {
@@ -258,6 +264,70 @@ describe('jobsUtils', () => {
         test('should handle undefined language gracefully', () => {
             // This test reveals that the function doesn't handle undefined properly
             expect(() => addForInOptionAudio(undefined, 'option1')).toThrow();
+        });
+    });
+
+    describe('withTimeout', () => {
+        test('resolves with value when inner promise resolves before timeout', async () => {
+            const result = await withTimeout(Promise.resolve(42), 1000, 'test');
+            expect(result).toBe(42);
+        });
+
+        test('rejects with inner error when inner promise rejects before timeout', async () => {
+            await expect(
+                withTimeout(Promise.reject(new Error('inner error')), 1000, 'test')
+            ).rejects.toThrow('inner error');
+        });
+
+        test('rejects with "<label> timed out" when timeout fires first', async () => {
+            jest.useFakeTimers();
+            const never = new Promise(() => {});
+            const p = withTimeout(never, 100, 'ffprobe');
+            jest.runAllTimers();
+            await expect(p).rejects.toThrow('ffprobe timed out');
+            jest.useRealTimers();
+        });
+    });
+
+    describe('extractAudioDuration', () => {
+        test('returns parsed duration when ffprobe succeeds', async () => {
+            ffmpeg.ffprobe.mockImplementation((_, cb) =>
+                cb(null, { format: { duration: '123.456' } })
+            );
+            await expect(extractAudioDuration('/tmp/audio.wav')).resolves.toBe(123.456);
+        });
+
+        test('returns null when duration is non-finite (NaN)', async () => {
+            ffmpeg.ffprobe.mockImplementation((_, cb) =>
+                cb(null, { format: { duration: 'not-a-number' } })
+            );
+            await expect(extractAudioDuration('/tmp/audio.wav')).resolves.toBeNull();
+        });
+
+        test('returns null when format metadata is absent', async () => {
+            ffmpeg.ffprobe.mockImplementation((_, cb) => cb(null, {}));
+            await expect(extractAudioDuration('/tmp/audio.wav')).resolves.toBeNull();
+        });
+
+        test('rejects when ffprobe returns an error', async () => {
+            ffmpeg.ffprobe.mockImplementation((_, cb) =>
+                cb(new Error('probe failed'), null)
+            );
+            await expect(extractAudioDuration('/tmp/audio.wav')).rejects.toThrow('probe failed');
+        });
+
+        test('rejects on timeout and late ffprobe callback is silently ignored', async () => {
+            jest.useFakeTimers();
+            let lateCb;
+            ffmpeg.ffprobe.mockImplementation((_, cb) => { lateCb = cb; });
+
+            const p = extractAudioDuration('/tmp/audio.wav');
+            jest.runAllTimers();
+            await expect(p).rejects.toThrow('ffprobe timed out');
+
+            // Zombie callback fires after timeout — must not throw
+            expect(() => lateCb(null, { format: { duration: '60' } })).not.toThrow();
+            jest.useRealTimers();
         });
     });
 


### PR DESCRIPTION
## Summary
Add duration extraction during audio processing to support IVR duration announcements feature.

## Changes
- Added `durationSeconds` field to AudioContent schema
- Implemented FFmpeg-based duration extraction using ffprobe
- Modified processAudioContent job to extract duration after conversion
- Created migration script for legacy content

## Deployment Notes
- Run migration script after deployment: `DB_CONNECTION=<mongo-uri> node backend-server/src/migrations/migrateDurations.js`

## Related
- Implements backend requirements for DESIGN_AUDIO_DURATION_ANNOUNCEMENTS
- Part of IVR Audio Controls feature set 
    - https://github.com/A4i-tech/.github/issues/251
    - 

