### PR TITLE
Add early return to prevent redundant conference start calls 

### DIFF
--- a/ConferenceV2/app/services/singletons/conference_call_manager.py
+++ b/ConferenceV2/app/services/singletons/conference_call_manager.py
@@ -80,6 +80,8 @@ class ConferenceCallManager:
         conf: ConferenceCall = self.get_conference(conf_id)
         if not conf:
             raise ValueError(f"No such conference has been created; ID: {conf_id}")
+        if conf.state.is_running:
+            return
 
         conf.start_processing_conf_events_from_queue()
         conf.start_remote_audio_relay()

--- a/websocket-service/src/server.js
+++ b/websocket-service/src/server.js
@@ -109,7 +109,9 @@ wss.on("connection", (ws, req) => {
     ws.on("close", () => {
       console.log(`WebSocket connection closed for ID: ${id}`);
       clearTimeout(connectionTimeout);
-      const { state } = connectionManager.getConnection(id);
+      const current = connectionManager.getConnection(id);
+      if (!current || current.ws !== ws) return;
+      const { state } = current;
       connectionManager.removeConnection(id);
 
       if (!state.isClosed) {

--- a/websocket-service/src/services/controlService.js
+++ b/websocket-service/src/services/controlService.js
@@ -24,7 +24,10 @@ function handleControlConnection(ws, id) {
 
   ws.on("close", (code, reason) => {
     console.log(`Control WebSocket connection closed (${id}): code=${code} reason=${reason}`);
-    connectionManager.removeConnection(id);
+    const current = connectionManager.getConnection(id);
+    if (current && current.ws === ws) {
+      connectionManager.removeConnection(id);
+    }
   });
 
   ws.on("error", (error) => {

--- a/websocket-service/tests/services/controlService.test.js
+++ b/websocket-service/tests/services/controlService.test.js
@@ -52,6 +52,7 @@ describe("ControlService", () => {
       );
 
       // Test close event
+      connectionManager.getConnection.mockReturnValue({ ws: mockWebSocket });
       mockCloseHandler(1000, "normal");
       expect(consoleSpy).toHaveBeenCalledWith(
         "Control WebSocket connection closed (confv2server): code=1000 reason=normal"


### PR DESCRIPTION
This pull request makes a small but important change to the `ConferenceCallManager` service. The update ensures that if a conference call is already running, the `start_conference_call` method will exit early and not attempt to start the call again, preventing duplicate starts.

- Conference call state handling:
  * Updated `start_conference_call` in `conference_call_manager.py` to check if the conference is already running and return early if so, avoiding redundant start operations.