### PR TITLE
fix: update authorization roles for SAS URL endpoint

### DIFF
--- a/backend-server/src/routes/contentRouter.js
+++ b/backend-server/src/routes/contentRouter.js
@@ -257,7 +257,7 @@ router.post(
 router.get(
   "/sasUrl",
   authenticateToken,
-  authorizeRole(TENANT_ROLE),
+  authorizeRole(TENANT_ROLE, SCHOOL_ADMIN_ROLE, TEACHER_ROLE),
   tryCatchWrapper(async (req, res) => {
     const url = req.query.url; // URL is now obtained from query string
     if (!url) {


### PR DESCRIPTION
This pull request makes a small change to the authorization logic in the `/sasUrl` route handler to allow more user roles to access the endpoint.

- Authorization update:
  * The `/sasUrl` route in `contentRouter.js` now allows users with the `SCHOOL_ADMIN_ROLE` and `TEACHER_ROLE` roles, in addition to `TENANT_ROLE`, to access the endpoint.