### PR TITLE
fix(conference): SSE reconnect with backoff + state snapshot on connect

### DIFF
--- a/ConferenceV2/app/services/conference_call.py
+++ b/ConferenceV2/app/services/conference_call.py
@@ -277,7 +277,14 @@ class ConferenceCall:
     async def connect_smartphone(self):
         teacher = self.state.get_teacher()
         if teacher:
-            return await self.connection_manager.connect(client=teacher)
+            response = await self.connection_manager.connect(client=teacher)
+            # A fresh SSE connection starts with an empty queue, so a client that
+            # (re)connects mid-conference would stay stale until the next event
+            # fires. Seed it with the current state immediately.
+            await self.connection_manager.send_message_to_client(
+                client=teacher, message=self.state.model_dump(by_alias=True)
+            )
+            return response
         raise ValueError("No teacher participant in conf call " + self.conf_id)
     
     async def disconnect_smartphone(self):

--- a/ConferenceV2/app/services/conference_call.py
+++ b/ConferenceV2/app/services/conference_call.py
@@ -280,10 +280,19 @@ class ConferenceCall:
             response = await self.connection_manager.connect(client=teacher)
             # A fresh SSE connection starts with an empty queue, so a client that
             # (re)connects mid-conference would stay stale until the next event
-            # fires. Seed it with the current state immediately.
-            await self.connection_manager.send_message_to_client(
-                client=teacher, message=self.state.model_dump(by_alias=True)
-            )
+            # fires. Seed it with the current state immediately. This is
+            # best-effort: a failed snapshot must not break the connection, since
+            # the next real event will refresh the client anyway.
+            try:
+                await self.connection_manager.send_message_to_client(
+                    client=teacher, message=self.state.model_dump(by_alias=True)
+                )
+            except Exception:
+                logger_instance.warning(
+                    "connect_smartphone: failed to seed state snapshot for "
+                    f"conference {self.conf_id}",
+                    exc_info=True,
+                )
             return response
         raise ValueError("No teacher participant in conf call " + self.conf_id)
     

--- a/ConferenceV2/tests/test_conference_call.py
+++ b/ConferenceV2/tests/test_conference_call.py
@@ -144,6 +144,43 @@ class TestConferenceCall:
         assert result["status"] == "disconnected"
     
     @pytest.mark.asyncio
+    async def test_connect_smartphone_sends_state_snapshot(self, conference_call, participants):
+        """Connecting the smartphone should immediately seed the client with current state"""
+        conf_call, _, _, conn_mgr = conference_call
+        teacher_phone, _ = participants
+        conf_call.set_participant_state(teacher_phone, [])
+
+        await conf_call.connect_smartphone()
+
+        teacher = conf_call.state.get_teacher()
+        conn_mgr.send_message_to_client.assert_called_once()
+        kwargs = conn_mgr.send_message_to_client.call_args.kwargs
+        assert kwargs["client"] == teacher
+        assert kwargs["message"] == conf_call.state.model_dump(by_alias=True)
+
+    @pytest.mark.asyncio
+    async def test_connect_smartphone_seeds_sse_queue(self, mock_services, participants):
+        """With the real SSE manager, the snapshot should be waiting in the queue on connect"""
+        from app.services.smartphone_connection_manager.sse_connection_manager import SSEConnectionManager
+
+        communication_api, storage_manager, _ = mock_services
+        conn_mgr = SSEConnectionManager()
+        conf_call = ConferenceCall(
+            conf_id="sse-snapshot-test",
+            communication_api=communication_api,
+            storage_manager=storage_manager,
+            connection_manager=conn_mgr
+        )
+        teacher_phone, _ = participants
+        conf_call.set_participant_state(teacher_phone, [])
+
+        await conf_call.connect_smartphone()
+
+        queue = conn_mgr.active_connections[teacher_phone]["queue"]
+        assert queue.qsize() == 1
+        assert queue.get_nowait() == conf_call.state.model_dump(by_alias=True)
+
+    @pytest.mark.asyncio
     async def test_smartphone_connection_no_teacher(self, conference_call):
         """Test smartphone operations when no teacher exists"""
         conf_call, _, _, _ = conference_call

--- a/teacher-webapp/src/pages/ClassroomDetail.js
+++ b/teacher-webapp/src/pages/ClassroomDetail.js
@@ -149,6 +149,10 @@ const ClassroomDetail = () => {
 
     const connect = () => {
       if (!isMountedRef.current) return;
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
 
       let eventSource;
       try {
@@ -189,13 +193,14 @@ const ClassroomDetail = () => {
         // While readyState is CONNECTING the browser is already retrying the
         // stream on its own — don't close, or state updates stop for good.
         if (eventSource.readyState !== EventSource.CLOSED) return;
+        // A superseded instance erroring late must not reconnect on top of
+        // the currently active connection.
+        if (eventSourceRef.current !== eventSource) return;
 
         // The browser gave up (handshake failure or non-200 response):
         // recreate the connection ourselves with exponential backoff.
         eventSource.close();
-        if (eventSourceRef.current === eventSource) {
-          eventSourceRef.current = null;
-        }
+        eventSourceRef.current = null;
         scheduleReconnect();
       };
     };

--- a/teacher-webapp/src/pages/ClassroomDetail.js
+++ b/teacher-webapp/src/pages/ClassroomDetail.js
@@ -59,6 +59,8 @@ const ClassroomDetail = () => {
   const [selectedLeaderForCall, setSelectedLeaderForCall] = useState(null);
   const eventSourceRef = useRef(null);
   const isMountedRef = useRef(true);
+  const sseRetryTimerRef = useRef(null);
+  const sseLostToastShownRef = useRef(false);
 
   const {
     selectedStudents,
@@ -129,10 +131,43 @@ const ClassroomDetail = () => {
       return;
     }
 
-    try {
-      const sseEp = SSE_ENDPOINTS.CONFERENCE.TEACHER_CONNECT(conferenceId);
-      const eventSource = new EventSource(sseEp);
+    let retryDelayMs = 1000;
+    const MAX_RETRY_DELAY_MS = 30000;
+
+    const scheduleReconnect = () => {
+      if (!isMountedRef.current || sseRetryTimerRef.current) return;
+      if (!sseLostToastShownRef.current) {
+        sseLostToastShownRef.current = true;
+        showToast.error("Connection to class lost. Reconnecting…");
+      }
+      sseRetryTimerRef.current = setTimeout(() => {
+        sseRetryTimerRef.current = null;
+        connect();
+      }, retryDelayMs);
+      retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
+    };
+
+    const connect = () => {
+      if (!isMountedRef.current) return;
+
+      let eventSource;
+      try {
+        const sseEp = SSE_ENDPOINTS.CONFERENCE.TEACHER_CONNECT(conferenceId);
+        eventSource = new EventSource(sseEp);
+      } catch (error) {
+        console.error("Error setting up SSE connection:", error);
+        scheduleReconnect();
+        return;
+      }
       eventSourceRef.current = eventSource;
+
+      eventSource.onopen = () => {
+        retryDelayMs = 1000;
+        if (sseLostToastShownRef.current) {
+          sseLostToastShownRef.current = false;
+          showToast.success("Reconnected to class");
+        }
+      };
 
       eventSource.onmessage = (event) => {
         // Only process if component is still mounted
@@ -151,21 +186,33 @@ const ClassroomDetail = () => {
 
       eventSource.onerror = (err) => {
         console.error("SSE Error:", err);
-        if (eventSourceRef.current) {
-          eventSourceRef.current.close();
+        // While readyState is CONNECTING the browser is already retrying the
+        // stream on its own — don't close, or state updates stop for good.
+        if (eventSource.readyState !== EventSource.CLOSED) return;
+
+        // The browser gave up (handshake failure or non-200 response):
+        // recreate the connection ourselves with exponential backoff.
+        eventSource.close();
+        if (eventSourceRef.current === eventSource) {
           eventSourceRef.current = null;
         }
+        scheduleReconnect();
       };
-    } catch (error) {
-      console.error("Error setting up SSE connection:", error);
-    }
+    };
+
+    connect();
 
     // Cleanup on unmount or when conference ends
     return () => {
+      if (sseRetryTimerRef.current) {
+        clearTimeout(sseRetryTimerRef.current);
+        sseRetryTimerRef.current = null;
+      }
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
+      sseLostToastShownRef.current = false;
     };
   }, [conferenceStarted, conferenceId, handleSSEEvent]);
 


### PR DESCRIPTION
## Problem

Live classes start smooth then degrade: the teacher webapp closed its EventSource permanently on the first SSE error (`ClassroomDetail.js` `onerror` called `.close()`). One network blip mid-class meant zero state updates for the rest of the session — audio player never appeared, mute/unmute looked broken, UI seemed laggy.

A second gap compounded it: the server sends nothing on SSE connect, so even a reconnected client stayed stale until the next conference event happened to fire.

## Fix

- **teacher-webapp/src/pages/ClassroomDetail.js**: don't close the EventSource while the browser is natively retrying (`readyState === CONNECTING`); when the browser gives up (`CLOSED`, e.g. handshake failure), recreate the connection with exponential backoff (1s → 30s cap) while the class is active. Toast on connection lost/reconnected.
- **ConferenceV2/app/services/conference_call.py** `connect_smartphone`: push the full conference state into the client's queue immediately on connect, so a (re)connecting client resyncs instantly. Frontend `handleSSEEvent` already consumes full snapshots idempotently.

## Testing

- `pytest tests/test_conference_call.py` — 33 passed, includes 2 new tests: snapshot sent on connect (mocked manager) and snapshot actually queued in the real `SSEConnectionManager`.
- Manual: `curl -N .../conference/teacherappconnect/{conf_id}` now prints a `data:` line with full state immediately, then heartbeats.
- Browser: devtools offline 5s mid-class → reconnects, snapshot arrives, mute updates flow again (previously froze permanently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smartphone clients now receive current conference state immediately upon connection instead of waiting for the next event.
  * Enhanced SSE reconnection handling with exponential backoff retry logic and improved error recovery.

* **Tests**
  * Added unit tests for smartphone connection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->