### PR TITLE
Migrate language fields to ISO 639-1 codes.

### DIFF
--- a/ContentWebApp/src/components/AddQuiz.js
+++ b/ContentWebApp/src/components/AddQuiz.js
@@ -27,7 +27,7 @@ const AddQuiz = ({ quiz }) => {
     localTitle: "",
     theme: "",
     localTheme: "",
-    language: "kannada",
+    language: "kn",
     positiveMark: 1,
     negativeMark: 0,
   });
@@ -119,11 +119,11 @@ const AddQuiz = ({ quiz }) => {
       // Theme fields expected by backend quiz creation (mirror AddStory behavior)
       theme: metadata.theme,
       localTheme:
-        languageLower === "english" ? metadata.theme : metadata.localTheme,
+        languageLower === "en" ? metadata.theme : metadata.localTheme,
       // Title fields expected by backend quiz creation (mirror AddStory behavior)
       title: metadata.title,
       localTitle:
-        languageLower === "english" ? metadata.title : metadata.localTitle,
+        languageLower === "en" ? metadata.title : metadata.localTitle,
       type: "quiz",
       id: quiz ? (quiz._id || quiz.id) : uuidv4(),
     };
@@ -139,7 +139,7 @@ const AddQuiz = ({ quiz }) => {
       valid = false;
       alert("Title cannot be empty");
     } else if (
-      languageLower !== "english" &&
+      languageLower !== "en" &&
       metadata.localTitle.length === 0
     ) {
       valid = false;
@@ -151,7 +151,7 @@ const AddQuiz = ({ quiz }) => {
       valid = false;
       alert("Language cannot be empty");
     } else if (
-      languageLower !== "english" &&
+      languageLower !== "en" &&
       metadata.localTheme.length === 0
     ) {
       valid = false;
@@ -235,17 +235,19 @@ const AddQuiz = ({ quiz }) => {
   const getLocalizedLabelPrefix = () => {
     const language = (metadata.language || "").toLowerCase();
     switch (language) {
-      case "kannada":
+      case "kn":
         return "Kannada";
-      case "hindi":
+      case "hi":
         return "Hindi";
-      case "marathi":
+      case "mr":
         return "Marathi";
-      case "tamil":
+      case "ta":
         return "Tamil";
-      case "bengali":
+      case "bn":
         return "Bengali";
-      case "english":
+      case "or":
+        return "Odia";
+      case "en":
       default:
         return "Local";
     }
@@ -264,13 +266,13 @@ const AddQuiz = ({ quiz }) => {
               className="mintgreen"
               style={{ width: "200px" }}
             >
-              <option value="kannada">Kannada</option>
-              <option value="hindi">Hindi</option>
-              <option value="marathi">Marathi</option>
-              <option value="odia">Odia</option>
-              <option value="english">English</option>
-              <option value="tamil">Tamil</option>
-              <option value="bengali">Bengali</option>
+              <option value="kn">Kannada</option>
+              <option value="hi">Hindi</option>
+              <option value="mr">Marathi</option>
+              <option value="or">Odia</option>
+              <option value="en">English</option>
+              <option value="ta">Tamil</option>
+              <option value="bn">Bengali</option>
             </select>
           </label>
         </div>
@@ -301,7 +303,7 @@ const AddQuiz = ({ quiz }) => {
           />
         </div>
 
-        {metadata.language.toLowerCase() !== "english" && (
+        {metadata.language.toLowerCase() !== "en" && (
           <>
             <div>
               <label>{`${getLocalizedLabelPrefix()} Title`}</label>

--- a/ContentWebApp/src/components/AddStory.js
+++ b/ContentWebApp/src/components/AddStory.js
@@ -7,6 +7,7 @@ import { getAuthHeaders } from "../utils/authHelpers";
 import { useAuth } from "../hooks/useAuth";
 import { isMp3File } from "../utils/fileValidators";
 import { contentService } from "../services/contentService";
+import { getLanguageLabel } from "../utils/languageUtils";
 
 const AddStory = ({ content, contentType, onContentTypeChange }) => {
   const { getCurrentUser } = useAuth();
@@ -14,7 +15,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
     id: "",
     type: "Story",
     description: "",
-    language: "kannada",
+    language: "kn",
     title: { english: "", local: "", audioUrl: "" },
     theme: { english: "", local: "", audioUrl: "" },
     audioContent: [],
@@ -151,11 +152,11 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
         id: content.id,
         type: content.type || "Story",
         description: content.description || "",
-        language: (content.language || "kannada").toLowerCase(),
+        language: (content.language || "kn").toLowerCase(),
         title: {
           english: content.title?.english || "",
           local:
-            (content.language || "").toLowerCase() === "english"
+            (content.language || "").toLowerCase() === "en"
               ? content.title?.english || ""
               : content.title?.local || "",
           audioUrl: content.title?.audioUrl || "",
@@ -163,7 +164,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
         theme: {
           english: content.theme?.english || "",
           local:
-            (content.language || "").toLowerCase() === "english"
+            (content.language || "").toLowerCase() === "en"
               ? content.theme?.english || ""
               : content.theme?.local || "",
           audioUrl: content.theme?.audioUrl || "",
@@ -216,7 +217,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
     }
     // When language is not English, local theme is also required
     else if (
-      languageLower !== "english" &&
+      languageLower !== "en" &&
       (!metadata.theme.local || metadata.theme.local === "new-theme")
     ) {
       alert("Local theme cannot be empty");
@@ -231,7 +232,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
       valid = false;
     }
     //Check that localTitle is not empty if language is not english
-    else if (languageLower !== "english" && !metadata.title.local) {
+    else if (languageLower !== "en" && !metadata.title.local) {
       alert("Local Title cannot be empty");
       valid = false;
     }
@@ -270,12 +271,12 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
       type: contentType,
       title: {
         english: metadata.title.english,
-        local: languageLower === "english" ? metadata.title.english : metadata.title.local,
+        local: languageLower === "en" ? metadata.title.english : metadata.title.local,
         audioUrl: metadata.title.audioUrl,
       },
       theme: {
         english: metadata.theme.english,
-        local: languageLower === "english" ? metadata.theme.english : metadata.theme.local,
+        local: languageLower === "en" ? metadata.theme.english : metadata.theme.local,
         audioUrl: metadata.theme.audioUrl,
       },
     };
@@ -452,13 +453,13 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
           className="mintgreen"
           style={{ width: "100%", maxWidth: "300px", padding: "8px" }}
         >
-          <option value="kannada">Kannada</option>
-          <option value="hindi">Hindi</option>
-          <option value="marathi">Marathi</option>
-          <option value="odia">Odia</option>
-          <option value="english">English</option>
-          <option value="tamil">Tamil</option>
-          <option value="bengali">Bengali</option>
+          <option value="kn">Kannada</option>
+          <option value="hi">Hindi</option>
+          <option value="mr">Marathi</option>
+          <option value="or">Odia</option>
+          <option value="en">English</option>
+          <option value="ta">Tamil</option>
+          <option value="bn">Bengali</option>
         </select>
       </div>
 
@@ -466,7 +467,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
         style={{
           display: "grid",
           gridTemplateColumns:
-            metadata.language === "english" ? "1fr" : "1fr 1fr",
+            metadata.language === "en" ? "1fr" : "1fr 1fr",
           gap: "20px",
           marginBottom: "25px",
         }}
@@ -499,7 +500,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
             </option>
           </select>
         </div>
-        {metadata.language !== "english" && (
+        {metadata.language !== "en" && (
           <div>
             <label
               style={{
@@ -509,7 +510,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
                 textTransform: "capitalize",
               }}
             >
-              {metadata.language} Theme
+              {getLanguageLabel(metadata.language)} Theme
             </label>
             <select
               name="localTheme"
@@ -550,9 +551,9 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
                 placeholder="Enter new theme in English"
               />
             </div>
-            {metadata.language !== "english" && (
+            {metadata.language !== "en" && (
               <div className="form-group">
-                <label className="form-label form-label-required">New {metadata.language.charAt(0).toUpperCase() + metadata.language.slice(1)} Theme</label>
+                <label className="form-label form-label-required">New {getLanguageLabel(metadata.language)} Theme</label>
                 <input
                   type="text"
                   value={metadata.theme.local}
@@ -563,7 +564,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
                     })
                   }
                   className="form-input"
-                  placeholder={`Enter new theme in ${metadata.language}`}
+                  placeholder={`Enter new theme in ${getLanguageLabel(metadata.language)}`}
                 />
               </div>
             )}
@@ -587,14 +588,14 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
               }
             />
           </div>
-          {metadata.language !== "english" && (
+          {metadata.language !== "en" && (
             <div className="form-group">
-              <label className="form-label form-label-required">{metadata.language.charAt(0).toUpperCase() + metadata.language.slice(1)} Title</label>
+              <label className="form-label form-label-required">{getLanguageLabel(metadata.language)} Title</label>
               <input
                 type="text"
                 name="titleLocal"
                 className="form-input"
-                placeholder={`Enter title in ${metadata.language}`}
+                placeholder={`Enter title in ${getLanguageLabel(metadata.language)}`}
                 value={metadata.title.local}
                 onChange={(event) =>
                   setMetadata({ ...metadata, title: { ...metadata.title, local: event.target.value } })
@@ -608,7 +609,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
       {Object.keys(titlesUnderTheme).length > 0 && !newTheme && (
         <div className="existing-titles">
           <label className="existing-titles-label">
-            Existing Titles under "{metadata.theme.english}" in {metadata.language}:
+            Existing Titles under "{metadata.theme.english}" in {getLanguageLabel(metadata.language)}:
           </label>
           <ul className="existing-titles-list">
             {Object.entries(titlesUnderTheme).map(([englishTitle, localTitle], index) => (

--- a/ContentWebApp/src/utils/filterHelpers.js
+++ b/ContentWebApp/src/utils/filterHelpers.js
@@ -1,3 +1,5 @@
+import { getLanguageLabel } from "./languageUtils";
+
 /**
  * Generate filter options from content list
  * @param {Array} contentList - Array of content items
@@ -7,14 +9,14 @@ export const generateFilterOptions = (contentList) => {
   if (!Array.isArray(contentList)) {
     throw new Error("generateFilterOptions: contentList must be an array");
   }
-  
+
   const languageSet = new Set();
   const experienceSet = new Set();
 
   contentList.forEach((contentItem) => {
     if (!contentItem) return;
     if (contentItem.language) {
-      languageSet.add(contentItem.language.charAt(0).toUpperCase() + contentItem.language.slice(1));
+      languageSet.add(getLanguageLabel(contentItem.language));
     }
     if (contentItem.type) {
       experienceSet.add(contentItem.type.charAt(0).toUpperCase() + contentItem.type.slice(1));
@@ -47,15 +49,15 @@ export const applyFilters = (allContent, selectedFilters, allOptions) => {
   if (!Array.isArray(allContent)) {
     throw new Error("applyFilters: allContent must be an array");
   }
-  
+
   if (!Array.isArray(selectedFilters)) {
     selectedFilters = [];
   }
-  
+
   if (!Array.isArray(allOptions)) {
     allOptions = [];
   }
-  
+
   let langs = selectedFilters
     .filter((option) => option && option.category === "Language")
     .map((option) => option.name.toLowerCase());
@@ -83,7 +85,7 @@ export const applyFilters = (allContent, selectedFilters, allOptions) => {
       contentItem &&
       contentItem.language &&
       contentItem.type &&
-      langs.includes(contentItem.language.toLowerCase()) &&
+      langs.includes(getLanguageLabel(contentItem.language).toLowerCase()) &&
       exps.includes(contentItem.type.toLowerCase())
   );
 };

--- a/ContentWebApp/src/utils/languageUtils.js
+++ b/ContentWebApp/src/utils/languageUtils.js
@@ -1,0 +1,21 @@
+export const LANGUAGE_LABELS = {
+  en: "English",
+  kn: "Kannada",
+  hi: "Hindi",
+  bn: "Bengali",
+  ta: "Tamil",
+  mr: "Marathi",
+  or: "Odia",
+};
+
+/**
+ * Returns the human-readable display label for an ISO 639-1 language code.
+ * Falls back to capitalizing the code if unmapped (e.g. "xx" → "Xx").
+ */
+export const getLanguageLabel = (iso) => {
+  if (!iso) return "";
+  return (
+    LANGUAGE_LABELS[iso.toLowerCase()] ||
+    iso.charAt(0).toUpperCase() + iso.slice(1).toLowerCase()
+  );
+};

--- a/ContentWebApp/tests/components/AddQuiz.test.js
+++ b/ContentWebApp/tests/components/AddQuiz.test.js
@@ -70,7 +70,7 @@ describe("AddQuiz", () => {
   it("populates fields when quiz prop is provided", () => {
     const quiz = {
       title: "Sample Quiz",
-      language: "english",
+      language: "en",
       positiveMarks: 2,
       negativeMarks: 1,
       questions: [
@@ -106,7 +106,7 @@ describe("AddQuiz", () => {
     // Check that the correct language option is selected by checking the selected option's text
     const select = screen.getByRole("combobox");
     const selectedOption = select.options[select.selectedIndex];
-    expect(selectedOption.value).toBe("english");
+    expect(selectedOption.value).toBe("en");
     expect(selectedOption.textContent.toLowerCase()).toBe("english");
     expect(screen.getByDisplayValue("2")).toBeInTheDocument();
     expect(screen.getByDisplayValue("1")).toBeInTheDocument();

--- a/ContentWebApp/tests/utils/filterHelpers.test.js
+++ b/ContentWebApp/tests/utils/filterHelpers.test.js
@@ -7,10 +7,10 @@ describe("filterHelpers", () => {
   describe("generateFilterOptions", () => {
     it("should generate filter options from content list", () => {
       const contentList = [
-        { type: "story", language: "english" },
-        { type: "quiz", language: "kannada" },
-        { type: "poem", language: "english" },
-        { type: "quiz", language: "hindi" },
+        { type: "story", language: "en" },
+        { type: "quiz", language: "kn" },
+        { type: "poem", language: "en" },
+        { type: "quiz", language: "hi" },
       ];
 
       const options = generateFilterOptions(contentList);
@@ -18,13 +18,12 @@ describe("filterHelpers", () => {
       expect(options).toBeInstanceOf(Array);
       expect(options.length).toBeGreaterThan(0);
 
-      // Check for language options
+      // generateFilterOptions returns display labels via getLanguageLabel()
       const languageOptions = options.filter((opt) => opt.category === "Language");
       expect(languageOptions.length).toBeGreaterThan(0);
-      expect(languageOptions.some((opt) => opt.name.toLowerCase() === "english")).toBe(true);
-      expect(languageOptions.some((opt) => opt.name.toLowerCase() === "kannada")).toBe(true);
+      expect(languageOptions.some((opt) => opt.name === "English")).toBe(true);
+      expect(languageOptions.some((opt) => opt.name === "Kannada")).toBe(true);
 
-      // Check for type/experience options
       const experienceOptions = options.filter((opt) => opt.category === "Experience");
       expect(experienceOptions.length).toBeGreaterThan(0);
       expect(experienceOptions.some((opt) => opt.name.toLowerCase() === "quiz")).toBe(true);
@@ -33,8 +32,8 @@ describe("filterHelpers", () => {
 
     it("should include quiz type in filter options", () => {
       const contentList = [
-        { type: "quiz", language: "kannada" },
-        { type: "story", language: "english" },
+        { type: "quiz", language: "kn" },
+        { type: "story", language: "en" },
       ];
 
       const options = generateFilterOptions(contentList);
@@ -53,26 +52,26 @@ describe("filterHelpers", () => {
 
     it("should handle content items without type or language", () => {
       const contentList = [
-        { type: "quiz", language: "kannada" },
+        { type: "quiz", language: "kn" },
         { type: "story" }, // missing language
-        { language: "english" }, // missing type
+        { language: "en" }, // missing type
         {}, // missing both
       ];
 
       const options = generateFilterOptions(contentList);
-      // Should still generate options for items that have the fields
       expect(options.length).toBeGreaterThan(0);
     });
   });
 
   describe("applyFilters", () => {
     const mockContent = [
-      { id: "1", type: "quiz", language: "kannada", title: "Quiz 1" },
-      { id: "2", type: "quiz", language: "english", title: "Quiz 2" },
-      { id: "3", type: "story", language: "kannada", title: "Story 1" },
-      { id: "4", type: "poem", language: "english", title: "Poem 1" },
+      { id: "1", type: "quiz", language: "kn", title: "Quiz 1" },
+      { id: "2", type: "quiz", language: "en", title: "Quiz 2" },
+      { id: "3", type: "story", language: "kn", title: "Story 1" },
+      { id: "4", type: "poem", language: "en", title: "Poem 1" },
     ];
 
+    // Filter chips use display labels (e.g. "Kannada", "English")
     const mockOptions = [
       { category: "Language", name: "Kannada", id: 1 },
       { category: "Language", name: "English", id: 2 },
@@ -94,7 +93,7 @@ describe("filterHelpers", () => {
       expect(filtered.some((item) => item.id === "2")).toBe(true);
     });
 
-    it("should filter by language", () => {
+    it("should filter by language (Kannada)", () => {
       const selectedFilters = [
         { category: "Language", name: "Kannada", id: 1 },
       ];
@@ -102,7 +101,7 @@ describe("filterHelpers", () => {
       const filtered = applyFilters(mockContent, selectedFilters, mockOptions);
 
       expect(filtered.length).toBe(2);
-      expect(filtered.every((item) => item.language.toLowerCase() === "kannada")).toBe(true);
+      expect(filtered.every((item) => item.language === "kn")).toBe(true);
       expect(filtered.some((item) => item.id === "1")).toBe(true);
       expect(filtered.some((item) => item.id === "3")).toBe(true);
     });
@@ -118,16 +117,11 @@ describe("filterHelpers", () => {
       expect(filtered.length).toBe(1);
       expect(filtered[0].id).toBe("1");
       expect(filtered[0].type.toLowerCase()).toBe("quiz");
-      expect(filtered[0].language.toLowerCase()).toBe("kannada");
+      expect(filtered[0].language).toBe("kn");
     });
 
     it("should return all content when no filters selected", () => {
       const filtered = applyFilters(mockContent, [], mockOptions);
-
-      // applyFilters filters out items missing type or language fields
-      // It also requires items to match available options
-      // All items in mockContent have both fields and match options, so all should be returned
-      // Note: The function filters items that don't have both type AND language
       const itemsWithBothFields = mockContent.filter(
         (item) => item.type && item.language
       );
@@ -135,46 +129,24 @@ describe("filterHelpers", () => {
       expect(filtered.every((item) => item.type && item.language)).toBe(true);
     });
 
-    it("should handle case-insensitive filtering", () => {
-      const contentWithMixedCase = [
-        { id: "1", type: "QUIZ", language: "KANNADA", title: "Quiz 1" },
-        { id: "2", type: "quiz", language: "kannada", title: "Quiz 2" },
-      ];
-
-      const selectedFilters = [
-        { category: "Experience", name: "Quiz", id: 3 },
-        { category: "Language", name: "Kannada", id: 1 },
-      ];
-
-      const filtered = applyFilters(contentWithMixedCase, selectedFilters, mockOptions);
-
-      expect(filtered.length).toBe(2);
-    });
-
     it("should handle empty content list", () => {
       const filtered = applyFilters([], [], mockOptions);
       expect(filtered).toEqual([]);
     });
 
-    it("should filter quiz items correctly", () => {
+    it("should filter quiz items correctly (experience only)", () => {
       const quizContent = [
-        { id: "q1", type: "quiz", language: "kannada", title: "Math Quiz" },
-        { id: "q2", type: "quiz", language: "english", title: "Science Quiz" },
-        { id: "s1", type: "story", language: "kannada", title: "Story" },
+        { id: "q1", type: "quiz", language: "kn", title: "Math Quiz" },
+        { id: "q2", type: "quiz", language: "en", title: "Science Quiz" },
+        { id: "s1", type: "story", language: "kn", title: "Story" },
       ];
 
-      const selectedFilters = [
-        { category: "Experience", name: "Quiz", id: 3 },
-      ];
+      const selectedFilters = [{ category: "Experience", name: "Quiz", id: 3 }];
 
       const filtered = applyFilters(quizContent, selectedFilters, mockOptions);
 
       expect(filtered.length).toBe(2);
       expect(filtered.every((item) => item.type.toLowerCase() === "quiz")).toBe(true);
-      expect(filtered.some((item) => item.id === "q1")).toBe(true);
-      expect(filtered.some((item) => item.id === "q2")).toBe(true);
-      expect(filtered.some((item) => item.id === "s1")).toBe(false);
     });
   });
 });
-

--- a/IVRv2/app/fsm/insti.py
+++ b/IVRv2/app/fsm/insti.py
@@ -52,6 +52,7 @@ from app.fsm.ivr_constants import (
     quiz_new,
 )
 from app.fsm.ivr_utils import get_content
+from app.utils.ivr_utils import get_blob_language_name
 from app.core.database import MongoDBCollection
 from app.settings import settings
 load_dotenv()
@@ -173,11 +174,12 @@ def handle_type(filtered_content, speechRate, parent_selections):
     sorted_categories = []
     sorted_keys = []
     language = parent_selections.get("language", settings.default_welcome_language)
+    blob_lang = get_blob_language_name(language)
     for exp in experiences:
         # Retrieve the URL template from the global mapping.
         template_url = experienceDialogAudioUrls[exp]
         # Replace the placeholders with the actual language and speechRate.
-        audio_url = template_url.replace("{language}", language).replace(
+        audio_url = template_url.replace("{language}", blob_lang).replace(
             "{speechRate}", str(speechRate)
         )
         values_to_urls[exp] = audio_url
@@ -250,11 +252,12 @@ attribute_handlers = {
     "title": handle_title,
 }
 
-welcomeToSEEDSUrl = f"https://{settings.storage_account_name}.blob.core.windows.net/pull-model-menus/welcomeDialog/{settings.default_welcome_language}/welcome%20to%20SEEDS/1.0.mp3"
+welcomeToSEEDSUrl = f"https://{settings.storage_account_name}.blob.core.windows.net/pull-model-menus/welcomeDialog/{get_blob_language_name(settings.default_welcome_language)}/welcome%20to%20SEEDS/1.0.mp3"
 
 
 def getKeyPressUrl(key, language, speechRate):
-    replaced_url = pressKeyMessageUrl.replace("{language}", language).replace(
+    blob_lang = get_blob_language_name(language)
+    replaced_url = pressKeyMessageUrl.replace("{language}", blob_lang).replace(
         "{speechRate}", str(speechRate)
     )
     replaced_url = re.sub(r"\{key\}", key, replaced_url)
@@ -282,7 +285,8 @@ def add_nav_action(
       speechRate (str): The speech rate value.
       description (str): The description text to assign for this key.
     """
-    url = pullMenuMainUrl + message_template.replace("{language}", language).replace(
+    blob_lang = get_blob_language_name(language)
+    url = pullMenuMainUrl + message_template.replace("{language}", blob_lang).replace(
         "{speechRate}", str(speechRate)
     )
     actions.append(StreamAction(url))
@@ -335,8 +339,9 @@ def getStreamActions(items_list, sorted_keys, level, state, parent_selections={}
                 parent_selections["type"].lower()
             ]
         if initial_dialog:
+            blob_lang = get_blob_language_name(language)
             dialog_url = pullMenuMainUrl + initial_dialog.replace(
-                "{language}", language
+                "{language}", blob_lang
             ).replace("{speechRate}", str(speechRate))
             actions.append(StreamAction(dialog_url))
 

--- a/IVRv2/app/fsm/ivr_constants.py
+++ b/IVRv2/app/fsm/ivr_constants.py
@@ -12,13 +12,13 @@ headers = {
 }
 
 languageDialogUrls = {
-  'english':'languageDialog/english/For%20English/{speechRate}.mp3',
-  'kannada':'languageDialog/kannada/For%20Kannada/{speechRate}.mp3',
-  'bengali':'languageDialog/bengali/For%20Bengali/{speechRate}.mp3',
-  'hindi':'languageDialog/hindi/For%20Hindi/{speechRate}.mp3',
-  'tamil':'languageDialog/tamil/For%20Tamil/{speechRate}.mp3',
-  'odia':'languageDialog/odia/For%20Odia/{speechRate}.mp3',
-  'marathi':'languageDialog/marathi/For%20Marathi/{speechRate}.mp3',
+  'en':'languageDialog/english/For%20English/{speechRate}.mp3',
+  'kn':'languageDialog/kannada/For%20Kannada/{speechRate}.mp3',
+  'bn':'languageDialog/bengali/For%20Bengali/{speechRate}.mp3',
+  'hi':'languageDialog/hindi/For%20Hindi/{speechRate}.mp3',
+  'ta':'languageDialog/tamil/For%20Tamil/{speechRate}.mp3',
+  'or':'languageDialog/odia/For%20Odia/{speechRate}.mp3',
+  'mr':'languageDialog/marathi/For%20Marathi/{speechRate}.mp3',
 }
 
 speechRate = "1.0"
@@ -109,7 +109,7 @@ content_attributes = [
 
 quiz_new = {
   "id": "e3d1db09-f5fd-44b2-8244-86ea61619175",
-  "language": "kannada",
+  "language": "kn",
   "theme": "water",
   "themeAudio": f"{storage_account_base_url}theme-titles/Water/kannada",
   "title": "Punyakoti",

--- a/IVRv2/app/fsm/pureAudio.py
+++ b/IVRv2/app/fsm/pureAudio.py
@@ -14,7 +14,7 @@ from app.utils.model_classes import Menu
 from app.utils.model_classes import Option
 from app.utils.pure_audio_model_classes import PureAudioData
 from app.utils.duration_announcement import format_duration_announcement
-from app.utils.ivr_utils import get_vonage_language_code
+from app.utils.ivr_utils import get_vonage_language_code, get_blob_language_name
 from app.fsm.operations.daily_limit_pre_operation import DailyLimitPreOperation
 from app.utils.speed_control import get_speed_instruction
 from app.utils.pause_announcement import get_pause_instruction
@@ -52,7 +52,8 @@ class PureAudio:
         actions = []
 
         # Build and add a "going to be played" dialog action.
-        going_to_play_url = audioGoingTobePlayedDialogUrl.replace("{language}", self.language).replace("{speechRate}", self.speechRate)
+        blob_lang = get_blob_language_name(self.language)
+        going_to_play_url = audioGoingTobePlayedDialogUrl.replace("{language}", blob_lang).replace("{speechRate}", self.speechRate)
         actions.append(StreamAction(pullMenuMainUrl + going_to_play_url))
 
         # Add duration announcement if available

--- a/IVRv2/app/settings.py
+++ b/IVRv2/app/settings.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     azure_service_bus_max_retries: int = 3
     mongo_max_pool_size: int = 50
     applicationinsights_connection_string: str = ""
-    default_welcome_language: str = "kannada"
+    default_welcome_language: str = "kn"
     websocket_service_url: str = ""
 
     # Derived Queue names

--- a/IVRv2/app/utils/duration_announcement.py
+++ b/IVRv2/app/utils/duration_announcement.py
@@ -9,34 +9,34 @@ from typing import Optional, Dict
 from app.settings import settings
 
 
-# Duration templates for each language (module-level constant for performance)
+# Duration templates for each language (keyed by ISO 639-1 codes)
 _DURATION_TEMPLATES: Dict[str, Dict[str, str]] = {
-    "kannada": {
+    "kn": {
         "full": "ಈ ವಿಷಯವು {minutes} ನಿಮಿಷ {seconds} ಸೆಕೆಂಡುಗಳ ಅವಧಿಯದ್ದಾಗಿದೆ",
         "minutes_only": "ಈ ವಿಷಯವು {minutes} ನಿಮಿಷಗಳ ಅವಧಿಯದ್ದಾಗಿದೆ",
         "seconds_only": "ಈ ವಿಷಯವು {seconds} ಸೆಕೆಂಡುಗಳ ಅವಧಿಯದ್ದಾಗಿದೆ"
     },
-    "english": {
+    "en": {
         "full": "This content is {minutes} minutes {seconds} seconds long",
         "minutes_only": "This content is {minutes} minutes long",
         "seconds_only": "This content is {seconds} seconds long"
     },
-    "hindi": {
+    "hi": {
         "full": "यह सामग्री {minutes} मिनट {seconds} सेकंड लंबी है",
         "minutes_only": "यह सामग्री {minutes} मिनट लंबी है",
         "seconds_only": "यह सामग्री {seconds} सेकंड लंबी है"
     },
-    "bengali": {
+    "bn": {
         "full": "এই বিষয়বস্তু {minutes} মিনিট {seconds} সেকেন্ড দীর্ঘ",
         "minutes_only": "এই বিষয়বস্তু {minutes} মিনিট দীর্ঘ",
         "seconds_only": "এই বিষয়বস্তু {seconds} সেকেন্ড দীর্ঘ"
     },
-    "tamil": {
+    "ta": {
         "full": "இந்த உள்ளடக்கம் {minutes} நிமிடங்கள் {seconds} விநாடிகள் நீளமானது",
         "minutes_only": "இந்த உள்ளடக்கம் {minutes} நிமிடங்கள் நீளமானது",
         "seconds_only": "இந்த உள்ளடக்கம் {seconds} விநாடிகள் நீளமானது"
     },
-    "marathi": {
+    "mr": {
         "full": "ही सामग्री {minutes} मिनिटे {seconds} सेकंद लांब आहे",
         "minutes_only": "ही सामग्री {minutes} मिनिटे लांब आहे",
         "seconds_only": "ही सामग्री {seconds} सेकंद लांब आहे"
@@ -44,12 +44,12 @@ _DURATION_TEMPLATES: Dict[str, Dict[str, str]] = {
 }
 
 _DAILY_LIMIT_TEMPLATES: Dict[str, str] = {
-    "kannada": "ನೀವು ಇಂದಿನ ದೈನಂದಿನ ಆಲಿಸುವ ಮಿತಿಯನ್ನು ತಲುಪಿದ್ದೀರಿ. ದಯವಿಟ್ಟು ನಾಳೆ ಮತ್ತೆ ಕರೆ ಮಾಡಿ.",
-    "english": "You have reached your daily listening limit. Please call back tomorrow.",
-    "hindi": "आपने अपनी दैनिक सुनने की सीमा पूरी कर ली है। कृपया कल फिर से कॉल करें।",
-    "bengali": "আপনি আজকের শোনার সীমায় পৌঁছে গেছেন। দয়া করে আগামীকাল আবার কল করুন।",
-    "tamil": "நீங்கள் இன்றைய கேட்கும் வரம்பை எட்டிவிட்டீர்கள். தயவுசெய்து நாளை மீண்டும் அழைக்கவும்.",
-    "marathi": "तुम्ही आजची ऐकण्याची मर्यादा गाठली आहे. कृपया उद्या पुन्हा कॉल करा."
+    "kn": "ನೀವು ಇಂದಿನ ದೈನಂದಿನ ಆಲಿಸುವ ಮಿತಿಯನ್ನು ತಲುಪಿದ್ದೀರಿ. ದಯವಿಟ್ಟು ನಾಳೆ ಮತ್ತೆ ಕರೆ ಮಾಡಿ.",
+    "en": "You have reached your daily listening limit. Please call back tomorrow.",
+    "hi": "आपने अपनी दैनिक सुनने की सीमा पूरी कर ली है। कृपया कल फिर से कॉल करें।",
+    "bn": "আপনি আজকের শোনার সীমায় পৌঁছে গেছেন। দয়া করে আগামীকাল আবার কল করুন।",
+    "ta": "நீங்கள் இன்றைய கேட்கும் வரம்பை எட்டிவிட்டீர்கள். தயவுசெய்து நாளை மீண்டும் அழைக்கவும்.",
+    "mr": "तुम्ही आजची ऐकण्याची मर्यादा गाठली आहे. कृपया उद्या पुन्हा कॉल करा."
 }
 
 
@@ -57,7 +57,7 @@ def get_daily_limit_announcement(language: str) -> str:
     """Get the daily limit reached announcement in the specified language.
 
     Args:
-        language: Language code (kannada, english, hindi, bengali, tamil, marathi)
+        language: ISO 639-1 code (e.g. "kn", "en", "hi", "bn", "ta", "mr")
 
     Returns:
         Limit announcement text in the specified language, falls back to default language.
@@ -71,19 +71,19 @@ def format_duration_announcement(duration_seconds: Optional[float], language: st
 
     Args:
         duration_seconds: Duration in seconds (can be None for backwards compatibility)
-        language: Language code (kannada, english, hindi, bengali, tamil, marathi)
+        language: ISO 639-1 code (e.g. "kn", "en", "hi", "bn", "ta", "mr")
 
     Returns:
         Formatted duration announcement text, or empty string if duration is None
 
     Examples:
-        >>> format_duration_announcement(270, "english")
+        >>> format_duration_announcement(270, "en")
         "This content is 4 minutes 30 seconds long"
 
-        >>> format_duration_announcement(65, "kannada")
+        >>> format_duration_announcement(65, "kn")
         "ಈ ವಿಷಯವು 1 ನಿಮಿಷ 5 ಸೆಕೆಂಡುಗಳ ಅವಧಿಯದ್ದಾಗಿದೆ"
 
-        >>> format_duration_announcement(None, "english")
+        >>> format_duration_announcement(None, "en")
         ""
     """
     # Handle None or invalid duration (backwards compatibility)
@@ -95,7 +95,7 @@ def format_duration_announcement(duration_seconds: Optional[float], language: st
     seconds = int(duration_seconds % 60)
 
     # Get templates for language (fallback to English for unsupported languages)
-    lang_templates = _DURATION_TEMPLATES.get(language, _DURATION_TEMPLATES["english"])
+    lang_templates = _DURATION_TEMPLATES.get(language, _DURATION_TEMPLATES["en"])
 
     # Select appropriate template based on duration
     if minutes > 0 and seconds > 0:

--- a/IVRv2/app/utils/ivr_utils.py
+++ b/IVRv2/app/utils/ivr_utils.py
@@ -5,35 +5,59 @@ IVR utility functions for language and configuration mapping.
 from typing import Dict
 
 
-# Language mapping for Vonage TTS codes (module-level constant for performance)
+# Language mapping for Vonage TTS codes (keyed by ISO 639-1 codes)
 _LANGUAGE_MAPPING: Dict[str, str] = {
-    "kannada": "kn-IN",
-    "english": "en-US",
-    "hindi": "hi-IN",
-    "bengali": "bn-IN",
-    "tamil": "ta-IN",
-    "marathi": "mr-IN"
+    "kn": "kn-IN",
+    "en": "en-US",
+    "hi": "hi-IN",
+    "bn": "bn-IN",
+    "ta": "ta-IN",
+    "mr": "mr-IN",
+}
+
+# Reverse mapping: ISO 639-1 code → Azure blob folder name
+_ISO_TO_BLOB_NAME: Dict[str, str] = {
+    "en": "english",
+    "kn": "kannada",
+    "hi": "hindi",
+    "bn": "bengali",
+    "ta": "tamil",
+    "mr": "marathi",
+    "or": "odia",
 }
 
 
 def get_vonage_language_code(language: str) -> str:
     """
-    Maps internal language codes to Vonage TTS language codes.
+    Maps ISO 639-1 language codes to Vonage TTS language codes.
 
     Args:
-        language: Internal language code (kannada, english, hindi, etc.)
+        language: ISO 639-1 code (e.g. "kn", "en", "hi")
 
     Returns:
         Vonage language code (e.g., "kn-IN", "en-US", "hi-IN")
 
     Examples:
-        >>> get_vonage_language_code("kannada")
+        >>> get_vonage_language_code("kn")
         "kn-IN"
 
-        >>> get_vonage_language_code("english")
+        >>> get_vonage_language_code("en")
         "en-US"
 
         >>> get_vonage_language_code("unknown")
         "en-US"  # Default fallback
     """
     return _LANGUAGE_MAPPING.get(language.lower(), "en-US")
+
+
+def get_blob_language_name(iso: str) -> str:
+    """
+    Return the Azure blob folder name for an ISO 639-1 code.
+
+    Args:
+        iso: ISO 639-1 language code (e.g. "kn")
+
+    Returns:
+        Blob folder name (e.g. "kannada"). Falls back to the input value if unknown.
+    """
+    return _ISO_TO_BLOB_NAME.get(iso.lower(), iso)

--- a/IVRv2/app/utils/pause_announcement.py
+++ b/IVRv2/app/utils/pause_announcement.py
@@ -6,32 +6,32 @@ Provides multi-language announcement text for pause/resume controls.
 
 # Pause/resume instruction announcements (before playback)
 PAUSE_INSTRUCTIONS = {
-    "kannada": "ವಿರಾಮಗೊಳಿಸಲು ಅಥವಾ ಮುಂದುವರಿಸಲು ಶೂನ್ಯವನ್ನು ಒತ್ತಿರಿ",  # Press zero to pause or resume
-    "english": "Press zero to pause or resume",
-    "hindi": "रोकने या फिर से शुरू करने के लिए शून्य दबाएं",  # Press zero to pause or resume
-    "bengali": "বিরতি দিতে বা পুনরায় শুরু করতে শূন্য টিপুন",  # Press zero to pause or resume
-    "tamil": "இடைநிறுத்த அல்லது தொடர பூஜ்ஜியத்தை அழுத்தவும்",  # Press zero to pause or resume
-    "marathi": "विराम देण्यासाठी किंवा पुन्हा सुरू करण्यासाठी शून्य दाबा",  # Press zero to pause or resume
+    "kn": "ವಿರಾಮಗೊಳಿಸಲು ಅಥವಾ ಮುಂದುವರಿಸಲು ಶೂನ್ಯವನ್ನು ಒತ್ತಿರಿ",  # Press zero to pause or resume
+    "en": "Press zero to pause or resume",
+    "hi": "रोकने या फिर से शुरू करने के लिए शून्य दबाएं",  # Press zero to pause or resume
+    "bn": "বিরতি দিতে বা পুনরায় শুরু করতে শূন্য টিপুন",  # Press zero to pause or resume
+    "ta": "இடைநிறுத்த அல்லது தொடர பூஜ்ஜியத்தை அழுத்தவும்",  # Press zero to pause or resume
+    "mr": "विराम देण्यासाठी किंवा पुन्हा सुरू करण्यासाठी शून्य दाबा",  # Press zero to pause or resume
 }
 
 # Paused state announcements (when user presses 0 to pause)
 PAUSED_ANNOUNCEMENTS = {
-    "kannada": "ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ. ಮುಂದುವರಿಸಲು ಶೂನ್ಯವನ್ನು ಒತ್ತಿರಿ",  # Paused. Press zero to resume
-    "english": "Paused. Press zero to resume",
-    "hindi": "रोका गया. फिर से शुरू करने के लिए शून्य दबाएं",  # Paused. Press zero to resume
-    "bengali": "বিরতি দেওয়া হয়েছে. পুনরায় শুরু করতে শূন্য টিপুন",  # Paused. Press zero to resume
-    "tamil": "இடைநிறுத்தப்பட்டது. தொடர பூஜ்ஜியத்தை அழுத்தவும்",  # Paused. Press zero to resume
-    "marathi": "विराम दिला आहे. पुन्हा सुरू करण्यासाठी शून्य दाबा",  # Paused. Press zero to resume
+    "kn": "ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ. ಮುಂದುವರಿಸಲು ಶೂನ್ಯವನ್ನು ಒತ್ತಿರಿ",  # Paused. Press zero to resume
+    "en": "Paused. Press zero to resume",
+    "hi": "रोका गया. फिर से शुरू करने के लिए शून्य दबाएं",  # Paused. Press zero to resume
+    "bn": "বিরতি দেওয়া হয়েছে. পুনরায় শুরু করতে শূন্য টিপুন",  # Paused. Press zero to resume
+    "ta": "இடைநிறுத்தப்பட்டது. தொடர பூஜ்ஜியத்தை அழுத்தவும்",  # Paused. Press zero to resume
+    "mr": "विराम दिला आहे. पुन्हा सुरू करण्यासाठी शून्य दाबा",  # Paused. Press zero to resume
 }
 
 # Resuming state announcements (when user presses 0 to resume)
 RESUMING_ANNOUNCEMENTS = {
-    "kannada": "ಮುಂದುವರಿಸಲಾಗುತ್ತಿದೆ",  # Resuming
-    "english": "Resuming",
-    "hindi": "फिर से शुरू किया जा रहा है",  # Resuming
-    "bengali": "পুনরায় শুরু করা হচ্ছে",  # Resuming
-    "tamil": "தொடர்கிறது",  # Resuming
-    "marathi": "पुन्हा सुरू करत आहे",  # Resuming
+    "kn": "ಮುಂದುವರಿಸಲಾಗುತ್ತಿದೆ",  # Resuming
+    "en": "Resuming",
+    "hi": "फिर से शुरू किया जा रहा है",  # Resuming
+    "bn": "পুনরায় শুরু করা হচ্ছে",  # Resuming
+    "ta": "தொடர்கிறது",  # Resuming
+    "mr": "पुन्हा सुरू करत आहे",  # Resuming
 }
 
 
@@ -40,12 +40,12 @@ def get_pause_instruction(language: str) -> str:
     Get pause/resume instruction text for the specified language.
 
     Args:
-        language: Language code (kannada, english, hindi, bengali, tamil, marathi)
+        language: ISO 639-1 code (e.g. "kn", "en", "hi", "bn", "ta", "mr")
 
     Returns:
         Instruction text in the specified language
     """
-    return PAUSE_INSTRUCTIONS.get(language, PAUSE_INSTRUCTIONS["english"])
+    return PAUSE_INSTRUCTIONS.get(language, PAUSE_INSTRUCTIONS["en"])
 
 
 def get_paused_announcement(language: str) -> str:
@@ -53,12 +53,12 @@ def get_paused_announcement(language: str) -> str:
     Get "paused" announcement text for the specified language.
 
     Args:
-        language: Language code (kannada, english, hindi, bengali, tamil, marathi)
+        language: ISO 639-1 code (e.g. "kn", "en", "hi", "bn", "ta", "mr")
 
     Returns:
         Paused announcement text in the specified language
     """
-    return PAUSED_ANNOUNCEMENTS.get(language, PAUSED_ANNOUNCEMENTS["english"])
+    return PAUSED_ANNOUNCEMENTS.get(language, PAUSED_ANNOUNCEMENTS["en"])
 
 
 def get_resuming_announcement(language: str) -> str:
@@ -66,9 +66,9 @@ def get_resuming_announcement(language: str) -> str:
     Get "resuming" announcement text for the specified language.
 
     Args:
-        language: Language code (kannada, english, hindi, bengali, tamil, marathi)
+        language: ISO 639-1 code (e.g. "kn", "en", "hi", "bn", "ta", "mr")
 
     Returns:
         Resuming announcement text in the specified language
     """
-    return RESUMING_ANNOUNCEMENTS.get(language, RESUMING_ANNOUNCEMENTS["english"])
+    return RESUMING_ANNOUNCEMENTS.get(language, RESUMING_ANNOUNCEMENTS["en"])

--- a/IVRv2/app/utils/speed_control.py
+++ b/IVRv2/app/utils/speed_control.py
@@ -12,9 +12,9 @@ MAX_SPEED = 2.0
 SPEED_INCREMENT = 0.25
 SUPPORTED_SPEEDS = [0.75, 1.0, 1.25, 1.5, 2.0]
 
-# Module-level constant for speed announcements
+# Module-level constant for speed announcements (keyed by ISO 639-1 codes)
 _SPEED_ANNOUNCEMENTS: Dict[str, dict] = {
-    "kannada": {
+    "kn": {
         "instruction": "ನಿಧಾನಗೊಳಿಸಲು ಸ್ಟಾರ್ ಒತ್ತಿರಿ, ವೇಗಗೊಳಿಸಲು ಹ್ಯಾಶ್ ಒತ್ತಿರಿ",
         0.75: "ವೇಗ ನಿಧಾನಕ್ಕೆ ಹೊಂದಿಸಲಾಗಿದೆ",
         1.0: "ವೇಗ ಸಾಮಾನ್ಯಕ್ಕೆ ಹೊಂದಿಸಲಾಗಿದೆ",
@@ -22,7 +22,7 @@ _SPEED_ANNOUNCEMENTS: Dict[str, dict] = {
         1.5: "ವೇಗ ಅತಿ ವೇಗಕ್ಕೆ ಹೊಂದಿಸಲಾಗಿದೆ",
         2.0: "ವೇಗ ಅತ್ಯಂತ ವೇಗಕ್ಕೆ ಹೊಂದಿಸಲಾಗಿದೆ"
     },
-    "english": {
+    "en": {
         "instruction": "Press star to slow down, press hash to speed up",
         0.75: "Speed set to slow",
         1.0: "Speed set to normal",
@@ -30,7 +30,7 @@ _SPEED_ANNOUNCEMENTS: Dict[str, dict] = {
         1.5: "Speed set to very fast",
         2.0: "Speed set to ultra fast"
     },
-    "hindi": {
+    "hi": {
         "instruction": "धीमा करने के लिए स्टार दबाएं, तेज करने के लिए हैश दबाएं",
         0.75: "गति धीमी पर सेट की गई",
         1.0: "गति सामान्य पर सेट की गई",
@@ -38,7 +38,7 @@ _SPEED_ANNOUNCEMENTS: Dict[str, dict] = {
         1.5: "गति बहुत तेज पर सेट की गई",
         2.0: "गति अति तेज पर सेट की गई"
     },
-    "bengali": {
+    "bn": {
         "instruction": "ধীর করতে স্টার চাপুন, দ্রুত করতে হ্যাশ চাপুন",
         0.75: "গতি ধীরে সেট করা হয়েছে",
         1.0: "গতি সাধারণে সেট করা হয়েছে",
@@ -46,7 +46,7 @@ _SPEED_ANNOUNCEMENTS: Dict[str, dict] = {
         1.5: "গতি খুব দ্রুতে সেট করা হয়েছে",
         2.0: "গতি অতি দ্রুতে সেট করা হয়েছে"
     },
-    "tamil": {
+    "ta": {
         "instruction": "மெதுவாக்க ஸ்டார் அழுத்தவும், வேகமாக்க ஹாஷ் அழுத்தவும்",
         0.75: "வேகம் மெதுவாக அமைக்கப்பட்டது",
         1.0: "வேகம் சாதாரணமாக அமைக்கப்பட்டது",
@@ -54,7 +54,7 @@ _SPEED_ANNOUNCEMENTS: Dict[str, dict] = {
         1.5: "வேகம் மிக விரைவாக அமைக்கப்பட்டது",
         2.0: "வேகம் அதி விரைவாக அமைக்கப்பட்டது"
     },
-    "marathi": {
+    "mr": {
         "instruction": "हळू करण्यासाठी स्टार दाबा, वेगवान करण्यासाठी हॅश दाबा",
         0.75: "वेग हळू वर सेट केला",
         1.0: "वेग सामान्य वर सेट केला",
@@ -144,14 +144,14 @@ def get_speed_instruction(language: str) -> str:
     Gets the speed control instruction text for initial announcement.
 
     Args:
-        language: Language code (kannada, english, hindi, bengali, tamil, marathi)
+        language: ISO 639-1 code (e.g. "kn", "en", "hi", "bn", "ta", "mr")
 
     Returns:
         Instruction text in the specified language
 
     Examples:
-        >>> get_speed_instruction("english")
+        >>> get_speed_instruction("en")
         "Press star to slow down, press hash to speed up"
     """
-    lang_announcements = _SPEED_ANNOUNCEMENTS.get(language.lower(), _SPEED_ANNOUNCEMENTS["english"])
+    lang_announcements = _SPEED_ANNOUNCEMENTS.get(language.lower(), _SPEED_ANNOUNCEMENTS["en"])
     return lang_announcements["instruction"]

--- a/IVRv2/tests/mocks/mock_database.py
+++ b/IVRv2/tests/mocks/mock_database.py
@@ -215,7 +215,7 @@ class MockDatabase(IDatabase):
                 "_id": "valid-story-1",
                 "type": "story",
                 "description": "Kannada Story",
-                "language": "kannada",
+                "language": "kn",
                 "title": {
                     "english": "Snehitaru",
                     "local": "ನಾನು ಮತ್ತು ನನ್ನ ಶರೀರ",
@@ -243,7 +243,7 @@ class MockDatabase(IDatabase):
                 "_id": "valid-quiz-1",
                 "type": "quiz",
                 "description": "Hindi Quiz",
-                "language": "hindi",
+                "language": "hi",
                 "localTitle": "गणित प्रश्नोत्तरी",
                 "titleAudio": "https://seedsblob.blob.core.windows.net/experience-titles/30/1.0.mp3",
                 "theme": {
@@ -263,7 +263,7 @@ class MockDatabase(IDatabase):
                 "_id": "deleted-story-1",
                 "type": "story",
                 "description": "Deleted Tamil Story",
-                "language": "tamil",
+                "language": "ta",
                 "title": {
                     "english": "Old Story",
                     "local": "பழைய கதை",
@@ -291,7 +291,7 @@ class MockDatabase(IDatabase):
                 "_id": "non-pull-story-1",
                 "type": "story",
                 "description": "Non-Pull Odia Story",
-                "language": "odia",
+                "language": "or",
                 "title": {
                     "english": "Push Model Story",
                     "local": "ପୁସ୍ ମଡେଲ୍ କାହାଣୀ",
@@ -319,7 +319,7 @@ class MockDatabase(IDatabase):
                 "_id": "invalid-content-1",
                 "type": "quiz",
                 "description": "Invalid Content",
-                "language": "marathi",
+                "language": "mr",
                 "localTitle": "अवैध प्रश्नमंजुषा",
                 "titleAudio": "https://seedsblob.blob.core.windows.net/experience-titles/60/1.0.mp3",
                 "theme": {
@@ -347,7 +347,7 @@ class MockDatabase(IDatabase):
                 "_id": "test-story-1",
                 "type": "story",
                 "description": "Kannada Story",
-                "language": "kannada",
+                "language": "kn",
                 "title": {
                     "english": "Test Story",
                     "local": "ಪರೀಕ್ಷಾ ಕಥೆ",

--- a/IVRv2/tests/unit/test_app/test_fsm/test_daily_limit_integration.py
+++ b/IVRv2/tests/unit/test_app/test_fsm/test_daily_limit_integration.py
@@ -36,7 +36,7 @@ def fsm_with_limit():
     content_state = State(
         state_id="content",
         actions=[TalkAction(text="Playing audio"), InputAction(type_=["dtmf"], eventApi="/input")],
-        pre_operation=DailyLimitPreOperation(duration_seconds=180, language="english", school_id="school-1"),
+        pre_operation=DailyLimitPreOperation(duration_seconds=180, language="en", school_id="school-1"),
     )
 
     fsm.add_state(menu_state)

--- a/IVRv2/tests/unit/test_app/test_utils/test_daily_limit.py
+++ b/IVRv2/tests/unit/test_app/test_utils/test_daily_limit.py
@@ -104,11 +104,11 @@ from app.utils.duration_announcement import get_daily_limit_announcement
 
 class TestGetDailyLimitAnnouncement:
     def test_english_announcement(self):
-        result = get_daily_limit_announcement("english")
+        result = get_daily_limit_announcement("en")
         assert "daily listening limit" in result.lower()
 
     def test_kannada_announcement(self):
-        result = get_daily_limit_announcement("kannada")
+        result = get_daily_limit_announcement("kn")
         assert len(result) > 0
 
     def test_unknown_language_falls_back_to_default_language(self):

--- a/IVRv2/tests/unit/test_app/test_utils/test_duration_and_ivr_utils.py
+++ b/IVRv2/tests/unit/test_app/test_utils/test_duration_and_ivr_utils.py
@@ -34,12 +34,12 @@ class TestFormatDurationAnnouncement:
 class TestGetVonageLanguageCode:
 
     @pytest.mark.parametrize("lang, expected", [
-        ("kannada", "kn-IN"),
-        ("english", "en-US"),
-        ("hindi",   "hi-IN"),
-        ("bengali", "bn-IN"),
-        ("tamil",   "ta-IN"),
-        ("marathi", "mr-IN"),
+        ("kn", "kn-IN"),
+        ("en", "en-US"),
+        ("hi", "hi-IN"),
+        ("bn", "bn-IN"),
+        ("ta", "ta-IN"),
+        ("mr", "mr-IN"),
         ("swahili", "en-US"),   # unknown → fallback
         ("",        "en-US"),   # empty → fallback
     ])

--- a/IVRv2/tests/unit/test_app/test_utils/test_pause_announcement.py
+++ b/IVRv2/tests/unit/test_app/test_utils/test_pause_announcement.py
@@ -9,7 +9,7 @@ from app.utils.pause_announcement import (
     RESUMING_ANNOUNCEMENTS,
 )
 
-LANGUAGES = ["kannada", "english", "hindi", "bengali", "tamil", "marathi"]
+LANGUAGES = ["kn", "en", "hi", "bn", "ta", "mr"]
 
 
 class TestGetPauseInstruction:
@@ -18,10 +18,10 @@ class TestGetPauseInstruction:
         assert get_pause_instruction(lang) == PAUSE_INSTRUCTIONS[lang]
 
     def test_unknown_language_falls_back_to_english(self):
-        assert get_pause_instruction("swahili") == PAUSE_INSTRUCTIONS["english"]
+        assert get_pause_instruction("swahili") == PAUSE_INSTRUCTIONS["en"]
 
     def test_empty_string_falls_back_to_english(self):
-        assert get_pause_instruction("") == PAUSE_INSTRUCTIONS["english"]
+        assert get_pause_instruction("") == PAUSE_INSTRUCTIONS["en"]
 
     def test_each_language_has_distinct_text(self):
         results = [get_pause_instruction(lang) for lang in LANGUAGES]
@@ -34,10 +34,10 @@ class TestGetPausedAnnouncement:
         assert get_paused_announcement(lang) == PAUSED_ANNOUNCEMENTS[lang]
 
     def test_unknown_language_falls_back_to_english(self):
-        assert get_paused_announcement("swahili") == PAUSED_ANNOUNCEMENTS["english"]
+        assert get_paused_announcement("swahili") == PAUSED_ANNOUNCEMENTS["en"]
 
     def test_empty_string_falls_back_to_english(self):
-        assert get_paused_announcement("") == PAUSED_ANNOUNCEMENTS["english"]
+        assert get_paused_announcement("") == PAUSED_ANNOUNCEMENTS["en"]
 
 
 class TestGetResumingAnnouncement:
@@ -46,7 +46,7 @@ class TestGetResumingAnnouncement:
         assert get_resuming_announcement(lang) == RESUMING_ANNOUNCEMENTS[lang]
 
     def test_unknown_language_falls_back_to_english(self):
-        assert get_resuming_announcement("swahili") == RESUMING_ANNOUNCEMENTS["english"]
+        assert get_resuming_announcement("swahili") == RESUMING_ANNOUNCEMENTS["en"]
 
     def test_empty_string_falls_back_to_english(self):
-        assert get_resuming_announcement("") == RESUMING_ANNOUNCEMENTS["english"]
+        assert get_resuming_announcement("") == RESUMING_ANNOUNCEMENTS["en"]

--- a/Teacher-App/app/src/main/java/com/example/seeds/BindingAdapters.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/BindingAdapters.kt
@@ -3,6 +3,7 @@ package com.example.seeds
 import android.graphics.drawable.Drawable
 import android.util.Log
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.seeds.adapters.ContentListAdapter
@@ -16,6 +17,7 @@ import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import com.example.seeds.utils.getLanguageLabel
 
 @BindingAdapter("contentData")
 fun bindContentRecyclerView(recyclerView: RecyclerView, data: List<Content>?) {
@@ -104,4 +106,9 @@ fun bindStudentCallStatusRecyclerView(
 @BindingAdapter("imageDrawable")
 fun bindDrawableImageView(imageView: ImageView, drawable: Drawable) {
     imageView.setImageDrawable(drawable)
+}
+
+@BindingAdapter("displayLanguage")
+fun bindDisplayLanguage(textView: TextView, languageCode: String?) {
+    textView.text = languageCode?.let { getLanguageLabel(it) } ?: ""
 }

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
@@ -29,6 +29,7 @@ import com.example.seeds.network.ConferenceSSEClient
 import com.example.seeds.network.SeedsService
 import com.example.seeds.network.asDomainModel
 import com.example.seeds.utils.Encryptor
+import com.example.seeds.utils.getLanguageLabel
 import com.example.seeds.repository.ClassroomRepository
 import com.example.seeds.repository.ContentRepository
 import com.example.seeds.repository.TeacherRepository
@@ -271,7 +272,7 @@ class CallViewModel @Inject constructor(
                 _filteredContent.value = filteredListContent 
 
                 _languages.value =
-                    filteredListContent.map { it.language.lowercase() }.distinct().map { it.capitalize() }
+                    filteredListContent.map { it.language.lowercase() }.distinct().map { getLanguageLabel(it) }
                 _experiences.value = filteredListContent.map { it.type.lowercase() }.distinct().map {
                     it.capitalize()
                 }

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/home/HomeViewModel.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/home/HomeViewModel.kt
@@ -12,6 +12,7 @@ import com.example.seeds.model.Classroom
 import com.example.seeds.model.Content
 import com.example.seeds.repository.ClassroomRepository
 import com.example.seeds.repository.ContentRepository
+import com.example.seeds.utils.getLanguageLabel
 import com.example.seeds.repository.TeacherRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -35,7 +36,7 @@ class HomeViewModel @Inject constructor(
 
     // --- UI-VISIBLE LIVE DATA ---
     val languages: LiveData<List<String>> = Transformations.map(_allContent) { list ->
-        list.map { it.language.lowercase() }.distinct().map { lang -> lang.capitalize() }
+        list.map { it.language.lowercase() }.distinct().map { lang -> getLanguageLabel(lang) }
     }
     val experiences: LiveData<List<String>> = Transformations.map(_allContent) { list ->
         list.map { it.type.lowercase() }.distinct().map { exp -> exp.capitalize() }

--- a/Teacher-App/app/src/main/java/com/example/seeds/utils/LanguageUtils.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/utils/LanguageUtils.kt
@@ -1,0 +1,14 @@
+package com.example.seeds.utils
+
+private val LANGUAGE_LABELS = mapOf(
+    "en" to "English",
+    "kn" to "Kannada",
+    "hi" to "Hindi",
+    "bn" to "Bengali",
+    "ta" to "Tamil",
+    "mr" to "Marathi",
+    "or" to "Odia",
+)
+
+fun getLanguageLabel(iso: String): String =
+    LANGUAGE_LABELS[iso.lowercase()] ?: iso.replaceFirstChar { it.uppercaseChar() }

--- a/Teacher-App/app/src/main/res/layout/content_item_row.xml
+++ b/Teacher-App/app/src/main/res/layout/content_item_row.xml
@@ -61,7 +61,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
-                android:text="@{content.language.substring(0, 1).toUpperCase() + content.language.substring(1)}"
+                app:displayLanguage="@{content.language}"
                 app:layout_constraintBottom_toBottomOf="@+id/contact_name2"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/imageView2"

--- a/Teacher-App/app/src/main/res/layout/fragment_call.xml
+++ b/Teacher-App/app/src/main/res/layout/fragment_call.xml
@@ -202,7 +202,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
-                    android:text="@{viewModel.selectedContent.language}"
+                    app:displayLanguage="@{viewModel.selectedContent.language}"
                     app:layout_constraintStart_toEndOf="@+id/content_image"
                     app:layout_constraintTop_toBottomOf="@+id/selected_content"
                     app:layout_constraintBottom_toBottomOf="@+id/content_image"

--- a/Teacher-App/app/src/main/res/layout/fragment_content_details.xml
+++ b/Teacher-App/app/src/main/res/layout/fragment_content_details.xml
@@ -120,7 +120,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
-            android:text="@{content.language.substring(0, 1).toUpperCase() + content.language.substring(1)}"
+            app:displayLanguage="@{content.language}"
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="@+id/contact_name2"
             app:layout_constraintEnd_toEndOf="@+id/contact_name"

--- a/backend-server/package-lock.json
+++ b/backend-server/package-lock.json
@@ -21,6 +21,7 @@
         "ffmpeg-static": "^5.2.0",
         "firebase-admin": "^13.6.0",
         "fluent-ffmpeg": "^2.1.3",
+        "iso-639-1": "^3.1.5",
         "jsonwebtoken": "^9.0.2",
         "microsoft-cognitiveservices-speech-sdk": "^1.50.0",
         "mongodb-memory-server": "^10.2.3",
@@ -1147,6 +1148,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1684,7 +1686,6 @@
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -1704,7 +1705,6 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1718,7 +1718,6 @@
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1729,7 +1728,6 @@
       "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -1745,7 +1743,6 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1757,7 +1754,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1771,7 +1767,6 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -1785,7 +1780,6 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1799,7 +1793,6 @@
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -1823,8 +1816,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1832,7 +1824,6 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1844,7 +1835,6 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1858,7 +1848,6 @@
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1872,7 +1861,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1899,7 +1887,6 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1910,7 +1897,6 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -2225,7 +2211,6 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -2236,7 +2221,6 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -2251,7 +2235,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2266,7 +2249,6 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -3633,8 +3615,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -4215,7 +4196,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -4252,7 +4232,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4705,6 +4684,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5337,8 +5317,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -5739,6 +5718,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5786,7 +5766,6 @@
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -5804,7 +5783,6 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5818,7 +5796,6 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5830,7 +5807,6 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5844,7 +5820,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -5862,7 +5837,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5876,7 +5850,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -5893,7 +5866,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5907,7 +5879,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -5924,7 +5895,6 @@
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -5957,7 +5927,6 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -5971,7 +5940,6 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -5985,7 +5953,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6100,6 +6067,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6244,8 +6212,7 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -6341,7 +6308,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -6505,7 +6471,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -6519,8 +6484,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/fluent-ffmpeg": {
       "version": "2.1.3",
@@ -7170,7 +7134,6 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -7188,7 +7151,6 @@
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -7206,7 +7168,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7436,6 +7397,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/iso-639-1": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-3.1.5.tgz",
+      "integrity": "sha512-gXkz5+KN7HrG0Q5UGqSMO2qB9AsbEeyLP54kF1YrMsIxmu+g4BdB7rflReZTSTZGpfj8wywu6pfPBCylPIzGQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -8200,8 +8170,7 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -8215,16 +8184,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8347,7 +8314,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -8368,7 +8334,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -8469,8 +8434,7 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -9529,7 +9493,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -9607,7 +9570,6 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -9764,7 +9726,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -9775,6 +9736,7 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11068,7 +11030,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -11229,7 +11190,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -11355,7 +11315,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/backend-server/package.json
+++ b/backend-server/package.json
@@ -27,6 +27,7 @@
     "ffmpeg-static": "^5.2.0",
     "firebase-admin": "^13.6.0",
     "fluent-ffmpeg": "^2.1.3",
+    "iso-639-1": "^3.1.5",
     "jsonwebtoken": "^9.0.2",
     "microsoft-cognitiveservices-speech-sdk": "^1.50.0",
     "mongodb-memory-server": "^10.2.3",

--- a/backend-server/src/models/QuizCreateRequest.js
+++ b/backend-server/src/models/QuizCreateRequest.js
@@ -16,7 +16,7 @@ class QuizCreateRequest {
     this.localTitle = data.localTitle || "Untitled Quiz";
     this.theme = data.theme || "Default theme";
     this.localTheme = data.localTheme || "Default Local Theme";
-    this.language = data.language || "English";
+    this.language = data.language || "en";
     this.positiveMark = data.positiveMark || 1;
     this.negativeMark = data.negativeMark || 0;
     this.questions = data.questions || [];

--- a/backend-server/src/routes/contentRouter.js
+++ b/backend-server/src/routes/contentRouter.js
@@ -25,14 +25,14 @@ const BlobService = require("../services/BlobService.js");
 const processNewContent = require("../jobs/processAudioContent.js");
 const processQuizContent = require("../jobs/processQuizContent.js");
 const { tryCatchWrapper } = require(path.join("..", "util.js"));
-const { Binary } = require("mongodb");
-const { parse: uuidParse } = require("uuid");
 const { authenticateToken, authorizeRole } = require("../auth/authenticateToken");
+const ISO6391 = require("iso-639-1");
 
 const TENANT_ROLE = "tenant";
 const SCHOOL_ADMIN_ROLE = "school_admin";
 const TEACHER_ROLE = "teacher";
 const CONTENT_CREATOR_ROLE = "content_creator";
+
 
 // For reads — school-scoped users see their own school's content + tenant content (schoolId: null)
 function getReadSchoolIdFilter(req) {
@@ -621,7 +621,7 @@ router.patch(
   authorizeRole(TENANT_ROLE, SCHOOL_ADMIN_ROLE, CONTENT_CREATOR_ROLE),
   tryCatchWrapper(async (req, res) => {
     const isRegionalLanguage = (language) =>
-      typeof language === "string" && !["en", "eng", "english"].includes(language.trim().toLowerCase());
+      typeof language === "string" && language.trim().toLowerCase() !== "en";
 
     const mergeTextContent = ({ value, current, language, localOverride }) => {
       const merged = {
@@ -653,6 +653,11 @@ router.patch(
       if (value === undefined && localOverride === undefined) return;
       doc[key] = mergeTextContent({ value, current: doc[key], language, localOverride });
     };
+
+
+    if (req.body.language !== undefined && !ISO6391.validate(req.body.language)) {
+      return res.status(400).json({ error: `language must be a valid ISO 639-1 code. Received: "${req.body.language}"` });
+    }
 
     const isAudioUploaded = req.query.isAudioUploaded === "true";
     const contentId = req.body?._id;
@@ -837,6 +842,10 @@ router.post(
   authenticateToken,
   authorizeRole(TENANT_ROLE, SCHOOL_ADMIN_ROLE, CONTENT_CREATOR_ROLE),
   tryCatchWrapper(async (req, res) => {
+    if (!ISO6391.validate(req.body.language)) {
+      return res.status(400).json({ error: `language must be a valid ISO 639-1 code. Received: "${req.body.language}"` });
+    }
+
     let content = new ContentV3(req.body);
     content.tenantId = req.tenantId;
     content.createdBy = req.userId;

--- a/backend-server/src/services/ttsService.js
+++ b/backend-server/src/services/ttsService.js
@@ -19,16 +19,6 @@ const translationLanguageCodeToAzureSpeechCode = {
   or: "or-IN",
 };
 
-const humanLanguageCodeToTranslationLanguageCode = {
-  english: "en",
-  kannada: "kn",
-  hindi: "hi",
-  marathi: "mr",
-  tamil: "ta",
-  bengali: "bn",
-  odia: "or",
-};
-
 const voiceName = {
   "en-IN": "en-IN-NeerjaNeural",
   "kn-IN": "kn-IN-SapnaNeural",
@@ -40,12 +30,8 @@ const voiceName = {
 };
 
 function getTTSAttributes(language) {
-  const translationCode = humanLanguageCodeToTranslationLanguageCode[language.toLowerCase()];
-  if (!translationCode) return null; // Language not found
-
-  const languageCode = translationLanguageCodeToAzureSpeechCode[translationCode];
+  const languageCode = translationLanguageCodeToAzureSpeechCode[language.toLowerCase()];
   const voice = voiceName[languageCode];
-
   return languageCode && voice ? { languageCode, voiceName: voice } : null;
 }
 

--- a/backend-server/tests/services/ttsService.test.js
+++ b/backend-server/tests/services/ttsService.test.js
@@ -24,14 +24,14 @@ describe('TTS Service', () => {
     // Test constants
     const CONFIG = {
         azure: { resource: "https://cognitiveservices.azure.com/.default", region: "test-region", resourceId: "test-resource-id" },
-        test: { text: "Hello, test message", language: "english", rate: "medium", filename: "test.mp3" },
+        test: { text: "Hello, test message", language: "en", rate: "medium", filename: "test.mp3" },
         languages: {
-            english: { languageCode: 'en-IN', voice: 'en-IN-NeerjaNeural' },
-            kannada: { languageCode: 'kn-IN', voice: 'kn-IN-SapnaNeural' },
-            hindi: { languageCode: 'hi-IN', voice: 'hi-IN-SwaraNeural' },
-            marathi: { languageCode: 'mr-IN', voice: 'mr-IN-AarohiNeural' },
-            tamil: { languageCode: 'ta-IN', voice: 'ta-IN-PallaviNeural' },
-            bengali: { languageCode: 'bn-IN', voice: 'bn-IN-TanishaaNeural' }
+            en: { languageCode: 'en-IN', voice: 'en-IN-NeerjaNeural' },
+            kn: { languageCode: 'kn-IN', voice: 'kn-IN-SapnaNeural' },
+            hi: { languageCode: 'hi-IN', voice: 'hi-IN-SwaraNeural' },
+            mr: { languageCode: 'mr-IN', voice: 'mr-IN-AarohiNeural' },
+            ta: { languageCode: 'ta-IN', voice: 'ta-IN-PallaviNeural' },
+            bn: { languageCode: 'bn-IN', voice: 'bn-IN-TanishaaNeural' }
         }
     };
 

--- a/teacher-webapp/src/components/ContentListItem.jsx
+++ b/teacher-webapp/src/components/ContentListItem.jsx
@@ -11,6 +11,7 @@ import {
   MenuBook as MenuBookIcon,
   PlayArrow as PlayArrowIcon,
 } from "@mui/icons-material";
+import { getLanguageLabel } from "../utils/languageUtils";
 
 /**
  * ContentListItem - renders individual content card in the library
@@ -123,7 +124,7 @@ const ContentListItem = ({
             color="text.secondary"
             sx={{ fontSize: "0.7rem" }}
           >
-            {[item.language, typeof item.theme === "string" ? item.theme : item.theme?.english]
+            {[item.language ? getLanguageLabel(item.language) : null, typeof item.theme === "string" ? item.theme : item.theme?.english]
               .filter(Boolean)
               .join(" \u00B7 ")}
           </Typography>

--- a/teacher-webapp/src/pages/ContentDetails.js
+++ b/teacher-webapp/src/pages/ContentDetails.js
@@ -12,6 +12,7 @@ import { LoadingSpinner } from "../components/common/LoadingSpinner";
 import { PageContainer } from "../components/layout/PageContainer";
 import { ROUTES } from "../constants/routes";
 import AudioPlayer from "../components/audio/AudioPlayer";
+import { getLanguageLabel } from "../utils/languageUtils";
 
 const ContentDetails = () => {
   const navigate = useNavigate();
@@ -143,7 +144,7 @@ const ContentDetails = () => {
 
   const formatLanguage = () => {
     if (!content || !content.language) return "";
-    return content.language.charAt(0).toUpperCase() + content.language.slice(1).toLowerCase();
+    return getLanguageLabel(content.language);
   };
 
   if (loading) {

--- a/teacher-webapp/src/utils/languageUtils.js
+++ b/teacher-webapp/src/utils/languageUtils.js
@@ -1,0 +1,21 @@
+export const LANGUAGE_LABELS = {
+  en: "English",
+  kn: "Kannada",
+  hi: "Hindi",
+  bn: "Bengali",
+  ta: "Tamil",
+  mr: "Marathi",
+  or: "Odia",
+};
+
+/**
+ * Returns the human-readable display label for an ISO 639-1 language code.
+ * Falls back to capitalizing the code if unmapped (e.g. "xx" → "Xx").
+ */
+export const getLanguageLabel = (iso) => {
+  if (!iso) return "";
+  return (
+    LANGUAGE_LABELS[iso.toLowerCase()] ||
+    iso.charAt(0).toUpperCase() + iso.slice(1).toLowerCase()
+  );
+};

--- a/teacher-webapp/tests/pages/ContentDetails.test.js
+++ b/teacher-webapp/tests/pages/ContentDetails.test.js
@@ -98,7 +98,7 @@ describe("ContentDetails", () => {
     });
 
     expect(screen.getByText("Story")).toBeInTheDocument();
-    expect(screen.getByText("En")).toBeInTheDocument();
+    expect(screen.getByText("English")).toBeInTheDocument();
   });
 
   test("fetches SAS URL for audio content", async () => {


### PR DESCRIPTION
- Updated `language` fields in the backend and applications to use ISO 639-1 codes instead of language names.
- Added forward and backward migration scripts to ensure seamless data transition.
- Ensures consistency and reduces ambiguity in handling language codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized language code handling across web and mobile applications for improved consistency
  * Enhanced language label formatting throughout content management and user interfaces

* **Bug Fixes**
  * Improved language selection and display consistency in quiz creation and content management
  * Fixed language filtering inconsistencies across the platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->