### PR TITLE
fix(conference): bound Vonage get_call to prevent 15-min event-loop hang

### DIFF
--- a/ConferenceV2/app/services/communication_api/vonage_api.py
+++ b/ConferenceV2/app/services/communication_api/vonage_api.py
@@ -12,14 +12,19 @@ from pydantic import BaseModel
 from app.conf_logger import logger_instance
 from app.services.singletons.sas_gen import sas_gen
 
+load_dotenv()
+
 _VONAGE_RATE_LIMIT = 3  # max outbound call POSTs per second
 
 # Vonage SDK 2.x uses requests with no default timeout, so a stuck Vonage call
 # can block the FastAPI event loop indefinitely (observed: 15+ minute hang on
 # GET /v1/calls/<uuid>). Used by _try_connecting_websocket_with_participant
-# below to bound the one sync call that lives on the websocket-attach hot path.
+# below to bound the sync calls that live on the websocket-attach hot path.
 _VONAGE_GET_CALL_TIMEOUT_SECONDS = float(
     os.environ.get("VONAGE_GET_CALL_TIMEOUT_SECONDS", "30.0")
+)
+_VONAGE_UPDATE_CALL_TIMEOUT_SECONDS = float(
+    os.environ.get("VONAGE_UPDATE_CALL_TIMEOUT_SECONDS", "30.0")
 )
 
 
@@ -28,9 +33,6 @@ class VonageParticipantInfo(BaseModel):
     call_leg_id: str
     initial_conv_id: str
     conference_conv_id: str = None
-
-
-load_dotenv()
 
 
 class VonageAPI(CommunicationAPI):
@@ -135,6 +137,15 @@ class VonageAPI(CommunicationAPI):
                 f"treating as not-answered"
             )
             return False
+        # Non-timeout SDK/network errors (404 stale leg, 401 auth, connection
+        # reset, etc.) used to propagate and crash callers (handle_call_transfer_event,
+        # reconnect_websocket). Match the timeout semantics — log + return False.
+        except Exception as e:
+            logger_instance.error(
+                f"Vonage get_call failed for {participant.phone_number} "
+                f"({participant.call_leg_id}): {e}"
+            )
+            return False
         logger_instance.info(
             f'Checking participant {participant.phone_number} call status: {call["status"]}'
         )
@@ -142,33 +153,50 @@ class VonageAPI(CommunicationAPI):
             logger_instance.info(
                 f"CONNECTING WEBSOCKET TO THE CONFERENCE {self.conf_id} USING NUMBER {participant.phone_number} URL: {self.ws_server_url}"
             )
-            self.client.voice.update_call(
-                uuid=participant.call_leg_id,
-                params={
-                    "action": "transfer",
-                    "destination": {
-                        "type": "ncco",
-                        "ncco": [
-                            # {
-                            #     "action": "talk",
-                            #     "text": "Connecting websocket"
-                            # },
-                            {
-                                "action": "connect",
-                                "from": "SEEDS-ConfV2",
-                                "endpoint": [
+            # Bound this sync update_call too. Same SDK, same no-default-timeout
+            # problem as get_call above — without this, a hung transfer would
+            # freeze the event loop.
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(
+                        self.client.voice.update_call,
+                        uuid=participant.call_leg_id,
+                        params={
+                            "action": "transfer",
+                            "destination": {
+                                "type": "ncco",
+                                "ncco": [
                                     {
-                                        "type": "websocket",
-                                        "uri": self.ws_server_url,
-                                        "content-type": "audio/l16;rate=8000",
-                                    }
+                                        "action": "connect",
+                                        "from": "SEEDS-ConfV2",
+                                        "endpoint": [
+                                            {
+                                                "type": "websocket",
+                                                "uri": self.ws_server_url,
+                                                "content-type": "audio/l16;rate=8000",
+                                            }
+                                        ],
+                                    },
+                                    {"action": "conversation", "name": self.conf_id},
                                 ],
                             },
-                            {"action": "conversation", "name": self.conf_id},
-                        ],
-                    },
-                },
-            )
+                        },
+                    ),
+                    timeout=_VONAGE_UPDATE_CALL_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger_instance.warning(
+                    f"Vonage update_call (transfer) timed out after "
+                    f"{_VONAGE_UPDATE_CALL_TIMEOUT_SECONDS}s for "
+                    f"{participant.phone_number} ({participant.call_leg_id})"
+                )
+                return False
+            except Exception as e:
+                logger_instance.error(
+                    f"Vonage update_call (transfer) failed for "
+                    f"{participant.phone_number} ({participant.call_leg_id}): {e}"
+                )
+                return False
             # Say it takes 2 seconds for vonage to connect the websocket to the conference.
             # TODO: Figure out a way around this assumption
             await asyncio.sleep(2)

--- a/ConferenceV2/app/services/communication_api/vonage_api.py
+++ b/ConferenceV2/app/services/communication_api/vonage_api.py
@@ -14,6 +14,14 @@ from app.services.singletons.sas_gen import sas_gen
 
 _VONAGE_RATE_LIMIT = 3  # max outbound call POSTs per second
 
+# Vonage SDK 2.x uses requests with no default timeout, so a stuck Vonage call
+# can block the FastAPI event loop indefinitely (observed: 15+ minute hang on
+# GET /v1/calls/<uuid>). Used by _try_connecting_websocket_with_participant
+# below to bound the one sync call that lives on the websocket-attach hot path.
+_VONAGE_GET_CALL_TIMEOUT_SECONDS = float(
+    os.environ.get("VONAGE_GET_CALL_TIMEOUT_SECONDS", "10.0")
+)
+
 
 class VonageParticipantInfo(BaseModel):
     phone_number: str
@@ -108,7 +116,25 @@ class VonageAPI(CommunicationAPI):
 
         Returns True if the above process happened for the given participant
         """
-        call = self.client.voice.get_call(uuid=participant.call_leg_id)
+        # Bound this single sync Vonage call. The Vonage 2.x SDK uses requests
+        # with no default timeout, so a non-responding leg used to freeze the
+        # event loop for 15+ minutes. On timeout, treat the leg as not-answered
+        # so the caller can move on (matches the existing else-branch semantics
+        # below, where a non-"answered" status returns False).
+        try:
+            call = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self.client.voice.get_call, uuid=participant.call_leg_id
+                ),
+                timeout=_VONAGE_GET_CALL_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger_instance.warning(
+                f"Vonage get_call timed out after {_VONAGE_GET_CALL_TIMEOUT_SECONDS}s "
+                f"for {participant.phone_number} ({participant.call_leg_id}); "
+                f"treating as not-answered"
+            )
+            return False
         logger_instance.info(
             f'Checking participant {participant.phone_number} call status: {call["status"]}'
         )

--- a/ConferenceV2/app/services/communication_api/vonage_api.py
+++ b/ConferenceV2/app/services/communication_api/vonage_api.py
@@ -19,7 +19,7 @@ _VONAGE_RATE_LIMIT = 3  # max outbound call POSTs per second
 # GET /v1/calls/<uuid>). Used by _try_connecting_websocket_with_participant
 # below to bound the one sync call that lives on the websocket-attach hot path.
 _VONAGE_GET_CALL_TIMEOUT_SECONDS = float(
-    os.environ.get("VONAGE_GET_CALL_TIMEOUT_SECONDS", "10.0")
+    os.environ.get("VONAGE_GET_CALL_TIMEOUT_SECONDS", "30.0")
 )
 
 


### PR DESCRIPTION
## Summary
- Vonage Python SDK 2.x uses `requests` with no default timeout. A non-responding `GET /v1/calls/<uuid>` froze the FastAPI event loop for 15+ minutes (seen in App Insights), blocking every other request to ConferenceV2 and cascading into PUT 400s on stale call legs.
- Wraps the single sync `get_call` in `_try_connecting_websocket_with_participant` with `asyncio.wait_for` + `asyncio.to_thread` (10s default, override via `VONAGE_GET_CALL_TIMEOUT_SECONDS`).
- On timeout: log warning and `return False` so the caller follows the existing not-answered path. No participant-map mutation, no behavior change on the happy path.

## Scope
Intentionally minimal — only `ConferenceV2/app/services/communication_api/vonage_api.py`, +27/-1. Other `update_call` / `get_call` sites (mute, unmute, remove, end_conf, TTS, reconnect loop) intentionally left untouched to limit blast radius.

## Rollback
Set `VONAGE_GET_CALL_TIMEOUT_SECONDS=86400` in App Service config → effectively disables the timeout without redeploy.

## Test plan
- [ ] Deploy to staging.
- [ ] Verify `_try_connecting_websocket_with_participant` succeeds for a healthy conference (status==answered, WS attached).
- [ ] Verify timeout path logs warning + returns False (can simulate by setting `VONAGE_GET_CALL_TIMEOUT_SECONDS=0.001`).
- [ ] Watch App Insights `dependencies` for `GET /v1/calls/*` — confirm no row exceeds ~10s duration.
- [ ] Watch `requests` for ConferenceV2 — confirm no 15+ minute hangs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added timeout protection to websocket connection operations, preventing indefinite stalls.
  * Improved timeout handling for voice call operations to enhance reliability.
  * Enhanced error handling to gracefully manage operation timeouts and exceptions during connection attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/A4i-tech/SEEDS/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->