### PR TITLE
fix(student): allow content_creator to list students

### DIFF
--- a/backend-server/src/routes/studentRouter.js
+++ b/backend-server/src/routes/studentRouter.js
@@ -13,6 +13,7 @@ const studentController = require("../controllers/student.controller");
 
 const SCHOOL_ADMIN_ROLE = "school_admin";
 const TEACHER_ROLE = "teacher";
+const CONTENT_CREATOR_ROLE = "content_creator";
 
 const router = express.Router();
 
@@ -64,7 +65,7 @@ router.post("/",authenticateToken, authorizeRole(SCHOOL_ADMIN_ROLE), studentCont
  *       401:
  *         description: Unauthorized
  */
-router.get("/",authenticateToken, authorizeRole(SCHOOL_ADMIN_ROLE, TEACHER_ROLE), studentController.getStudents);
+router.get("/",authenticateToken, authorizeRole(SCHOOL_ADMIN_ROLE, TEACHER_ROLE, CONTENT_CREATOR_ROLE), studentController.getStudents);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- `ClassroomForm` calls `GET /student` to populate the student picker.
- Currently only `school_admin` and `teacher` are authorized; `content_creator` users get **403 Forbidden** → toast `Failed to fetch student list`.
- Add `content_creator` to the `authorizeRole` allowlist on `GET /student`.

## Test plan
- [ ] Login as a `content_creator` teacher
- [ ] Open / edit a classroom → student picker loads (no 403, no toast)
- [ ] `school_admin` and `teacher` flows still load students unchanged