### PR TITLE
fix(conference): event-queue hardening — retry timeouts, resync state on dropped events

### DIFF
--- a/ConferenceV2/app/services/conference_call.py
+++ b/ConferenceV2/app/services/conference_call.py
@@ -297,19 +297,49 @@ class ConferenceCall:
         await self.communication_api.reconnect_websocket()
     
     # Dequeue function: runs continuously to process tasks
-    async def __process_conf_events_queue(self, timeout: float = 15.0):
+    # The timeout must exceed VONAGE_CALL_TIMEOUT_SECONDS (30s) — an event
+    # wrapping a Vonage call needs room for the call's own timeout (and one
+    # internal retry) to fire and run its clean failure path; a shorter queue
+    # timeout would kill the handler mid-flight instead.
+    async def __process_conf_events_queue(self, timeout: float = 65.0):
         while True:
             event: ConferenceEvent = await self.event_queue.get()
             try:
-                # Attempt to execute the event with a timeout
-                await asyncio.wait_for(event.execute_event(), timeout=timeout)
-            except asyncio.TimeoutError:
-                # Handle the timeout (e.g., log a warning, skip, etc.)
-                logger_instance.info(f"Event {event} execution timed out and was skipped.")
-            except Exception as e:
-                logger_instance.error(f"Error executing event {event} : ", e)
-                traceback_str = ''.join(traceback.format_tb(e.__traceback__))
-                logger_instance.error("Traceback:\n%s", traceback_str)
+                failed = False
+                try:
+                    # Attempt to execute the event with a timeout
+                    await asyncio.wait_for(event.execute_event(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    # Retry once, inline, so ordering relative to later events
+                    # is preserved. Only timeouts are retried: handlers are
+                    # state-idempotent, while exceptions (e.g. a Vonage 400 on
+                    # a stale leg) are deterministic and would just fail again.
+                    logger_instance.warning(
+                        f"Event {event} execution timed out; retrying once."
+                    )
+                    try:
+                        await asyncio.wait_for(event.execute_event(), timeout=timeout)
+                    except asyncio.TimeoutError:
+                        logger_instance.error(
+                            f"Event {event} timed out twice and was dropped."
+                        )
+                        failed = True
+                except Exception as e:
+                    logger_instance.error(f"Error executing event {event} : ", e)
+                    traceback_str = ''.join(traceback.format_tb(e.__traceback__))
+                    logger_instance.error("Traceback:\n%s", traceback_str)
+                    failed = True
+
+                if failed:
+                    # A dropped event usually means its terminal update_state()
+                    # never ran — push the current truthful state so the
+                    # frontend doesn't stay stuck on an optimistic assumption.
+                    try:
+                        await self.update_state()
+                    except Exception as e:
+                        logger_instance.error(
+                            f"Failed to push state after dropped event {event}: {e}"
+                        )
             finally:
                 # Mark the task as done to release the queue item
                 self.event_queue.task_done()

--- a/ConferenceV2/tests/test_conference_call.py
+++ b/ConferenceV2/tests/test_conference_call.py
@@ -33,13 +33,16 @@ from app.models.audio_content_state import ContentStatus
 
 class MockEvent(ConferenceEvent):
     """Mock event for testing"""
-    def __init__(self, should_raise_exception=False, should_timeout=False):
+    def __init__(self, should_raise_exception=False, should_timeout=False, timeout_first_n=0):
         self.executed = False
+        self.attempts = 0
         self.should_raise_exception = should_raise_exception
         self.should_timeout = should_timeout
-    
+        self.timeout_first_n = timeout_first_n
+
     async def execute_event(self):
-        if self.should_timeout:
+        self.attempts += 1
+        if self.should_timeout or self.attempts <= self.timeout_first_n:
             await asyncio.sleep(60)
         if self.should_raise_exception:
             raise Exception("Test exception")
@@ -250,24 +253,88 @@ class TestConferenceCall:
         await conf_call.event_queue.put(event)
         
         with patch('app.services.conference_call.logger_instance') as mock_logger:
-            # For timeout test, use a short timeout to make the test run fast
+            # For timeout test, use a short timeout to make the test run fast.
+            # A timed-out event is retried once, so allow two timeout windows.
             if event_type == "timeout":
                 conf_call.event_queue_processing_task = asyncio.create_task(
-                    conf_call._ConferenceCall__process_conf_events_queue(timeout=1.0)
+                    conf_call._ConferenceCall__process_conf_events_queue(timeout=0.3)
                 )
-                wait_time = 1.5
+                wait_time = 1.0
             else:
                 conf_call.start_processing_conf_events_from_queue()
                 wait_time = 0.1
 
             await asyncio.sleep(wait_time)
-            
+
             conf_call.end_processing_conf_events_from_queue()
-            
+
             assert event.executed == expected_executed
             if should_log:
-                assert mock_logger.error.called or mock_logger.info.called
+                assert mock_logger.error.called or mock_logger.warning.called
     
+    @pytest.mark.asyncio
+    async def test_event_timeout_retried_once_then_succeeds(self, conference_call):
+        """An event that times out on the first attempt should succeed on retry"""
+        conf_call, _, _, _ = conference_call
+        event = MockEvent(timeout_first_n=1)
+        await conf_call.event_queue.put(event)
+
+        conf_call.event_queue_processing_task = asyncio.create_task(
+            conf_call._ConferenceCall__process_conf_events_queue(timeout=0.3)
+        )
+        await asyncio.sleep(0.7)
+        conf_call.end_processing_conf_events_from_queue()
+
+        assert event.attempts == 2
+        assert event.executed is True
+
+    @pytest.mark.asyncio
+    async def test_event_dropped_after_double_timeout_pushes_state(self, conference_call):
+        """After a double timeout the event is dropped and state is resynced"""
+        conf_call, _, _, conn_mgr = conference_call
+        event = MockEvent(should_timeout=True)
+        await conf_call.event_queue.put(event)
+
+        conf_call.event_queue_processing_task = asyncio.create_task(
+            conf_call._ConferenceCall__process_conf_events_queue(timeout=0.3)
+        )
+        await asyncio.sleep(1.0)
+        conf_call.end_processing_conf_events_from_queue()
+
+        assert event.attempts == 2
+        assert event.executed is False
+        conn_mgr.send_message_to_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_event_exception_not_retried_pushes_state(self, conference_call):
+        """Exceptions are deterministic: no retry, but state is still resynced"""
+        conf_call, _, _, conn_mgr = conference_call
+        event = MockEvent(should_raise_exception=True)
+        await conf_call.event_queue.put(event)
+
+        conf_call.start_processing_conf_events_from_queue()
+        await asyncio.sleep(0.2)
+        conf_call.end_processing_conf_events_from_queue()
+
+        assert event.attempts == 1
+        assert event.executed is False
+        conn_mgr.send_message_to_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_queue_continues_after_dropped_event(self, conference_call):
+        """A dropped event must not stall the events queued behind it"""
+        conf_call, _, _, _ = conference_call
+        bad_event = MockEvent(should_raise_exception=True)
+        good_event = MockEvent()
+        await conf_call.event_queue.put(bad_event)
+        await conf_call.event_queue.put(good_event)
+
+        conf_call.start_processing_conf_events_from_queue()
+        await asyncio.sleep(0.3)
+        conf_call.end_processing_conf_events_from_queue()
+
+        assert good_event.executed is True
+
     @pytest.mark.asyncio
     async def test_multiple_events_processing(self, conference_call):
         """Test processing multiple events from queue"""


### PR DESCRIPTION
## Problem

`__process_conf_events_queue` ran each event with a 15s timeout and dropped it silently on timeout or exception:

- 15s < the 30s `VONAGE_CALL_TIMEOUT_SECONDS`, so an event wrapping a slow Vonage call was cancelled mid-flight before the Vonage-level timeout (#225) could run its clean failure path.
- A dropped event never reached its terminal `update_state()`, so no SSE update was sent — the frontend stayed stuck showing stale mute/participant state.

## Fix

- Per-event timeout 15s → 65s (> 2× Vonage timeout) so the inner timeout fires first and the handler's log-and-resync path runs.
- Timed-out events are retried once, inline (preserves ordering vs. requeueing). Exceptions are not retried — handlers are state-idempotent and errors like a Vonage 400 on a stale leg are deterministic.
- After a final failure (double timeout or exception), the queue loop pushes the current truthful state so the frontend resyncs.

## Testing

`pytest tests/` — **76 passed**. New tests:
- timeout → retried once → succeeds
- double timeout → dropped + state pushed
- exception → not retried + state pushed
- a dropped event doesn't stall events queued behind it

Completes the reliability series: #224 (SSE reconnect + snapshot), #225 (Vonage timeouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)