### PR TITLE
fix(teacher): include phoneNumber and name in getMe response

### DIFF
--- a/backend-server/src/controllers/teacher.controller.js
+++ b/backend-server/src/controllers/teacher.controller.js
@@ -21,7 +21,11 @@ exports.getMe = async (req, res) => {
       }
     }
 
-    return res.status(STATUS.OK).json({ schoolName });
+    return res.status(STATUS.OK).json({
+      schoolName,
+      phoneNumber: teacher.phoneNumber,
+      name: teacher.name,
+    });
   } catch (error) {
     if (error.status === STATUS.NOT_FOUND) {
       return res.status(STATUS.NOT_FOUND).json({ message: "Teacher not found" });

--- a/backend-server/tests/unit/teacherGetMe.test.js
+++ b/backend-server/tests/unit/teacherGetMe.test.js
@@ -53,7 +53,11 @@ describe("Teacher getMe API handler (unit)", () => {
     expect(teacherService.getTeacherById).toHaveBeenCalledWith("teacher123");
     expect(schoolService.getSchoolById).toHaveBeenCalledWith("school123", "tenant123");
     expect(res.statusCode).toBe(STATUS_OK);
-    expect(res.body).toEqual({ schoolName: "School One" });
+    expect(res.body).toEqual({
+      schoolName: "School One",
+      phoneNumber: "9876543210",
+      name: "Creator User",
+    });
   });
 
   test("returns empty schoolName when school lookup is not found", async () => {
@@ -73,6 +77,10 @@ describe("Teacher getMe API handler (unit)", () => {
     await teacherController.getMe(req, res);
 
     expect(res.statusCode).toBe(STATUS_OK);
-    expect(res.body).toEqual({ schoolName: "" });
+    expect(res.body).toEqual({
+      schoolName: "",
+      phoneNumber: "1234567890",
+      name: "Teacher User",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `ClassroomDetail` in teacher-webapp throws `Teacher phone number not available` → toast **"Failed to load classroom data"** because `/teacher/me` was trimmed to `{schoolName}` only in e2e0c69.
- Re-include `phoneNumber` and `name` in the `/teacher/me` response so existing consumers keep working. Tests updated to match the new shape.

## Test plan
- [x] `npx jest tests/unit/teacherGetMe.test.js` — passes
- [x] Login to teacher-webapp, open a classroom → loads without `Failed to load classroom data` toast
- [ ] Start a conference from the classroom → teacher phone propagates to ConferenceV2