### PR TITLE
Add `ffprobe-static` dependency and configure `fluent-ffmpeg`

### DIFF
--- a/backend-server/package-lock.json
+++ b/backend-server/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
         "ffmpeg-static": "^5.2.0",
+        "ffprobe-static": "^3.1.0",
         "firebase-admin": "^13.6.0",
         "fluent-ffmpeg": "^2.1.3",
         "iso-639-1": "^3.1.5",
@@ -6301,6 +6302,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ffprobe-static": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
+      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/backend-server/package.json
+++ b/backend-server/package.json
@@ -25,6 +25,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
     "ffmpeg-static": "^5.2.0",
+    "ffprobe-static": "^3.1.0",
     "firebase-admin": "^13.6.0",
     "fluent-ffmpeg": "^2.1.3",
     "iso-639-1": "^3.1.5",

--- a/backend-server/src/jobs/jobsUtils.js
+++ b/backend-server/src/jobs/jobsUtils.js
@@ -8,7 +8,9 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const ffmpegPath = require("ffmpeg-static");
+const ffprobePath = require("ffprobe-static").path;
 const ffmpeg = require("fluent-ffmpeg");
+ffmpeg.setFfprobePath(ffprobePath);
 
 /**
  * Writes a Buffer to a file.

--- a/backend-server/tests/jobs/jobsUtils.test.js
+++ b/backend-server/tests/jobs/jobsUtils.test.js
@@ -8,9 +8,11 @@ jest.mock('fs');
 jest.mock('fluent-ffmpeg', () => {
     const mockFn = jest.fn();
     mockFn.ffprobe = jest.fn();
+    mockFn.setFfprobePath = jest.fn();
     return mockFn;
 });
 jest.mock('ffmpeg-static', () => '/mocked/path/to/ffmpeg');
+jest.mock('ffprobe-static', () => ({ path: '/mocked/path/to/ffprobe' }));
 
 const {
     writeBufferToFile,


### PR DESCRIPTION
This pull request introduces the following changes:
- Adds the `ffprobe-static` dependency to the project.
- Configures the `fluent-ffmpeg` package to use `ffprobe` for enhanced media processing capabilities.

No associated issues were linked to this pull request.