### PR TITLE
ci: swap backend-server/ConferenceV2/IVRv2 for platform-service in de…

### DIFF
--- a/.github/actions/run-node-lint/action.yml
+++ b/.github/actions/run-node-lint/action.yml
@@ -9,6 +9,5 @@ runs:
   steps:
     - name: Lint with ESLint
       shell: bash
-      run: |
-        cd ${{ inputs.directory }}
-        npm run lint --if-present
+      working-directory: ${{ inputs.directory }}
+      run: npm run lint --if-present

--- a/.github/actions/run-node-lint/action.yml
+++ b/.github/actions/run-node-lint/action.yml
@@ -1,0 +1,14 @@
+name: Run Node.js Lint
+description: Run ESLint for a Node.js project
+inputs:
+  directory:
+    description: "Directory of the Node.js project"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Lint with ESLint
+      shell: bash
+      run: |
+        cd ${{ inputs.directory }}
+        npm run lint --if-present

--- a/.github/actions/run-python-lint/action.yml
+++ b/.github/actions/run-python-lint/action.yml
@@ -1,0 +1,14 @@
+name: Run Python Lint
+description: Run ruff linter for a Python project
+inputs:
+  directory:
+    description: "Directory of the Python project"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Lint with ruff
+      shell: bash
+      run: |
+        cd ${{ inputs.directory }}
+        poetry run ruff check .

--- a/.github/actions/run-python-lint/action.yml
+++ b/.github/actions/run-python-lint/action.yml
@@ -9,6 +9,5 @@ runs:
   steps:
     - name: Lint with ruff
       shell: bash
-      run: |
-        cd ${{ inputs.directory }}
-        poetry run ruff check .
+      working-directory: ${{ inputs.directory }}
+      run: poetry run ruff check .

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -13,7 +13,7 @@ runs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs['python-version'] }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - a4i/main
+      - a4i/staging
+  pull_request:
+  workflow_call:
+    inputs:
+      upload_coverage:
+        description: "Upload coverage results to gist"
+        type: boolean
+        default: false
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - name: platform
+            context: platform
+            lang: python
+
+          - name: content-webapp
+            context: ContentWebApp
+            lang: node
+
+          - name: teacher-webapp
+            context: teacher-webapp
+            lang: node
+
+          - name: websocket-service
+            context: websocket-service
+            lang: node
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up (Poetry)
+        if: matrix.service.lang == 'python'
+        uses: ./.github/actions/setup-poetry
+        with:
+          python-version: "3.12"
+          directory: ${{ matrix.service.context }}
+
+      - name: Set up (Node.js)
+        if: matrix.service.lang == 'node'
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: "20"
+          directory: ${{ matrix.service.context }}
+
+      - name: Lint (Python)
+        if: matrix.service.lang == 'python'
+        uses: ./.github/actions/run-python-lint
+        with:
+          directory: ${{ matrix.service.context }}
+
+      - name: Lint (Node.js)
+        if: matrix.service.lang == 'node'
+        uses: ./.github/actions/run-node-lint
+        with:
+          directory: ${{ matrix.service.context }}
+
+      - name: Test (Python)
+        if: matrix.service.lang == 'python'
+        uses: ./.github/actions/run-python-tests
+        with:
+          directory: ${{ matrix.service.context }}
+
+      - name: Test (Node.js)
+        if: matrix.service.lang == 'node'
+        uses: ./.github/actions/run-node-tests
+        with:
+          directory: ${{ matrix.service.context }}
+
+      - name: Extract coverage (Python)
+        if: matrix.service.lang == 'python' && inputs.upload_coverage
+        uses: ./.github/actions/extract-coverage-python
+        with:
+          coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
+          coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
+          directory: ${{ matrix.service.context }}
+
+      - name: Extract coverage (Node.js)
+        if: matrix.service.lang == 'node' && inputs.upload_coverage
+        uses: ./.github/actions/extract-coverage-node
+        with:
+          coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
+          coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
+          directory: ${{ matrix.service.context }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches-ignore:
-      - a4i/main
-      - a4i/staging
   pull_request:
   workflow_call:
     inputs:

--- a/.github/workflows/coverage-summary.yml
+++ b/.github/workflows/coverage-summary.yml
@@ -5,14 +5,14 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows:
-      - Deploy Staging Services
+      - CI
     types:
       - completed
 
 jobs:
   aggregate-coverage:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     outputs:
       overall_coverage: ${{ steps.aggregate.outputs.overall_coverage }}
       services_tested: ${{ steps.aggregate.outputs.services_tested }}
@@ -29,7 +29,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         continue-on-error: true
         with:
-          workflow: deploy-staging.yml
+          workflow: ci.yml
           workflow_conclusion: success
           path: coverage-artifacts
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -17,11 +17,11 @@ jobs:
         strategy:
             matrix:
                 service:
-                    - name: backend-server-service
-                      context: backend-server
-                      image: backend-server
-                      lang: node
-                      azure_publish_profile: BACKEND_SERVER_AZURE_PUBLISH_PROFILE
+                    - name: platform-service
+                      context: platform
+                      image: platform
+                      lang: python
+                      azure_publish_profile: PLATFORM_AZURE_PUBLISH_PROFILE
 
                     - name: content-webapp-service
                       context: ContentWebApp
@@ -43,17 +43,6 @@ jobs:
                       build_arg_storage: TEACHER_WEBAPP_STORAGE_ACCOUNT_NAME
                       build_arg_api_url: TEACHER_WEBAPP_API_BASE_URL
 
-                    - name: conference-v2-service
-                      context: ConferenceV2
-                      image: conference-v2
-                      lang: python
-                      azure_publish_profile: CONFERENCE_V2_AZURE_PUBLISH_PROFILE
-
-                    - name: IvrV2-service
-                      context: IVRv2
-                      image: ivrv2
-                      lang: python
-                      azure_publish_profile: IVRV2_AZURE_PUBLISH_PROFILE
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -3,8 +3,6 @@ name: Deploy Main Services
 on:
     push:
         branches: a4i/main
-    pull_request:
-        branches: a4i/main
     workflow_call:
     workflow_dispatch:
 
@@ -12,7 +10,7 @@ env:
     REGISTRY: ghcr.io
 
 jobs:
-    service:
+    deploy:
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -20,15 +18,12 @@ jobs:
                     - name: platform-service
                       context: platform
                       image: platform
-                      lang: python
                       azure_publish_profile: PLATFORM_AZURE_PUBLISH_PROFILE
 
                     - name: content-webapp-service
                       context: ContentWebApp
                       image: content-webapp
-                      lang: node
                       azure_publish_profile: CONTENT_WEBAPP_AZURE_PUBLISH_PROFILE
-                      needs_build_args: true
                       build_arg_api_url: CONTENT_WEBAPP_REACT_APP_API_BASE_URL
                       build_arg_ivr_api_url: CONTENT_WEBAPP_REACT_APP_API_IVRV2_URL
                       build_arg_google_site_verification: CONTENT_WEBAPP_REACT_APP_GOOGLE_SITE_VERIFICATION
@@ -36,72 +31,15 @@ jobs:
                     - name: teacher-webapp-service
                       context: teacher-webapp
                       image: teacher-webapp
-                      lang: node
                       azure_publish_profile: TEACHER_WEBAPP_AZURE_PUBLISH_PROFILE
-                      needs_build_args: true
                       build_arg_conf_uri: TEACHER_WEBAPP_CONF_SERVER_BASE_URI
                       build_arg_storage: TEACHER_WEBAPP_STORAGE_ACCOUNT_NAME
                       build_arg_api_url: TEACHER_WEBAPP_API_BASE_URL
-
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: Set up language (Poetry)
-              if: matrix.service.lang == 'python'
-              uses: ./.github/actions/setup-poetry
-              with:
-                  python-version: "3.12"
-                  directory: ${{ matrix.service.context }}
-
-            - name: Set up language (Node.js)
-              if: matrix.service.lang == 'node'
-              uses: ./.github/actions/setup-node
-              with:
-                  node-version: "20"
-                  directory: ${{ matrix.service.context }}
-
-            - name: Run tests (python)
-              if: matrix.service.lang == 'python'
-              uses: ./.github/actions/run-python-tests
-              with:
-                  directory: ${{ matrix.service.context }}
-
-            - name: Run tests (Node.js)
-              if: matrix.service.lang == 'node'
-              uses: ./.github/actions/run-node-tests
-              with:
-                  directory: ${{ matrix.service.context }}
-
-            - name: Extract coverage (python)
-              if: matrix.service.lang == 'python'
-              uses: ./.github/actions/extract-coverage-python
-              with:
-                  coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
-                  coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
-                  directory: ${{ matrix.service.context }}
-
-            - name: Extract coverage (Node.js)
-              if: matrix.service.lang == 'node'
-              uses: ./.github/actions/extract-coverage-node
-              with:
-                  coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
-                  coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
-                  directory: ${{ matrix.service.context }}
-
-            - name: Determine environment tag
-              id: env-tag
-              run: |
-                  if [[ "${{ github.ref }}" == "refs/heads/a4i/main" ]]; then
-                    echo "tag=prod" >> $GITHUB_OUTPUT
-                  elif [[ "${{ github.ref }}" == "refs/heads/a4i/staging" ]]; then
-                    echo "tag=staging" >> $GITHUB_OUTPUT
-                  else
-                    echo "tag=latest" >> $GITHUB_OUTPUT
-                  fi
-
             - name: Build & push image
-              if: github.event_name == 'push'
               uses: ./.github/actions/deploy-docker
               with:
                   context: ${{ matrix.service.context }}
@@ -110,7 +48,7 @@ jobs:
                   repository: ${{ github.repository }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   username: ${{ github.actor }}
-                  environment_tag: ${{ steps.env-tag.outputs.tag }}
+                  environment_tag: prod
                   build_args: |
                       ${{ matrix.service.build_arg_conf_uri && format('REACT_APP_CONF_SERVER_BASE_URI={0}', vars[matrix.service.build_arg_conf_uri]) || '' }}
                       ${{ matrix.service.build_arg_storage && format('REACT_APP_STORAGE_ACCOUNT_NAME={0}', vars[matrix.service.build_arg_storage]) || '' }}
@@ -120,13 +58,11 @@ jobs:
 
             - name: Normalize repo name to lowercase
               id: repo
-              run: |
-                  echo "repository_lowercase=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+              run: echo "repository_lowercase=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
             - name: Deploy to Azure
-              if: github.event_name == 'push'
               uses: ./.github/actions/deploy-azure
               with:
                   app_name: ${{ matrix.service.name }}
                   publish_profile: ${{ secrets[matrix.service.azure_publish_profile] }}
-                  image: ${{ env.REGISTRY }}/${{ steps.repo.outputs.repository_lowercase }}/${{ matrix.service.image }}:${{ steps.env-tag.outputs.tag }}
+                  image: ${{ env.REGISTRY }}/${{ steps.repo.outputs.repository_lowercase }}/${{ matrix.service.image }}:prod

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,8 +3,6 @@ name: Deploy Staging Services
 on:
   push:
     branches: a4i/staging
-  pull_request:
-    branches: a4i/staging
   workflow_call:
   workflow_dispatch:
 
@@ -12,7 +10,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  service:
+  deploy:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,80 +18,22 @@ jobs:
           - name: platform
             context: platform
             image: platform
-            lang: python
             render_deploy_hook_url: PLATFORM_RENDER_DEPLOY_HOOK_URL
 
           - name: content-webapp
             context: ContentWebApp
             image: content-webapp
-            lang: node
             render_deploy_hook_url: CONTENT_WEBAPP_RENDER_DEPLOY_HOOK_URL
 
           - name: teacher-webapp
             context: teacher-webapp
             image: teacher-webapp
-            lang: node
             render_deploy_hook_url: TEACHER_WEBAPP_RENDER_DEPLOY_HOOK_URL
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up language (Poetry)
-        if: matrix.service.lang == 'python'
-        uses: ./.github/actions/setup-poetry
-        with:
-          python-version: "3.12"
-          directory: ${{ matrix.service.context }}
-
-      - name: Set up language (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/setup-node
-        with:
-          node-version: "20"
-          directory: ${{ matrix.service.context }}
-
-      - name: Run tests (python)
-        if: matrix.service.lang == 'python'
-        uses: ./.github/actions/run-python-tests
-        with:
-          directory: ${{ matrix.service.context }}
-
-      - name: Run tests (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/run-node-tests
-        with:
-          directory: ${{ matrix.service.context }}
-
-      - name: Extract coverage (python)
-        if: matrix.service.lang == 'python'
-        uses: ./.github/actions/extract-coverage-python
-        with:
-          coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
-          coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
-          directory: ${{ matrix.service.context }}
-
-      - name: Extract coverage (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/extract-coverage-node
-        with:
-          coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
-          coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
-          directory: ${{ matrix.service.context }}
-
-      - name: Determine environment tag
-        id: env-tag
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/a4i/main" ]]; then
-            echo "tag=prod" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == "refs/heads/a4i/staging" ]]; then
-            echo "tag=staging" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
       - name: Build & push image
-        if: github.event_name == 'push'
         uses: ./.github/actions/deploy-docker
         with:
           context: ${{ matrix.service.context }}
@@ -102,10 +42,9 @@ jobs:
           repository: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          environment_tag: ${{ steps.env-tag.outputs.tag }}
+          environment_tag: staging
 
       - name: Deploy to Render
-        if: github.event_name == 'push'
         uses: ./.github/actions/deploy-render
         with:
-          deploy_hook_url: ${{ secrets[ matrix.service.render_deploy_hook_url ] }}
+          deploy_hook_url: ${{ secrets[matrix.service.render_deploy_hook_url] }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       matrix:
         service:
-          - name: backend-server
-            context: backend-server
-            image: backend-server
-            lang: node
-            render_deploy_hook_url: BACKEND_SERVER_RENDER_DEPLOY_HOOK_URL
+          - name: platform
+            context: platform
+            image: platform
+            lang: python
+            render_deploy_hook_url: PLATFORM_RENDER_DEPLOY_HOOK_URL
 
           - name: content-webapp
             context: ContentWebApp
@@ -35,17 +35,6 @@ jobs:
             lang: node
             render_deploy_hook_url: TEACHER_WEBAPP_RENDER_DEPLOY_HOOK_URL
 
-          - name: conference-v2
-            context: ConferenceV2
-            image: conference-v2
-            lang: python
-            render_deploy_hook_url: CONFERENCE_V2_RENDER_DEPLOY_HOOK_URL
-
-          - name: IvrV2
-            context: IVRv2
-            image: ivrv2
-            lang: python
-            render_deploy_hook_url: IVRV2_RENDER_DEPLOY_HOOK_URL
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-websocket-service-main.yml
+++ b/.github/workflows/deploy-websocket-service-main.yml
@@ -1,81 +1,39 @@
 name: Deploy Websocket Service Main
+
 on:
   push:
     branches: a4i/main
-  pull_request:
-    branches: a4i/main
   workflow_call:
   workflow_dispatch:
+
 env:
   REGISTRY: ghcr.io
+
 jobs:
-  service:
+  deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        service:
-          - name: web-socket-service-main
-            context: websocket-service
-            image: websocket-service
-            lang: node
-            azure_publish_profile: WEBSOCKET_SERVICE_AZURE_PUBLISH_PROFILE
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up language (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/setup-node
-        with:
-          node-version: '20'
-          directory: ${{ matrix.service.context }}
-
-      - name: Run tests (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/run-node-tests
-        with:
-          directory: ${{ matrix.service.context }}
-
-      - name: Extract coverage (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/extract-coverage-node
-        with:
-            directory: ${{ matrix.service.context }}
-            coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
-            coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
-
-      - name: Determine environment tag
-        id: env-tag
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/a4i/main" ]]; then
-            echo "tag=prod" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == "refs/heads/a4i/staging" ]]; then
-            echo "tag=staging" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
       - name: Build & push image
-        if: github.event_name == 'push'
         uses: ./.github/actions/deploy-docker
         with:
-          context: ${{ matrix.service.context }}
-          image: ${{ matrix.service.image }}
+          context: websocket-service
+          image: websocket-service
           registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          environment_tag: ${{ steps.env-tag.outputs.tag }}
+          environment_tag: prod
 
       - name: Normalize repo name to lowercase
         id: repo
-        run: |
-          echo "repository_lowercase=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+        run: echo "repository_lowercase=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
-      - name: Publish to Azure
-        if: github.event_name == 'push'
+      - name: Deploy to Azure
         uses: ./.github/actions/deploy-azure
         with:
-          app_name: ${{ matrix.service.name }}
-          publish_profile: ${{ secrets[matrix.service.azure_publish_profile] }}
-          image: ${{ env.REGISTRY }}/${{ steps.repo.outputs.repository_lowercase }}/${{ matrix.service.image }}:${{ steps.env-tag.outputs.tag }}
+          app_name: web-socket-service-main
+          publish_profile: ${{ secrets.WEBSOCKET_SERVICE_AZURE_PUBLISH_PROFILE }}
+          image: ${{ env.REGISTRY }}/${{ steps.repo.outputs.repository_lowercase }}/websocket-service:prod

--- a/.github/workflows/deploy-websocket-service-staging.yml
+++ b/.github/workflows/deploy-websocket-service-staging.yml
@@ -1,81 +1,39 @@
 name: Deploy Websocket Service Staging
+
 on:
   push:
     branches: a4i/staging
-  pull_request:
-    branches: a4i/staging
   workflow_call:
   workflow_dispatch:
+
 env:
   REGISTRY: ghcr.io
+
 jobs:
-  service:
+  deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        service:
-          - name: web-socket-service-staging
-            context: websocket-service
-            image: websocket-service
-            lang: node
-            azure_publish_profile: WEBSOCKET_SERVICE_AZURE_PUBLISH_PROFILE_STAGING
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up language (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/setup-node
-        with:
-          node-version: '20'
-          directory: ${{ matrix.service.context }}
-
-      - name: Run tests (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/run-node-tests
-        with:
-          directory: ${{ matrix.service.context }}
-
-      - name: Extract coverage (Node.js)
-        if: matrix.service.lang == 'node'
-        uses: ./.github/actions/extract-coverage-node
-        with:
-            directory: ${{ matrix.service.context }}
-            coverage_gist_token: ${{ secrets.COVERAGE_GIST_TOKEN }}
-            coverage_gist_id: ${{ vars.COVERAGE_GIST_ID }}
-
-      - name: Determine environment tag
-        id: env-tag
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/a4i/main" ]]; then
-            echo "tag=prod" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == "refs/heads/a4i/staging" ]]; then
-            echo "tag=staging" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
       - name: Build & push image
-        if: github.event_name == 'push'
         uses: ./.github/actions/deploy-docker
         with:
-          context: ${{ matrix.service.context }}
-          image: ${{ matrix.service.image }}
+          context: websocket-service
+          image: websocket-service
           registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          environment_tag: ${{ steps.env-tag.outputs.tag }}
+          environment_tag: staging
 
       - name: Normalize repo name to lowercase
         id: repo
-        run: |
-          echo "repository_lowercase=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+        run: echo "repository_lowercase=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
-      - name: Publish to Azure
-        if: github.event_name == 'push'
+      - name: Deploy to Azure
         uses: ./.github/actions/deploy-azure
         with:
-          app_name: ${{ matrix.service.name }}
-          publish_profile: ${{ secrets[matrix.service.azure_publish_profile] }}
-          image: ${{ env.REGISTRY }}/${{ steps.repo.outputs.repository_lowercase }}/${{ matrix.service.image }}:${{ steps.env-tag.outputs.tag }}
+          app_name: web-socket-service-staging
+          publish_profile: ${{ secrets.WEBSOCKET_SERVICE_AZURE_PUBLISH_PROFILE_STAGING }}
+          image: ${{ env.REGISTRY }}/${{ steps.repo.outputs.repository_lowercase }}/websocket-service:staging

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,33 +7,45 @@ on:
 
 jobs:
 
+  ci-workflow:
+    uses: ./.github/workflows/ci.yml
+    with:
+      upload_coverage: true
+    secrets: inherit
+
   deploy-websocket-service-main-workflow:
+    needs: ci-workflow
     if: github.ref == 'refs/heads/a4i/main'
     uses: ./.github/workflows/deploy-websocket-service-main.yml
     secrets: inherit
 
   deploy-websocket-service-staging-workflow:
+    needs: ci-workflow
     if: github.ref == 'refs/heads/a4i/staging'
     uses: ./.github/workflows/deploy-websocket-service-staging.yml
     secrets: inherit
 
   deploy-staging-workflow:
+    needs: ci-workflow
     if: github.ref == 'refs/heads/a4i/staging'
     uses: ./.github/workflows/deploy-staging.yml
     secrets: inherit
 
   deploy-main-workflow:
+    needs: ci-workflow
     if: github.ref == 'refs/heads/a4i/main'
     uses: ./.github/workflows/deploy-main.yml
     secrets: inherit
 
   deploy-android:
+    needs: ci-workflow
     if: github.ref == 'refs/heads/a4i/staging' || github.ref == 'refs/heads/a4i/main'
     uses: ./.github/workflows/android-deploy.yml
     secrets: inherit
 
   run-coverage-summary:
-    needs: deploy-staging-workflow
+    needs: ci-workflow
+    if: github.ref == 'refs/heads/a4i/staging'
     uses: ./.github/workflows/coverage-summary.yml
     secrets: inherit
 
@@ -41,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - ci-workflow
       - deploy-websocket-service-main-workflow
       - deploy-websocket-service-staging-workflow
       - deploy-staging-workflow
@@ -59,6 +72,7 @@ jobs:
           RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           JOB_MAPPING='{
+            "ci-workflow": "CI",
             "deploy-websocket-service-main-workflow": "Websocket",
             "deploy-websocket-service-staging-workflow": "Websocket",
             "deploy-staging-workflow": "Backend",
@@ -72,7 +86,7 @@ jobs:
             --argjson map "$JOB_MAPPING" \
             '
             ($needs | to_entries | map(select(.value.result != "skipped") | select($map[.key] != null))) as $jobs |
-            
+
             [
               {
                 "type": "ColumnSet",
@@ -107,7 +121,7 @@ jobs:
               }
             ]'
           )
-          
+
           echo "columns_json=$COLUMNS_JSON" >> $GITHUB_OUTPUT
 
       - name: Send Teams Notification

--- a/platform/app/consumers/content_job_consumer.py
+++ b/platform/app/consumers/content_job_consumer.py
@@ -71,7 +71,6 @@ import logging
 import os
 import subprocess  # nosec B404 — used safely with list form, no shell=True
 import tempfile
-from datetime import UTC, datetime
 from pathlib import Path
 
 from motor.motor_asyncio import AsyncIOMotorDatabase

--- a/platform/app/controllers/conference_controller.py
+++ b/platform/app/controllers/conference_controller.py
@@ -10,12 +10,9 @@ from fastapi import APIRouter, Depends
 from app.controllers._conference_helpers import get_conf_or_404
 from app.models.requests.call_requests import CreateConferenceRequest
 from app.models.responses.common import ConferenceStatusResponse, EventQueuedResponse
-from app.models.responses.login import MessageResponse
 from app.platform.auth.dependencies import (
-    get_current_user,
     require_conference_owner,
     require_role,
-    require_teacher,
 )
 from app.platform.lifespan import get_conference_manager
 from app.services.conference_service import (

--- a/platform/app/controllers/ivr_controller.py
+++ b/platform/app/controllers/ivr_controller.py
@@ -13,10 +13,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-
-from app.services.ivr_service import IVRService, get_ivr_service
+from fastapi import APIRouter
 
 logger = logging.getLogger(__name__)
 

--- a/platform/app/controllers/student_controller.py
+++ b/platform/app/controllers/student_controller.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 
 from app.models.requests.user_requests import StudentCreateRequest, StudentUpdateRequest
 from app.platform.auth.dependencies import require_role

--- a/platform/app/controllers/teacher_controller.py
+++ b/platform/app/controllers/teacher_controller.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 
 from app.models.requests.user_requests import TeacherUpdateRequest
 from app.models.responses.login import MessageResponse

--- a/platform/app/models/requests/auth_requests.py
+++ b/platform/app/models/requests/auth_requests.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class TeacherLoginRequest(BaseModel):

--- a/platform/app/models/requests/call_requests.py
+++ b/platform/app/models/requests/call_requests.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 
 class CallStartRequest(BaseModel):

--- a/platform/app/providers/websocket_client.py
+++ b/platform/app/providers/websocket_client.py
@@ -25,7 +25,9 @@ from app.models.playback_state import ContentStatus
 from app.models.ws_service_message import MessageType
 from app.platform.settings import get_settings
 from app.services.confevents.playback_state_update_event import PlaybackStateUpdateEvent
-from app.services.confevents.reconnect_comm_api_websocket_event import ReconnectCommApiWebsocketEvent
+from app.services.confevents.reconnect_comm_api_websocket_event import (
+    ReconnectCommApiWebsocketEvent,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/platform/app/repositories/school_repository.py
+++ b/platform/app/repositories/school_repository.py
@@ -5,8 +5,8 @@ from datetime import UTC, datetime
 
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
-from app.models.school import School
 from app.models.requests.school_requests import SchoolCreate
+from app.models.school import School
 from app.repositories.base_repository import BaseRepository
 
 

--- a/platform/app/services/auth_service.py
+++ b/platform/app/services/auth_service.py
@@ -17,7 +17,6 @@ from typing import Any
 from fastapi import Depends
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
-from app.models.responses.school_response import SchoolResponse
 from app.models.responses.user import UserPublicResponse
 from app.models.user import User, UserCreate, UserRole
 from app.platform.auth.dependencies import get_db

--- a/platform/app/services/ivr_service.py
+++ b/platform/app/services/ivr_service.py
@@ -22,7 +22,13 @@ import vonage
 from fastapi import Depends
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
-from app.models.ivr_state import ConversationRTCEventType, IVRCallStateMongoDoc, IVRCallStatus, IVRfsmDoc, UserAction
+from app.models.ivr_state import (
+    ConversationRTCEventType,
+    IVRCallStateMongoDoc,
+    IVRCallStatus,
+    IVRfsmDoc,
+    UserAction,
+)
 from app.platform.auth.dependencies import get_db
 from app.platform.settings import get_settings
 from app.providers.vonage_actions.action_factory import VonageActionFactory
@@ -31,10 +37,20 @@ from app.providers.vonage_actions.input_action import InputAction
 from app.providers.vonage_actions.talk_action import TalkAction
 from app.providers.websocket_client import WebsocketClientProvider, get_websocket_service
 from app.repositories.ivr_repository import IVRRepository
-from app.services.fsm.instantiation.insti import instantiate_from_latest_content, instantitate_from_doc
-from app.services.fsm.instantiation.pause_announcement import get_paused_announcement, get_resuming_announcement
+from app.services.fsm.instantiation.insti import (
+    instantiate_from_latest_content,
+    instantitate_from_doc,
+)
+from app.services.fsm.instantiation.pause_announcement import (
+    get_paused_announcement,
+    get_resuming_announcement,
+)
 from app.services.fsm.instantiation.speed_control import decrease_speed, increase_speed
-from app.services.fsm.utils import get_daily_limit_announcement, get_ist_date_string, get_vonage_language_code
+from app.services.fsm.utils import (
+    get_daily_limit_announcement,
+    get_ist_date_string,
+    get_vonage_language_code,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/platform/app/services/school_service.py
+++ b/platform/app/services/school_service.py
@@ -18,6 +18,7 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 
 from app.models.classroom import Classroom
 from app.models.requests.school_requests import ClassroomCreate, SchoolCreate, SchoolUpdateRequest
+from app.models.responses.classroom import ClassMemberResponse, ClassroomDetailResponse
 from app.models.responses.school_response import SchoolResponse
 from app.models.school import School
 from app.models.user import User, UserCreate, UserRole
@@ -223,8 +224,6 @@ class SchoolService:
 
     async def get_classroom_detail(self, classroom_id: str) -> ClassroomDetailResponse:
         """Fetch classroom with students and leaders hydrated into member objects."""
-        from app.models.responses.classroom import ClassMemberResponse, ClassroomDetailResponse  # noqa: PLC0415
-
         classroom = await self.get_classroom(classroom_id)
 
         all_ids = list(set(classroom.students) | set(classroom.leaders))

--- a/platform/migrations/001_rollback_unify_users.py
+++ b/platform/migrations/001_rollback_unify_users.py
@@ -61,7 +61,7 @@ async def rollback(mongo_uri: str, dry_run: bool) -> None:
             )
         if count > 5:
             print(f"  [DRY-RUN] ... and {count - 5} more.")
-        print(f"\n[DRY-RUN] No documents deleted (dry-run mode).")
+        print("\n[DRY-RUN] No documents deleted (dry-run mode).")
     else:
         result = await db["users"].delete_many(filter_query)
         print(f"Rollback complete — {result.deleted_count} document(s) removed from users.")

--- a/platform/migrations/002_verify_tenant_scoped_indexes.py
+++ b/platform/migrations/002_verify_tenant_scoped_indexes.py
@@ -52,7 +52,7 @@ _resolve_mongo_uri = _create_mod._resolve_mongo_uri
 
 def _index_key_from_spec(key_spec: list[tuple[str, int]]) -> dict[str, int]:
     """Convert a key_spec list to a dict matching MongoDB's index key format."""
-    return {field: direction for field, direction in key_spec}
+    return dict(key_spec)
 
 
 def _index_matches(existing_key: dict, expected_spec: list[tuple[str, int]]) -> bool:

--- a/platform/poetry.lock
+++ b/platform/poetry.lock
@@ -200,7 +200,7 @@ version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
     {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
@@ -235,7 +235,7 @@ version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
@@ -510,7 +510,7 @@ version = "2026.5.20"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
     {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
@@ -522,7 +522,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -609,7 +609,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\"", dev = "os_name == \"nt\" and implementation_name != \"pypy\""}
+markers = {main = "platform_python_implementation != \"PyPy\"", test = "os_name == \"nt\" and implementation_name != \"pypy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -774,12 +774,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -787,7 +787,7 @@ version = "7.14.1"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf"},
     {file = "coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf"},
@@ -986,7 +986,7 @@ version = "2.8.0"
 description = "DNS toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
     {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
@@ -1526,7 +1526,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1688,7 +1688,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1770,7 +1770,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -1808,7 +1808,7 @@ version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -1847,7 +1847,7 @@ version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
@@ -1935,7 +1935,7 @@ version = "4.3.0"
 description = "Fake pymongo stub for testing simple MongoDB-dependent code"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "mongomock-4.3.0-py2.py3-none-any.whl", hash = "sha256:5ef86bd12fc8806c6e7af32f21266c61b6c4ba96096f85129852d1c4fec1327e"},
     {file = "mongomock-4.3.0.tar.gz", hash = "sha256:32667b79066fabc12d4f17f16a8fd7361b5f4435208b3ba32c226e52212a8c30"},
@@ -1956,7 +1956,7 @@ version = "0.0.36"
 description = "Library for mocking AsyncIOMotorClient built on top of mongomock."
 optional = false
 python-versions = "<4.0,>=3.8"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "mongomock_motor-0.0.36-py3-none-any.whl", hash = "sha256:3ecb7949662b8986ff9c267fa0b1402b5b75a6afd57f03850cd6e13a067e3691"},
     {file = "mongomock_motor-0.0.36.tar.gz", hash = "sha256:3cf62352ece5af2f02e04d2f252393f88b5fe0487997da00584020cee4b8efba"},
@@ -1972,7 +1972,7 @@ version = "3.7.1"
 description = "Non-blocking MongoDB driver for Tornado or asyncio"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "motor-3.7.1-py3-none-any.whl", hash = "sha256:8a63b9049e38eeeb56b4fdd57c3312a6d1f25d01db717fe7d82222393c410298"},
     {file = "motor-3.7.1.tar.gz", hash = "sha256:27b4d46625c87928f331a6ca9d7c51c2f518ba0e270939d395bc1ddc89d64526"},
@@ -2725,7 +2725,7 @@ version = "1.3.0.post0"
 description = "Capture the outcome of Python function calls."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"},
     {file = "outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8"},
@@ -2740,7 +2740,7 @@ version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
@@ -2773,7 +2773,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -3018,12 +3018,12 @@ version = "3.0"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", dev = "os_name == \"nt\" and implementation_name != \"pypy\" and implementation_name != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", test = "os_name == \"nt\" and implementation_name != \"pypy\" and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -3211,7 +3211,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["dev", "test"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -3244,7 +3244,7 @@ version = "4.17.0"
 description = "PyMongo - the Official MongoDB Python driver"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "pymongo-4.17.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:47b021363cd923ace5edc7a1d63c0ff8a6d9d43859b8a1ba23645f5afae63221"},
     {file = "pymongo-4.17.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:422fa50d7d7f5c22ea0953554396c9ef95684a2d775f860bd75a7b510538dfca"},
@@ -3338,7 +3338,7 @@ version = "9.1.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
     {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
@@ -3360,7 +3360,7 @@ version = "1.4.0"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1"},
     {file = "pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"},
@@ -3380,7 +3380,7 @@ version = "7.1.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"},
     {file = "pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"},
@@ -3466,7 +3466,7 @@ version = "2026.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126"},
     {file = "pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"},
@@ -3659,7 +3659,7 @@ version = "0.15.18"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df"},
     {file = "ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2"},
@@ -3766,7 +3766,7 @@ version = "1.1.1"
 description = "Various objects to denote special meanings in python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "sentinels-1.1.1-py3-none-any.whl", hash = "sha256:835d3b28f3b47f5284afa4bf2db6e00f2dc5f80f9923d4b7e7aeeeccf6146a11"},
     {file = "sentinels-1.1.1.tar.gz", hash = "sha256:3c2f64f754187c19e0a1a029b148b74cf58dd12ec27b4e19c0e5d6e22b5a9a86"},
@@ -3811,7 +3811,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -3823,7 +3823,7 @@ version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
@@ -3866,7 +3866,7 @@ version = "0.33.0"
 description = "A friendly Python library for async concurrency and I/O"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["test"]
 files = [
     {file = "trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b"},
     {file = "trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970"},
@@ -3886,12 +3886,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "test"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {dev = "python_version == \"3.12\""}
+markers = {test = "python_version == \"3.12\""}
 
 [[package]]
 name = "typing-inspection"
@@ -4797,4 +4797,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "3ca063ce122a051f340f95c263e85ac9dae1dfd45b1651e8ec7ea481cbefb61b"
+content-hash = "52cdb1ef36b0c950b6a35106e42c84d11f5ed2832f8145d8f6276e547e044b1b"

--- a/platform/pyproject.toml
+++ b/platform/pyproject.toml
@@ -34,15 +34,16 @@ cryptography = ">=41.0"
 numpy = ">=1.26"
 scipy = ">=1.12"
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.test.dependencies]
 pytest = ">=8.0"
 pytest-asyncio = ">=0.23"
 pytest-cov = ">=4.1"
-httpx = ">=0.27"
 mongomock-motor = ">=0.0.21"
-bandit = ">=1.7"
 anyio = {extras = ["trio"], version = ">=4.0"}
 ruff = ">=0.4"
+
+[tool.poetry.group.dev.dependencies]
+bandit = ">=1.7"
 
 [tool.ruff]
 line-length = 100

--- a/platform/tests/integration/test_backend_p1.py
+++ b/platform/tests/integration/test_backend_p1.py
@@ -34,11 +34,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/platform/tests/integration/test_backend_p2.py
+++ b/platform/tests/integration/test_backend_p2.py
@@ -15,7 +15,6 @@ Coverage:
 
 from __future__ import annotations
 
-import asyncio
 import os
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,6 +26,8 @@ os.environ.setdefault("ENV", "development")
 os.environ.setdefault("MONGO_DB_CONNECTION_STRING", "")
 os.environ.setdefault("DB_CONNECTION", "")
 
+from datetime import UTC
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -35,7 +36,6 @@ from mongomock_motor import AsyncMongoMockClient
 from app.main import app
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.jwt import create_access_token
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -204,9 +204,9 @@ async def test_list_calls_requires_teacher(client):
 @pytest.mark.asyncio
 async def test_content_job_consumer_process_audio(mock_db):
     """ContentJobConsumer processes a pending job: mocks ffmpeg + blob, verifies temp file cleanup."""
-    from datetime import datetime, timezone
-    import tempfile
     import os
+    import tempfile
+    from datetime import datetime
 
     content_id = str(uuid.uuid4())
     job_id = str(uuid.uuid4())
@@ -230,7 +230,7 @@ async def test_content_job_consumer_process_audio(mock_db):
         "_id": job_id,
         "content_id": content_id,
         "status": "pending",
-        "created_at": datetime.now(timezone.utc),
+        "created_at": datetime.now(UTC),
     })
 
     # Track temp files created
@@ -279,7 +279,7 @@ async def test_content_job_consumer_process_audio(mock_db):
 @pytest.mark.asyncio
 async def test_content_job_dead_letter_on_failure(mock_db):
     """A job with a corrupt blob URL is dead-lettered: status=failed with reason set."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     content_id = str(uuid.uuid4())
     job_id = str(uuid.uuid4())
@@ -302,7 +302,7 @@ async def test_content_job_dead_letter_on_failure(mock_db):
         "_id": job_id,
         "content_id": content_id,
         "status": "pending",
-        "created_at": datetime.now(timezone.utc),
+        "created_at": datetime.now(UTC),
     })
 
     # Mock blob provider to always fail

--- a/platform/tests/integration/test_call_controller_extra2.py
+++ b/platform/tests/integration/test_call_controller_extra2.py
@@ -10,7 +10,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-integration-tests-32ch"
 os.environ.setdefault("APP_MODE", "api")
 os.environ.setdefault("ENV", "development")
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -18,10 +18,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture

--- a/platform/tests/integration/test_conference.py
+++ b/platform/tests/integration/test_conference.py
@@ -25,17 +25,16 @@ os.environ.setdefault("ENV", "development")
 os.environ.setdefault("MONGO_DB_CONNECTION_STRING", "")
 os.environ.setdefault("DB_CONNECTION", "")
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.main import app
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/platform/tests/integration/test_content_call_extra.py
+++ b/platform/tests/integration/test_content_call_extra.py
@@ -20,11 +20,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/platform/tests/integration/test_content_controller_deep.py
+++ b/platform/tests/integration/test_content_controller_deep.py
@@ -10,7 +10,6 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-integration-tests-32ch"
 os.environ.setdefault("APP_MODE", "api")
 os.environ.setdefault("ENV", "development")
 
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -18,10 +17,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture

--- a/platform/tests/integration/test_controllers_call_webhook.py
+++ b/platform/tests/integration/test_controllers_call_webhook.py
@@ -13,7 +13,7 @@ os.environ.setdefault("ENV", "development")
 os.environ.setdefault("MONGO_DB_CONNECTION_STRING", "")
 os.environ.setdefault("DB_CONNECTION", "")
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -21,11 +21,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -162,7 +161,6 @@ class TestWebhookController:
     async def test_conference_webhook_event_exists(self, client, mock_db):
         # The webhook requires conference_manager to be initialized. In test mode,
         # it will return 500 due to RuntimeError, or 200/204 if manager is up.
-        from app.platform.lifespan import get_conference_manager
         mock_mgr = MagicMock()
         mock_mgr.get_conference = MagicMock(return_value=None)
         with patch("app.controllers.webhook_controller.get_conference_manager", return_value=mock_mgr):

--- a/platform/tests/integration/test_controllers_extended.py
+++ b/platform/tests/integration/test_controllers_extended.py
@@ -21,11 +21,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/platform/tests/integration/test_participants_extra.py
+++ b/platform/tests/integration/test_participants_extra.py
@@ -18,10 +18,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture

--- a/platform/tests/integration/test_participants_v2_extra.py
+++ b/platform/tests/integration/test_participants_v2_extra.py
@@ -18,10 +18,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture
@@ -226,8 +226,9 @@ class TestParticipantsControllerV2:
     @pytest.mark.asyncio
     async def test_get_conf_helper_not_found(self, client, mock_db):
         """Direct unit test for get_conf_or_404."""
-        from app.controllers._conference_helpers import get_conf_or_404
         from fastapi import HTTPException
+
+        from app.controllers._conference_helpers import get_conf_or_404
 
         mock_mgr = _make_mock_mgr(conf=None)
         with patch("app.platform.lifespan.get_conference_manager", return_value=mock_mgr):

--- a/platform/tests/integration/test_playback_blob_extra.py
+++ b/platform/tests/integration/test_playback_blob_extra.py
@@ -10,7 +10,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-integration-tests-32ch"
 os.environ.setdefault("APP_MODE", "api")
 os.environ.setdefault("ENV", "development")
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -18,10 +18,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture

--- a/platform/tests/integration/test_school_controller_extra.py
+++ b/platform/tests/integration/test_school_controller_extra.py
@@ -10,7 +10,6 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-integration-tests-32ch"
 os.environ.setdefault("APP_MODE", "api")
 os.environ.setdefault("ENV", "development")
 
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -18,10 +17,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture

--- a/platform/tests/integration/test_school_users_deep.py
+++ b/platform/tests/integration/test_school_users_deep.py
@@ -10,19 +10,17 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-integration-tests-32ch"
 os.environ.setdefault("APP_MODE", "api")
 os.environ.setdefault("ENV", "development")
 
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
-from bson import ObjectId
 from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture
@@ -228,7 +226,7 @@ class TestUsersControllerDeep:
         token = _school_admin_token(teacher["_id"])
 
         # Create first
-        resp1 = await client.post("/student", json={
+        await client.post("/student", json={
             "name": "Student A",
             "phoneNumber": "+919999999997",
         }, headers={"Authorization": f"Bearer {token}"})

--- a/platform/tests/integration/test_shared_helpers_and_gaps.py
+++ b/platform/tests/integration/test_shared_helpers_and_gaps.py
@@ -27,7 +27,6 @@ from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -91,8 +90,9 @@ class TestConferenceHelpersShared:
         assert result is mock_conf
 
     def test_raises_404_when_not_found(self) -> None:
-        from app.controllers._conference_helpers import get_conf_or_404
         from fastapi import HTTPException
+
+        from app.controllers._conference_helpers import get_conf_or_404
         mock_mgr = MagicMock()
         mock_mgr.get_conference.return_value = None
         with patch("app.platform.lifespan.get_conference_manager", return_value=mock_mgr):
@@ -102,21 +102,21 @@ class TestConferenceHelpersShared:
         assert "Conference not found" in exc_info.value.detail
 
     def test_participants_controller_uses_shared_helper(self) -> None:
-        import app.controllers.participants_controller as pc
         import app.controllers._conference_helpers as ch
+        import app.controllers.participants_controller as pc
         # _get_conf_or_404 must no longer exist locally; get_conf_or_404 is imported
         assert not hasattr(pc, "_get_conf_or_404")
         assert pc.get_conf_or_404 is ch.get_conf_or_404
 
     def test_playback_controller_uses_shared_helper(self) -> None:
-        import app.controllers.playback_controller as plc
         import app.controllers._conference_helpers as ch
+        import app.controllers.playback_controller as plc
         assert not hasattr(plc, "_get_conf_or_404")
         assert plc.get_conf_or_404 is ch.get_conf_or_404
 
     def test_conference_controller_uses_shared_helper(self) -> None:
-        import app.controllers.conference_controller as cc
         import app.controllers._conference_helpers as ch
+        import app.controllers.conference_controller as cc
         assert not hasattr(cc, "_get_conf_or_404")
         assert cc.get_conf_or_404 is ch.get_conf_or_404
 

--- a/platform/tests/integration/test_users_controller_extra.py
+++ b/platform/tests/integration/test_users_controller_extra.py
@@ -10,7 +10,6 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-integration-tests-32ch"
 os.environ.setdefault("APP_MODE", "api")
 os.environ.setdefault("ENV", "development")
 
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -18,10 +17,10 @@ from httpx import ASGITransport, AsyncClient
 from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
+from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
 from app.platform.auth.hashing import hash_password
 from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture

--- a/platform/tests/integration/test_webhook_extra.py
+++ b/platform/tests/integration/test_webhook_extra.py
@@ -19,9 +19,6 @@ from mongomock_motor import AsyncMongoMockClient
 
 from app.main import app
 from app.platform.auth.dependencies import get_db
-from app.platform.auth.hashing import hash_password
-from app.platform.auth.jwt import create_access_token
-from app.models.user import UserRole
 
 
 @pytest_asyncio.fixture

--- a/platform/tests/regression/test_fsm_parity.py
+++ b/platform/tests/regression/test_fsm_parity.py
@@ -7,45 +7,48 @@ no Service Bus, no Vonage calls.
 
 from __future__ import annotations
 
-import asyncio
-import pytest
-from typing import Any, Dict, List
+from datetime import datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from app.models.ivr_state import IVRCallStateMongoDoc
+from app.providers.vonage_actions.base.action import Action
+from app.providers.vonage_actions.input_action import InputAction
+from app.providers.vonage_actions.stream_action import StreamAction
+from app.providers.vonage_actions.talk_action import TalkAction
+from app.services.fsm.fsm import FSM
+from app.services.fsm.operations.daily_limit_pre_operation import DailyLimitPreOperation
+from app.services.fsm.state import State
+from app.services.fsm.transition import Transition
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 def _make_stream_action(url: str):
-    from app.providers.vonage_actions.stream_action import StreamAction  # noqa: PLC0415
     return StreamAction(url=url)
 
 
 def _make_talk_action(text: str):
-    from app.providers.vonage_actions.talk_action import TalkAction  # noqa: PLC0415
     return TalkAction(text=text, level=1.0, bargeIn=False, loop=1, language="en-US")
 
 
 def _make_input_action():
-    from app.providers.vonage_actions.input_action import InputAction  # noqa: PLC0415
     return InputAction(type_=["dtmf"], eventApi="/input", timeOut=10)
 
 
 def _make_state(state_id: str, actions=None):
-    from app.services.fsm.state import State  # noqa: PLC0415
     return State(state_id=state_id, actions=actions or [])
 
 
 def _make_transition(input_key: str, src: str, dst: str, actions=None):
-    from app.services.fsm.transition import Transition  # noqa: PLC0415
     return Transition(input=input_key, source_state_id=src, dest_state_id=dst, actions=actions or [])
 
 
 def _make_ivr_state_doc(conv_id: str, current_state_id: str, phone: str = "+1234567890"):
     """Build a minimal IVRCallStateMongoDoc in-memory."""
-    from app.models.ivr_state import IVRCallStateMongoDoc  # noqa: PLC0415
-    from datetime import datetime  # noqa: PLC0415
     return IVRCallStateMongoDoc(
         _id=conv_id,
         phone_number=phone,
@@ -69,8 +72,6 @@ def _build_simple_fsm() -> Any:
     All states have a StreamAction. States LA1 and LA2 are leaf nodes
     with a back-to-root key "9".
     """
-    from app.services.fsm.fsm import FSM  # noqa: PLC0415
-
     with patch("app.services.fsm.fsm.get_settings") as mock_settings:
         mock_settings.return_value.storage_account_name = ""
         mock_settings.return_value.ivr_daily_listening_limit_seconds = 1800
@@ -235,8 +236,6 @@ class TestFSMSerializationRoundTrip:
         assert state_ids == {"LA0", "LA1", "LA2"}
 
     def test_deserialize_round_trip(self):
-        from app.services.fsm.fsm import FSM  # noqa: PLC0415
-
         fsm = _build_simple_fsm()
         with patch("app.services.fsm.fsm.get_settings") as mock_settings:
             mock_settings.return_value.storage_account_name = ""
@@ -255,9 +254,6 @@ class TestFSMSerializationRoundTrip:
         assert "9" in fsm2.states["LA1"].transition_map
 
     def test_action_to_json_from_json_round_trip(self):
-        from app.providers.vonage_actions.stream_action import StreamAction  # noqa: PLC0415
-        from app.providers.vonage_actions.base.action import Action  # noqa: PLC0415
-
         action = StreamAction(url="https://example.com/audio.mp3", record_playback_time=False)
         data = action.to_json()
         restored = Action.from_json(data)
@@ -267,8 +263,6 @@ class TestFSMSerializationRoundTrip:
         assert restored.record_playback_time == action.record_playback_time
 
     def test_transition_to_json_from_json(self):
-        from app.services.fsm.transition import Transition  # noqa: PLC0415
-
         t = _make_transition("1", "LA0", "LA1", [_make_stream_action("a.mp3")])
         data = t.to_json()
         restored = Transition.from_json(data)
@@ -283,8 +277,6 @@ class TestDailyLimitPreOperation:
     """DailyLimitPreOperation sets flag in experience_data."""
 
     def test_execute_sets_daily_limit_check_flag(self):
-        from app.services.fsm.operations.daily_limit_pre_operation import DailyLimitPreOperation  # noqa: PLC0415
-
         op = DailyLimitPreOperation(duration_seconds=300.0, language="kannada", school_id="sch1")
         doc = _make_ivr_state_doc("conv6", "LA0")
 
@@ -299,8 +291,6 @@ class TestDailyLimitPreOperation:
         assert check["school_id"] == "sch1"
 
     def test_execute_noop_when_no_doc(self):
-        from app.services.fsm.operations.daily_limit_pre_operation import DailyLimitPreOperation  # noqa: PLC0415
-
         op = DailyLimitPreOperation(duration_seconds=100.0, language="hindi")
         # Should not raise
         op.execute(fsm=MagicMock(), fsm_state_doc=None)
@@ -311,7 +301,6 @@ class TestDailyLimitPreOperation:
         fsm = _build_simple_fsm()
 
         # Add daily limit pre-operation to LA1
-        from app.services.fsm.operations.daily_limit_pre_operation import DailyLimitPreOperation  # noqa: PLC0415
         fsm.states["LA1"].pre_operation = DailyLimitPreOperation(
             duration_seconds=300.0, language="kannada"
         )
@@ -337,7 +326,6 @@ class TestDailyLimitPreOperation:
         # Should still advance to LA1 (limit actions are served AT the dest state)
         assert next_state_id == "LA1"
         # But actions should be the limit announcement (TalkAction), not option_a.mp3
-        from app.providers.vonage_actions.talk_action import TalkAction  # noqa: PLC0415
         assert any(isinstance(a, TalkAction) for a in actions), (
             "Expected TalkAction limit announcement when daily limit exceeded"
         )
@@ -347,7 +335,6 @@ class TestDailyLimitPreOperation:
         """When usage is below limit, navigation proceeds normally."""
         fsm = _build_simple_fsm()
 
-        from app.services.fsm.operations.daily_limit_pre_operation import DailyLimitPreOperation  # noqa: PLC0415
         fsm.states["LA1"].pre_operation = DailyLimitPreOperation(
             duration_seconds=300.0, language="kannada"
         )
@@ -371,7 +358,6 @@ class TestDailyLimitPreOperation:
 
         assert next_state_id == "LA1"
         # No limit TalkAction expected
-        from app.providers.vonage_actions.talk_action import TalkAction  # noqa: PLC0415
         assert not any(isinstance(a, TalkAction) for a in actions), (
             "Should not return limit announcement when usage is within limit"
         )

--- a/platform/tests/security/test_hardening.py
+++ b/platform/tests/security/test_hardening.py
@@ -17,10 +17,14 @@ Tests:
 
 from __future__ import annotations
 
-import asyncio
 import base64  # used by _b64 helper
+
+# ---------------------------------------------------------------------------
+# JWT helpers
+# ---------------------------------------------------------------------------
+import hashlib
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,14 +32,6 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
-
-
-# ---------------------------------------------------------------------------
-# JWT helpers
-# ---------------------------------------------------------------------------
-
-import hashlib
-import json as _json
 
 
 def _make_vonage_token(
@@ -63,13 +59,13 @@ async def _noop_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 def _mock_settings(**overrides):
     from app.platform.settings import Settings
-    defaults = dict(
-        env="production",
-        mongo_db_connection_string="",
-        vonage_api_key="test-api-key",
-        vonage_conference_application_id="test-conf-app",
-        vonage_ivr_application_id="test-ivr-app",
-    )
+    defaults = {
+        "env": "production",
+        "mongo_db_connection_string": "",
+        "vonage_api_key": "test-api-key",
+        "vonage_conference_application_id": "test-conf-app",
+        "vonage_ivr_application_id": "test-ivr-app",
+    }
     return Settings(**{**defaults, **overrides})
 
 
@@ -348,7 +344,7 @@ def test_websocket_valid_secret_connects():
         except WebSocketDisconnect as exc:
             # A normal close (not 1008) still means the handshake succeeded
             assert exc.code != 1008, (
-                f"Expected successful connection but got 1008 Policy Violation"
+                "Expected successful connection but got 1008 Policy Violation"
             )
         except Exception as exc:
             exc_str = str(exc)

--- a/platform/tests/unit/test_audio_capture_extra.py
+++ b/platform/tests/unit/test_audio_capture_extra.py
@@ -4,11 +4,10 @@ Extra coverage for audio_capture.py service.
 
 from __future__ import annotations
 
-import os
 import tempfile
-import wave
+from unittest.mock import MagicMock
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 
 class TestAudioCaptureServiceEnabled:

--- a/platform/tests/unit/test_audio_recording_extra.py
+++ b/platform/tests/unit/test_audio_recording_extra.py
@@ -4,14 +4,15 @@ Extra coverage for audio_recording_consumer.py.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 class TestAudioRecordingConsumerExtra:
     @pytest.mark.asyncio
     async def test_handle_audio_frame_with_session(self) -> None:
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer, AudioFrame
+        from app.consumers.audio_recording_consumer import AudioFrame, AudioRecordingConsumer
 
         consumer = AudioRecordingConsumer()
         frame = AudioFrame(conference_id="conf1", audio_bytes=b"\x00" * 100)
@@ -25,20 +26,23 @@ class TestAudioRecordingConsumerExtra:
 
     @pytest.mark.asyncio
     async def test_handle_audio_frame_write_error(self) -> None:
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer, AudioFrame
+        from app.consumers.audio_recording_consumer import AudioFrame, AudioRecordingConsumer
 
         consumer = AudioRecordingConsumer()
         frame = AudioFrame(conference_id="conf1", audio_bytes=b"\x00" * 100)
 
         mock_session = MagicMock()
-        mock_session.write_chunk = MagicMock(side_effect=IOError("disk error"))
+        mock_session.write_chunk = MagicMock(side_effect=OSError("disk error"))
         consumer._capture_sessions["conf1"] = mock_session
 
         await consumer._handle_audio_frame(frame)  # Should not raise
 
     @pytest.mark.asyncio
     async def test_handle_finalize_no_session(self) -> None:
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer, FinalizeConference
+        from app.consumers.audio_recording_consumer import (
+            AudioRecordingConsumer,
+            FinalizeConference,
+        )
 
         consumer = AudioRecordingConsumer()
         msg = FinalizeConference(conference_id="gone_conf")
@@ -47,7 +51,10 @@ class TestAudioRecordingConsumerExtra:
 
     @pytest.mark.asyncio
     async def test_handle_finalize_with_url(self) -> None:
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer, FinalizeConference
+        from app.consumers.audio_recording_consumer import (
+            AudioRecordingConsumer,
+            FinalizeConference,
+        )
 
         consumer = AudioRecordingConsumer()
         msg = FinalizeConference(conference_id="conf1")
@@ -61,7 +68,10 @@ class TestAudioRecordingConsumerExtra:
 
     @pytest.mark.asyncio
     async def test_handle_finalize_finalize_error(self) -> None:
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer, FinalizeConference
+        from app.consumers.audio_recording_consumer import (
+            AudioRecordingConsumer,
+            FinalizeConference,
+        )
 
         consumer = AudioRecordingConsumer()
         msg = FinalizeConference(conference_id="conf1")
@@ -75,8 +85,12 @@ class TestAudioRecordingConsumerExtra:
     @pytest.mark.asyncio
     async def test_handle_finalize_with_url_analysis_queue_full(self) -> None:
         """When analysis queue is full, should log warning and not crash."""
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer, FinalizeConference
         import asyncio
+
+        from app.consumers.audio_recording_consumer import (
+            AudioRecordingConsumer,
+            FinalizeConference,
+        )
 
         consumer = AudioRecordingConsumer()
         msg = FinalizeConference(conference_id="conf_full")

--- a/platform/tests/unit/test_audio_ws_consumers2.py
+++ b/platform/tests/unit/test_audio_ws_consumers2.py
@@ -5,9 +5,9 @@ websocket_client message class, and call_webhook_consumer.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # AudioCaptureService — disabled mode (safe, no file I/O)
@@ -188,8 +188,9 @@ class TestWebsocketClientProviderMessage:
         assert "position_seconds" not in d  # None omitted
 
     def test_message_model_dump_json(self) -> None:
-        from app.providers.websocket_client import WebsocketServiceMessage
         import json
+
+        from app.providers.websocket_client import WebsocketServiceMessage
 
         msg = WebsocketServiceMessage(
             websocket_id="ws3",
@@ -280,7 +281,7 @@ class TestCallWebhookConsumer:
 
 class TestTeacherDisconnectTimerDeeper:
     def _mock_conf_call(self, auto_end_enabled=True, timeout_minutes=2):
-        from unittest.mock import MagicMock, AsyncMock
+        from unittest.mock import AsyncMock, MagicMock
         conf_call = MagicMock()
         conf_call.conf_id = "conf_timer_1"
         conf_call.state = MagicMock()
@@ -291,7 +292,9 @@ class TestTeacherDisconnectTimerDeeper:
         return conf_call
 
     def test_start_event_auto_end_enabled_attr(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_timeout_minutes = 2
@@ -304,7 +307,9 @@ class TestTeacherDisconnectTimerDeeper:
 
     @pytest.mark.asyncio
     async def test_cancel_timer_event_no_active_timer(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import CancelTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            CancelTeacherDisconnectTimerEvent,
+        )
 
         conf_call = self._mock_conf_call()
         conf_call.state.auto_end_state.is_active = False
@@ -315,7 +320,9 @@ class TestTeacherDisconnectTimerDeeper:
     @pytest.mark.asyncio
     async def test_start_timer_enabled_no_teacher(self) -> None:
         """Timer enabled but no teacher phone — should complete without hanging."""
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_timeout_minutes = 1

--- a/platform/tests/unit/test_blob_storage_extra.py
+++ b/platform/tests/unit/test_blob_storage_extra.py
@@ -4,8 +4,9 @@ Extra unit coverage for blob_storage.py provider.
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 
 class TestParseBlobUrl:

--- a/platform/tests/unit/test_conference_service.py
+++ b/platform/tests/unit/test_conference_service.py
@@ -7,12 +7,10 @@ no real network calls are made.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -341,15 +339,17 @@ class TestConfeventModels:
         assert evt.phone_number == "+111"
 
     def test_reconnect_comm_api_event_construction(self) -> None:
-        from app.services.confevents.reconnect_comm_api_websocket_event import ReconnectCommApiWebsocketEvent
+        from app.services.confevents.reconnect_comm_api_websocket_event import (
+            ReconnectCommApiWebsocketEvent,
+        )
 
         call = _make_conf_call()
         evt = ReconnectCommApiWebsocketEvent(conf_call=call)
         assert evt.conf_call is call
 
     def test_playback_state_update_event_construction(self) -> None:
-        from app.services.confevents.playback_state_update_event import PlaybackStateUpdateEvent
         from app.models.playback_state import ContentStatus
+        from app.services.confevents.playback_state_update_event import PlaybackStateUpdateEvent
 
         call = _make_conf_call()
         evt = PlaybackStateUpdateEvent(conf_call=call, content_state=ContentStatus.PLAYING)
@@ -364,8 +364,8 @@ class TestConfeventModels:
 class TestConfeventExecution:
     @pytest.mark.asyncio
     async def test_pause_content_event_sends_pause_message(self) -> None:
-        from app.services.confevents.pause_content_event import PauseContentEvent
         from app.models.ws_service_message import MessageType
+        from app.services.confevents.pause_content_event import PauseContentEvent
 
         call = _make_conf_call()
         call.storage_manager.save_state = AsyncMock()

--- a/platform/tests/unit/test_conference_service_extra.py
+++ b/platform/tests/unit/test_conference_service_extra.py
@@ -4,8 +4,10 @@ Extra coverage for conference_service.py.
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def _make_conf_call(conf_id="test_conf"):
@@ -110,14 +112,14 @@ class TestConferenceCallExtra:
 
         # Create an event that will timeout
         slow_event = MagicMock()
-        slow_event.execute_event = AsyncMock(side_effect=asyncio.TimeoutError())
+        slow_event.execute_event = AsyncMock(side_effect=TimeoutError())
 
         await conf.event_queue.put(slow_event)
         # Manually process one event from queue
         event = conf.event_queue.get_nowait()
         try:
             await asyncio.wait_for(event.execute_event(), timeout=0.1)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass  # Expected
         finally:
             conf.event_queue.task_done()
@@ -193,10 +195,8 @@ class TestConferenceCallExtra:
         conf.communication_api.start_conference = AsyncMock(return_value="vonage_conv_id")
         conf.state.teacher_phone_number = "+111"
 
-        try:
+        with contextlib.suppress(Exception):
             await conf.start_conference()
-        except Exception:
-            pass  # May fail without real vonage setup
 
 
 class TestConferenceCallManagerExtra2:

--- a/platform/tests/unit/test_confevents_call_dtmf.py
+++ b/platform/tests/unit/test_confevents_call_dtmf.py
@@ -4,8 +4,10 @@ Coverage for DTMFInputEvent and CallStatusChangeEvent.
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.models.participant import CallStatus, Role
 
@@ -95,10 +97,8 @@ class TestDTMFInputEvent:
         conf.state.participants["+222"].call_status = CallStatus.CONNECTED
 
         event = DTMFInputEvent(phone_number="+222", digit="1", conf_call=conf)
-        try:
+        with contextlib.suppress(Exception):
             await event.execute_event()
-        except Exception:
-            pass  # Vonage not available
 
     @pytest.mark.asyncio
     async def test_leader_digit_3_unmute_all(self) -> None:
@@ -106,15 +106,13 @@ class TestDTMFInputEvent:
 
         conf = _make_conf(teacher_phone="+111", student_phones=["+222"], leader_phone="+222")
         event = DTMFInputEvent(phone_number="+222", digit="3", conf_call=conf)
-        try:
+        with contextlib.suppress(Exception):
             await event.execute_event()
-        except Exception:
-            pass
 
     @pytest.mark.asyncio
     async def test_leader_digit_6_no_content_returns_early(self) -> None:
-        from app.services.confevents.dtmf_input_event import DTMFInputEvent
         from app.models.playback_state import ContentStatus
+        from app.services.confevents.dtmf_input_event import DTMFInputEvent
 
         conf = _make_conf(teacher_phone="+111", student_phones=["+222"], leader_phone="+222")
         conf.state.audio_content_state.status = ContentStatus.STOPPED

--- a/platform/tests/unit/test_confevents_timer_deep.py
+++ b/platform/tests/unit/test_confevents_timer_deep.py
@@ -4,9 +4,10 @@ Deep coverage for teacher_disconnect_timer_event, confevents, conference_service
 
 from __future__ import annotations
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # StartTeacherDisconnectTimerEvent
@@ -40,7 +41,9 @@ class TestStartTeacherDisconnectTimerEvent:
 
     @pytest.mark.asyncio
     async def test_execute_auto_end_disabled(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_enabled = False
@@ -55,7 +58,9 @@ class TestStartTeacherDisconnectTimerEvent:
 
     @pytest.mark.asyncio
     async def test_execute_teacher_connected_returns_early(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_enabled = True
@@ -69,7 +74,9 @@ class TestStartTeacherDisconnectTimerEvent:
 
     @pytest.mark.asyncio
     async def test_execute_no_teacher_returns_early(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_enabled = True
@@ -86,7 +93,9 @@ class TestStartTeacherDisconnectTimerEvent:
 class TestCancelTeacherDisconnectTimerEvent:
     @pytest.mark.asyncio
     async def test_cancel_no_task(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import CancelTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            CancelTeacherDisconnectTimerEvent,
+        )
 
         conf = MagicMock()
         conf.state = MagicMock()
@@ -101,7 +110,9 @@ class TestCancelTeacherDisconnectTimerEvent:
 
     @pytest.mark.asyncio
     async def test_cancel_active_task(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import CancelTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            CancelTeacherDisconnectTimerEvent,
+        )
 
         conf = MagicMock()
         conf.state = MagicMock()
@@ -217,10 +228,8 @@ class TestConferenceCallExtra:
         conf.state.auto_end_state.expires_at = future
         conf.state.auto_end_state.timeout_minutes = 5
         conf.queue_event = AsyncMock()
-        try:
+        with contextlib.suppress(Exception):
             conf.restore_auto_end_timer()
-        except Exception:
-            pass  # May create asyncio task
 
     def test_conference_call_id_attribute(self) -> None:
         conf = self._make_conf_call()

--- a/platform/tests/unit/test_consumers_audio_deep.py
+++ b/platform/tests/unit/test_consumers_audio_deep.py
@@ -5,9 +5,10 @@ hold_detector deeper methods.
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # CallEventConsumer
@@ -203,8 +204,8 @@ class TestPureAudioBuilder:
         assert pa.speechRate == "1.0"
 
     def test_pure_audio_generate_state(self) -> None:
-        from app.services.fsm.instantiation.pure_audio import PureAudio
         from app.services.fsm.fsm import FSM
+        from app.services.fsm.instantiation.pure_audio import PureAudio
         from app.services.fsm.state import State
 
         pa_data = self._make_pure_audio_data()
@@ -311,7 +312,5 @@ class TestConferenceConfeventsDeeper:
         conf.update_state = AsyncMock()
 
         event = DTMFInputEvent(phone_number="+111", digit="2", conf_call=conf)
-        try:
+        with contextlib.suppress(Exception):
             await event.execute_event()
-        except Exception:
-            pass  # OK — no FSM state in mock

--- a/platform/tests/unit/test_consumers_extra.py
+++ b/platform/tests/unit/test_consumers_extra.py
@@ -5,9 +5,10 @@ and content job consumer utilities.
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # Audio recording consumer — pure message classes + queue
@@ -29,15 +30,17 @@ class TestAudioRecordingConsumer:
         assert msg.conference_id == "conf1"
 
     def test_get_audio_analysis_queue(self) -> None:
-        from app.consumers.audio_recording_consumer import get_audio_analysis_queue
         import asyncio
+
+        from app.consumers.audio_recording_consumer import get_audio_analysis_queue
 
         q = get_audio_analysis_queue()
         assert isinstance(q, asyncio.Queue)
 
     def test_audio_recording_consumer_instantiation(self) -> None:
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer
         import asyncio
+
+        from app.consumers.audio_recording_consumer import AudioRecordingConsumer
 
         consumer = AudioRecordingConsumer()
         assert isinstance(consumer._queue, asyncio.Queue)
@@ -61,6 +64,7 @@ class TestAudioRecordingConsumer:
 class TestContentJobConsumerUtils:
     def test_content_job_consumer_instantiation(self) -> None:
         import mongomock_motor
+
         from app.consumers.content_job_consumer import ContentJobConsumer
 
         client = mongomock_motor.AsyncMongoMockClient()
@@ -71,17 +75,16 @@ class TestContentJobConsumerUtils:
     @pytest.mark.asyncio
     async def test_content_job_consumer_process_unknown_raises(self) -> None:
         import mongomock_motor
-        from app.consumers.content_job_consumer import ContentJobConsumer
+
         from app.consumers.base_consumer import PermanentError
+        from app.consumers.content_job_consumer import ContentJobConsumer
 
         client = mongomock_motor.AsyncMongoMockClient()
         db = client["test_cjc_stop"]
         consumer = ContentJobConsumer(db)
         # Unknown message type should raise
-        try:
+        with contextlib.suppress(PermanentError, Exception):
             await consumer.process("unknown")
-        except (PermanentError, Exception):
-            pass  # Expected
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +140,6 @@ class TestConferenceCallDeeper:
         await cc.stream_system_message("TEST_MESSAGE")
 
     def test_start_processing_marks_running(self) -> None:
-        import asyncio
         cc = self._make_conf_call()
         # create_task needs event loop — skip if no loop
         # Just test the flag mechanism directly
@@ -325,7 +327,7 @@ class TestLifespanAppMode:
 
 class TestWebhookEventModel:
     def test_webhook_event_creation(self) -> None:
-        from app.models.webhook_event import WebHookEvent, EventType
+        from app.models.webhook_event import EventType, WebHookEvent
 
         event = WebHookEvent(
             conference_id="conf1",
@@ -335,7 +337,7 @@ class TestWebhookEventModel:
         assert event.conference_id == "conf1"
 
     def test_webhook_event_with_participant(self) -> None:
-        from app.models.webhook_event import WebHookEvent, EventType
+        from app.models.webhook_event import EventType, WebHookEvent
 
         event = WebHookEvent(
             conference_id="conf1",
@@ -349,7 +351,7 @@ class TestWebhookEventModel:
 
 class TestWSServiceMessage:
     def test_ws_message_creation(self) -> None:
-        from app.models.ws_service_message import WebsocketServiceMessage, MessageType
+        from app.models.ws_service_message import MessageType, WebsocketServiceMessage
 
         msg = WebsocketServiceMessage(
             websocket_id="ws1",
@@ -359,7 +361,7 @@ class TestWSServiceMessage:
         assert msg.websocket_id == "ws1"
 
     def test_ws_message_play_audio(self) -> None:
-        from app.models.ws_service_message import WebsocketServiceMessage, MessageType
+        from app.models.ws_service_message import MessageType, WebsocketServiceMessage
 
         msg = WebsocketServiceMessage(
             websocket_id="ws2",
@@ -416,8 +418,8 @@ class TestAuditRepositoryExtra:
 
     @pytest.mark.asyncio
     async def test_create_and_find_logs(self, db) -> None:
-        from app.repositories.audit_repository import AuditRepository
         from app.models.audit_log import AuditLog
+        from app.repositories.audit_repository import AuditRepository
 
         repo = AuditRepository(db)
         log = AuditLog(user="u1", logText="action1", time="10:00", priority=1, tenant_id="t1")

--- a/platform/tests/unit/test_consumers_extra2.py
+++ b/platform/tests/unit/test_consumers_extra2.py
@@ -5,9 +5,10 @@ call_webhook_consumer, audio_recording_consumer helper functions.
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # ContentJobConsumer
@@ -33,9 +34,10 @@ class TestContentJobConsumerExtra:
         assert consumer._running is False
 
     def test_validate_temp_path_valid(self) -> None:
-        from app.consumers.content_job_consumer import _validate_temp_path
-        import tempfile
         import os
+        import tempfile
+
+        from app.consumers.content_job_consumer import _validate_temp_path
 
         # Create a valid temp path
         tmp_dir = tempfile.gettempdir()
@@ -178,10 +180,8 @@ class TestCallWebhookConsumerExtra:
 
         with patch("app.consumers.call_webhook_consumer.IVRService", return_value=mock_instance):
             with patch("app.platform.database.get_database", return_value=mock_db):
-                try:
+                with contextlib.suppress(Exception):
                     await consumer.process(msg)
-                except Exception:
-                    pass  # Acceptable — DB not available
 
 
 # ---------------------------------------------------------------------------
@@ -205,7 +205,10 @@ class TestAudioRecordingConsumerExtra:
 
     @pytest.mark.asyncio
     async def test_process_finalize_event(self) -> None:
-        from app.consumers.audio_recording_consumer import AudioRecordingConsumer, FinalizeConference
+        from app.consumers.audio_recording_consumer import (
+            AudioRecordingConsumer,
+            FinalizeConference,
+        )
 
         consumer = AudioRecordingConsumer()
         event = FinalizeConference(conference_id="conf1")

--- a/platform/tests/unit/test_create_dtos.py
+++ b/platform/tests/unit/test_create_dtos.py
@@ -8,7 +8,6 @@ from pydantic import ValidationError
 from app.models.requests.content_requests import ContentCreate, QuizCreate
 from app.models.requests.school_requests import ClassroomCreate, SchoolCreate
 
-
 # ---------------------------------------------------------------------------
 # ClassroomCreate
 # ---------------------------------------------------------------------------

--- a/platform/tests/unit/test_dtmf_quiz_lifespan.py
+++ b/platform/tests/unit/test_dtmf_quiz_lifespan.py
@@ -4,9 +4,9 @@ Coverage for dtmf_consumer, quiz FSM builder, lifespan helpers.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # DtmfConsumer
@@ -135,8 +135,8 @@ class TestQuizBuilder:
         assert quiz.move_forward_key == "1"
 
     def test_quiz_generate_states(self) -> None:
-        from app.services.fsm.instantiation.quiz import Quiz
         from app.services.fsm.fsm import FSM
+        from app.services.fsm.instantiation.quiz import Quiz
         from app.services.fsm.state import State
 
         quiz_data = self._make_quiz_data()
@@ -240,8 +240,9 @@ class TestWebsocketClientDispatch:
 
     @pytest.mark.asyncio
     async def test_dispatch_no_conf_manager_returns_early(self) -> None:
-        from app.providers.websocket_client import WebsocketClientProvider
         import json
+
+        from app.providers.websocket_client import WebsocketClientProvider
 
         provider = WebsocketClientProvider()
         provider._conference_manager = None
@@ -252,8 +253,9 @@ class TestWebsocketClientDispatch:
 
     @pytest.mark.asyncio
     async def test_dispatch_conf_not_found_returns_early(self) -> None:
-        from app.providers.websocket_client import WebsocketClientProvider
         import json
+
+        from app.providers.websocket_client import WebsocketClientProvider
 
         provider = WebsocketClientProvider()
         provider._conference_manager = MagicMock()

--- a/platform/tests/unit/test_foundation.py
+++ b/platform/tests/unit/test_foundation.py
@@ -6,16 +6,14 @@ Uses httpx.AsyncClient with ASGI transport - no real DB or consumers needed.
 
 from __future__ import annotations
 
-import importlib
 import sys
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/platform/tests/unit/test_fsm_blob_extra.py
+++ b/platform/tests/unit/test_fsm_blob_extra.py
@@ -10,9 +10,10 @@ Additional coverage for:
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # FSM debug methods
@@ -88,7 +89,7 @@ class TestFSMDebugMethods:
 
 class TestBlobStorageExtractPath:
     def test_extract_path_without_extension(self) -> None:
-        from app.providers.blob_storage import _parse_blob_url, BlobStorageProvider
+        from app.providers.blob_storage import _parse_blob_url
 
         # Test _parse_blob_url directly
         container, blob = _parse_blob_url(
@@ -106,10 +107,7 @@ class TestBlobStorageExtractPath:
         assert container == "audio"
         # Strip extension manually
         dot_pos = blob.rfind(".")
-        if dot_pos > 0:
-            stripped = blob[:dot_pos]
-        else:
-            stripped = blob
+        stripped = blob[:dot_pos] if dot_pos > 0 else blob
         assert "conf-123" in stripped
 
 
@@ -213,7 +211,7 @@ class TestContentJobConsumerDeeper:
     @pytest.mark.asyncio
     async def test_process_message_with_call_webhook_type(self, db) -> None:
         from app.consumers.content_job_consumer import ContentJobConsumer
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         consumer = ContentJobConsumer(db)
         msg = QueueMessage(
@@ -225,25 +223,21 @@ class TestContentJobConsumerDeeper:
             },
         )
         # process should handle unknown status gracefully
-        try:
+        with contextlib.suppress(Exception):
             await consumer.process(msg)
-        except Exception:
-            pass  # External service calls may fail
 
     @pytest.mark.asyncio
     async def test_process_message_missing_fields(self, db) -> None:
         from app.consumers.content_job_consumer import ContentJobConsumer
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         consumer = ContentJobConsumer(db)
         msg = QueueMessage(
             type=MessageType.CALL_EVENT,
             payload={},  # empty payload
         )
-        try:
+        with contextlib.suppress(Exception):
             await consumer.process(msg)
-        except Exception:
-            pass  # Acceptable
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +273,9 @@ class TestConferenceConfeventsExtra:
         await event.execute_event()  # Should return early if no participant
 
     def test_reconnect_comm_api_event_creation(self) -> None:
-        from app.services.confevents.reconnect_comm_api_websocket_event import ReconnectCommApiWebsocketEvent
+        from app.services.confevents.reconnect_comm_api_websocket_event import (
+            ReconnectCommApiWebsocketEvent,
+        )
 
         conf = self._mock_conf()
         event = ReconnectCommApiWebsocketEvent(conf_call=conf)
@@ -308,6 +304,7 @@ class TestSchoolControllerEndpoints:
 
         from httpx import ASGITransport, AsyncClient
         from mongomock_motor import AsyncMongoMockClient
+
         from app.main import app
         from app.platform.auth.dependencies import get_db
 
@@ -332,6 +329,7 @@ class TestSchoolControllerEndpoints:
 
         from httpx import ASGITransport, AsyncClient
         from mongomock_motor import AsyncMongoMockClient
+
         from app.main import app
         from app.platform.auth.dependencies import get_db
 

--- a/platform/tests/unit/test_fsm_utils.py
+++ b/platform/tests/unit/test_fsm_utils.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Pause announcement
 # ---------------------------------------------------------------------------
@@ -60,47 +59,61 @@ class TestPauseAnnouncement:
 
 class TestDurationAnnouncement:
     def test_format_minutes_only(self) -> None:
-        from app.services.fsm.instantiation.duration_announcement import format_duration_announcement
+        from app.services.fsm.instantiation.duration_announcement import (
+            format_duration_announcement,
+        )
 
         result = format_duration_announcement(120.0, "english")
         assert "2" in result
         assert "minutes" in result.lower()
 
     def test_format_seconds_only(self) -> None:
-        from app.services.fsm.instantiation.duration_announcement import format_duration_announcement
+        from app.services.fsm.instantiation.duration_announcement import (
+            format_duration_announcement,
+        )
 
         result = format_duration_announcement(45.0, "english")
         assert "45" in result
         assert "seconds" in result.lower()
 
     def test_format_full(self) -> None:
-        from app.services.fsm.instantiation.duration_announcement import format_duration_announcement
+        from app.services.fsm.instantiation.duration_announcement import (
+            format_duration_announcement,
+        )
 
         result = format_duration_announcement(90.5, "english")
         assert "1" in result  # 1 minute
         assert "30" in result or "seconds" in result.lower()
 
     def test_format_none_returns_empty(self) -> None:
-        from app.services.fsm.instantiation.duration_announcement import format_duration_announcement
+        from app.services.fsm.instantiation.duration_announcement import (
+            format_duration_announcement,
+        )
 
         result = format_duration_announcement(None, "english")
         assert result == ""
 
     def test_format_zero_returns_empty(self) -> None:
-        from app.services.fsm.instantiation.duration_announcement import format_duration_announcement
+        from app.services.fsm.instantiation.duration_announcement import (
+            format_duration_announcement,
+        )
 
         result = format_duration_announcement(0.0, "english")
         assert result == ""
 
     def test_format_kannada(self) -> None:
-        from app.services.fsm.instantiation.duration_announcement import format_duration_announcement
+        from app.services.fsm.instantiation.duration_announcement import (
+            format_duration_announcement,
+        )
 
         result = format_duration_announcement(60.0, "kannada")
         assert isinstance(result, str)
         assert len(result) > 0
 
     def test_format_unknown_language_falls_back(self) -> None:
-        from app.services.fsm.instantiation.duration_announcement import format_duration_announcement
+        from app.services.fsm.instantiation.duration_announcement import (
+            format_duration_announcement,
+        )
 
         result = format_duration_announcement(60.0, "unknown")
         # Falls back to English
@@ -116,7 +129,7 @@ class TestIVRConstantsExtended:
     def test_language_dialog_urls_are_strings(self) -> None:
         from app.services.fsm.instantiation.ivr_constants import languageDialogUrls
 
-        for lang, url in languageDialogUrls.items():
+        for _lang, url in languageDialogUrls.items():
             assert isinstance(url, str)
             assert len(url) > 0
 
@@ -175,6 +188,7 @@ class TestRedisConferenceStore:
     def _make_store(self):
         """Create a RedisConferenceStore with a mocked redis client."""
         import redis.asyncio as aioredis
+
         from app.services.redis_conference_store import RedisConferenceStore
 
         mock_client = AsyncMock()

--- a/platform/tests/unit/test_insti_deep.py
+++ b/platform/tests/unit/test_insti_deep.py
@@ -4,9 +4,9 @@ Deep coverage for insti.py helper functions and data classes.
 
 from __future__ import annotations
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # _SimpleQuizData, _SimpleQuizQuestion, _SimpleURLText, _SimplePureAudioData
@@ -45,7 +45,7 @@ class TestInstiDataClasses:
         assert q.question.text == "Q1?"
 
     def test_simple_quiz_data(self) -> None:
-        from app.services.fsm.instantiation.insti import _SimpleQuizData, _SimpleQuizQuestion
+        from app.services.fsm.instantiation.insti import _SimpleQuizData
 
         data = {
             "id": "quiz1",
@@ -286,6 +286,7 @@ class TestIVRServiceUtils:
     @pytest.mark.asyncio
     async def test_get_ivr_structure_empty_db(self) -> None:
         import mongomock_motor
+
         from app.services.ivr_service import IVRService
 
         client = mongomock_motor.AsyncMongoMockClient()
@@ -300,6 +301,7 @@ class TestIVRServiceUtils:
     @pytest.mark.asyncio
     async def test_process_dtmf_nonexistent_call(self) -> None:
         import mongomock_motor
+
         from app.services.ivr_service import IVRService
 
         client = mongomock_motor.AsyncMongoMockClient()
@@ -315,6 +317,7 @@ class TestIVRServiceUtils:
     @pytest.mark.asyncio
     async def test_process_call_event_nonexistent(self) -> None:
         import mongomock_motor
+
         from app.services.ivr_service import IVRService
 
         client = mongomock_motor.AsyncMongoMockClient()

--- a/platform/tests/unit/test_misc_coverage.py
+++ b/platform/tests/unit/test_misc_coverage.py
@@ -5,9 +5,9 @@ quiz model, IVR constants, SAS service (offline), and platform utilities.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # Quiz model
@@ -42,7 +42,6 @@ class TestQuizModel:
         from bson import ObjectId
 
         from app.models.quiz import Quiz
-        from app.models.content import TextContent
 
         oid = ObjectId()
         doc = {
@@ -124,8 +123,9 @@ class TestJWTUtilities:
 
     def test_invalid_token_raises(self) -> None:
         from app.platform.auth.jwt import verify_token
+        from app.platform.error_handling import UnauthorizedError
 
-        with pytest.raises(Exception):
+        with pytest.raises(UnauthorizedError):
             verify_token("not.a.valid.token")
 
 

--- a/platform/tests/unit/test_models_extended.py
+++ b/platform/tests/unit/test_models_extended.py
@@ -9,12 +9,10 @@ Covers: audit_log, webhook_event, ws_service_message, quiz, ivr_state,
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Models — audit_log
@@ -162,8 +160,9 @@ class TestWSServiceMessage:
         assert msg.position_seconds == 30.5
 
     def test_websocket_service_message_speed_clamp(self) -> None:
-        from app.models.ws_service_message import MessageType, WebsocketServiceMessage
         import pydantic
+
+        from app.models.ws_service_message import MessageType, WebsocketServiceMessage
 
         with pytest.raises(pydantic.ValidationError):
             WebsocketServiceMessage(
@@ -296,8 +295,8 @@ class TestNativeAuthProvider:
 
     @pytest.mark.asyncio
     async def test_get_user_by_credentials_wrong_password(self) -> None:
-        from app.platform.auth.providers.native_provider import get_user_by_credentials
         from app.platform.auth.hashing import hash_password
+        from app.platform.auth.providers.native_provider import get_user_by_credentials
 
         hashed = hash_password("correctpass")
         user_doc = {"_id": "uid1", "email": "x@y.com", "hashed_password": hashed}
@@ -311,8 +310,8 @@ class TestNativeAuthProvider:
 
     @pytest.mark.asyncio
     async def test_get_user_by_credentials_success(self) -> None:
-        from app.platform.auth.providers.native_provider import get_user_by_credentials
         from app.platform.auth.hashing import hash_password
+        from app.platform.auth.providers.native_provider import get_user_by_credentials
 
         hashed = hash_password("correctpass")
         user_doc = {"_id": "uid1", "email": "x@y.com", "hashed_password": hashed, "name": "Alice"}
@@ -393,7 +392,7 @@ class TestBaseConsumer:
     @pytest.mark.asyncio
     async def test_safe_process_transient_retries_then_dead_letters(self) -> None:
         """Transient errors retry MAX_TRANSIENT_RETRIES times then dead-letter."""
-        from app.consumers.base_consumer import BaseConsumer, MAX_TRANSIENT_RETRIES
+        from app.consumers.base_consumer import MAX_TRANSIENT_RETRIES, BaseConsumer
 
         attempts = []
         dead_lettered = []

--- a/platform/tests/unit/test_models_extra.py
+++ b/platform/tests/unit/test_models_extra.py
@@ -4,13 +4,11 @@ Extra coverage for models with small missing line counts.
 
 from __future__ import annotations
 
-import pytest
-from unittest.mock import MagicMock
+import contextlib
 
 
 class TestModelsCoverage:
     def test_classroom_model(self) -> None:
-        from app.models.classroom import Classroom
         from app.models.requests.school_requests import ClassroomCreate
 
         c = ClassroomCreate(
@@ -46,7 +44,6 @@ class TestModelsCoverage:
             pass  # OK if schema differs
 
     def test_school_model(self) -> None:
-        from app.models.school import School
         from app.models.requests.school_requests import SchoolCreate
 
         s = SchoolCreate(
@@ -67,7 +64,6 @@ class TestModelsCoverage:
             pass
 
     def test_content_model(self) -> None:
-        from app.models.content import Content
         from app.models.requests.content_requests import ContentCreate
 
         try:
@@ -99,30 +95,24 @@ class TestModelsCoverage:
             pass
 
     def test_ivr_state_model(self) -> None:
-        from app.models.ivr_state import IVRCallStatus, IVRCallStateMongoDoc
+        from app.models.ivr_state import IVRCallStatus
 
-        try:
+        with contextlib.suppress(Exception):
             status = IVRCallStatus.ACTIVE
             assert status is not None
-        except Exception:
-            pass
 
     def test_vonage_action_base(self) -> None:
         from app.providers.vonage_actions.base.action import Action
 
-        try:
+        with contextlib.suppress(Exception):
             # Action is abstract — just import it
             assert Action is not None
-        except Exception:
-            pass
 
     def test_tenant_scope_same_tenant(self) -> None:
         from app.platform.authz.tenant_scope import assert_same_tenant
 
-        try:
+        with contextlib.suppress(Exception):
             assert_same_tenant("tenant1", "tenant1")
-        except Exception:
-            pass
 
     def test_tenant_scope_different_tenant(self) -> None:
         from app.platform.authz.tenant_scope import assert_same_tenant
@@ -141,11 +131,7 @@ class TestModelsCoverage:
 
         settings = get_settings()
         # Access computed properties
-        try:
+        with contextlib.suppress(Exception):
             _ = settings.effective_mongo_connection_string
-        except Exception:
-            pass
-        try:
+        with contextlib.suppress(Exception):
             _ = settings.azure_blob_sas_enabled
-        except Exception:
-            pass

--- a/platform/tests/unit/test_models_repos.py
+++ b/platform/tests/unit/test_models_repos.py
@@ -7,14 +7,12 @@ from __future__ import annotations
 import pytest
 from bson import ObjectId
 from mongomock_motor import AsyncMongoMockClient
+from pydantic import ValidationError
 
-from app.models.conference_state import ConferenceCallState
-from app.models.content import Content, TextContent
 from app.models.user import User, UserCreate, UserRole
 from app.repositories.conference_repository import ConferenceRepository
 from app.repositories.content_repository import ContentRepository
 from app.repositories.user_repository import UserRepository
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -72,7 +70,7 @@ def test_user_model_role_validation():
         u = User(role=role, name="Test User")
         assert u.role == role
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         User(role="admin", name="Bad Role")
 
 

--- a/platform/tests/unit/test_platform_extra.py
+++ b/platform/tests/unit/test_platform_extra.py
@@ -4,9 +4,10 @@ Extra coverage for platform/database.py and school_controller endpoints.
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # database.py — pure function coverage
@@ -91,7 +92,7 @@ class TestDatabaseModule:
 class TestTeacherDisconnectDeeper:
     def _make_conf(self, auto_end_enabled=True):
         from app.models.conference_state import ConferenceCallState
-        from app.models.participant import Participant, Role, CallStatus
+        from app.models.participant import CallStatus, Participant, Role
 
         conf = MagicMock()
         conf.conf_id = "conf_timer"
@@ -113,7 +114,9 @@ class TestTeacherDisconnectDeeper:
 
     @pytest.mark.asyncio
     async def test_execute_event_disabled_returns_early(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_enabled = False
@@ -199,7 +202,5 @@ class TestTelemetry:
         mock_settings.azure_monitor_connection_string = ""
         mock_settings.telemetry_sampling_ratio = 1.0
 
-        try:
+        with contextlib.suppress(Exception):
             configure_telemetry(mock_settings)
-        except Exception:
-            pass  # OK if Azure not configured

--- a/platform/tests/unit/test_providers_extra.py
+++ b/platform/tests/unit/test_providers_extra.py
@@ -5,9 +5,9 @@ teacher_disconnect_timer_event, and FSM quiz/pure_audio import coverage.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # service_bus — QueueMessage and MessageType (no Azure SDK calls)
@@ -23,7 +23,7 @@ class TestServiceBusQueueMessage:
         assert MessageType.CALL_EVENT is not None
 
     def test_queue_message_creation(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         msg = QueueMessage(
             type=MessageType.CALL_WEBHOOK,
@@ -33,7 +33,7 @@ class TestServiceBusQueueMessage:
         assert msg.payload["status"] == "answered"
 
     def test_queue_message_to_json(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         msg = QueueMessage(
             type=MessageType.DTMF_INPUT,
@@ -44,7 +44,7 @@ class TestServiceBusQueueMessage:
         assert "digits" in json_str
 
     def test_queue_message_from_json(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         msg = QueueMessage(
             type=MessageType.CALL_EVENT,
@@ -55,13 +55,13 @@ class TestServiceBusQueueMessage:
         assert restored.payload["status"] == "completed"
 
     def test_queue_message_has_message_id(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         msg = QueueMessage(type=MessageType.CALL_WEBHOOK, payload={})
         assert msg.message_id is not None
 
     def test_queue_message_retry_count_default(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         msg = QueueMessage(type=MessageType.CALL_WEBHOOK, payload={})
         assert msg.retry_count == 0
@@ -179,7 +179,9 @@ class TestTeacherDisconnectTimerEvent:
         return conf_call
 
     def test_start_timer_event_creation(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_timeout_minutes = 5
@@ -191,7 +193,9 @@ class TestTeacherDisconnectTimerEvent:
 
     @pytest.mark.asyncio
     async def test_start_timer_does_nothing_when_disabled(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import StartTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            StartTeacherDisconnectTimerEvent,
+        )
 
         mock_settings = MagicMock()
         mock_settings.auto_end_timeout_minutes = 5
@@ -203,14 +207,18 @@ class TestTeacherDisconnectTimerEvent:
             await event.execute_event()
 
     def test_cancel_timer_event_creation(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import CancelTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            CancelTeacherDisconnectTimerEvent,
+        )
 
         event = CancelTeacherDisconnectTimerEvent(conf_call=self._mock_conf_call())
         assert event is not None
 
     @pytest.mark.asyncio
     async def test_cancel_timer_inactive(self) -> None:
-        from app.services.confevents.teacher_disconnect_timer_event import CancelTeacherDisconnectTimerEvent
+        from app.services.confevents.teacher_disconnect_timer_event import (
+            CancelTeacherDisconnectTimerEvent,
+        )
 
         conf_call = self._mock_conf_call()
         conf_call.state.auto_end_state.is_active = False
@@ -322,6 +330,7 @@ class TestConferenceCallUnit:
 class TestIVRStateModels:
     def test_ivr_call_state_creation(self) -> None:
         from datetime import datetime
+
         from app.models.ivr_state import IVRCallStateMongoDoc
 
         doc = IVRCallStateMongoDoc(
@@ -336,6 +345,7 @@ class TestIVRStateModels:
 
     def test_ivr_fsm_doc_creation(self) -> None:
         import time
+
         from app.models.ivr_state import IVRfsmDoc
 
         doc = IVRfsmDoc(
@@ -361,6 +371,7 @@ class TestIVRStateModels:
 
     def test_ivr_call_state_from_mongo_with_id(self) -> None:
         from datetime import datetime
+
         from app.models.ivr_state import IVRCallStateMongoDoc
 
         doc = {

--- a/platform/tests/unit/test_sas_ivr_extra.py
+++ b/platform/tests/unit/test_sas_ivr_extra.py
@@ -5,9 +5,9 @@ FSM quiz/pure_audio instantiation stubs, and confevents event classes.
 
 from __future__ import annotations
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # SAS service — offline path coverage
@@ -215,7 +215,9 @@ class TestConfeventsAdditional:
         assert event is not None
 
     def test_reconnect_websocket_event_creation(self) -> None:
-        from app.services.confevents.reconnect_comm_api_websocket_event import ReconnectCommApiWebsocketEvent
+        from app.services.confevents.reconnect_comm_api_websocket_event import (
+            ReconnectCommApiWebsocketEvent,
+        )
 
         event = ReconnectCommApiWebsocketEvent(conf_call=self._mock_conf_call())
         assert event is not None
@@ -234,7 +236,9 @@ class TestConfeventsAdditional:
 
 class TestVonageConfevents:
     def test_vonage_call_status_change_event_answered(self) -> None:
-        from app.services.confevents.vonage.vonage_call_status_change_event import VonageCallStatusChangeEvent
+        from app.services.confevents.vonage.vonage_call_status_change_event import (
+            VonageCallStatusChangeEvent,
+        )
 
         event = VonageCallStatusChangeEvent(
             status="answered",
@@ -243,7 +247,10 @@ class TestVonageConfevents:
         assert event.status.value == "answered"
 
     def test_vonage_call_status_change_normalizes_invalid_to_notconnected(self) -> None:
-        from app.services.confevents.vonage.vonage_call_status_change_event import VonageCallStatusChangeEvent, VonageCallStatus
+        from app.services.confevents.vonage.vonage_call_status_change_event import (
+            VonageCallStatus,
+            VonageCallStatusChangeEvent,
+        )
 
         event = VonageCallStatusChangeEvent(
             status="unknown_invalid",
@@ -252,7 +259,10 @@ class TestVonageConfevents:
         assert event.status == VonageCallStatus.NOTCONNECTED
 
     def test_vonage_call_status_completed(self) -> None:
-        from app.services.confevents.vonage.vonage_call_status_change_event import VonageCallStatusChangeEvent, VonageCallStatus
+        from app.services.confevents.vonage.vonage_call_status_change_event import (
+            VonageCallStatus,
+            VonageCallStatusChangeEvent,
+        )
 
         event = VonageCallStatusChangeEvent(status="completed", to="+222")
         assert event.status == VonageCallStatus.COMPLETED
@@ -279,6 +289,7 @@ class TestClassroomModel:
 
     def test_classroom_from_mongo_with_id(self) -> None:
         from bson import ObjectId
+
         from app.models.classroom import Classroom
 
         doc = {
@@ -332,7 +343,7 @@ class TestConferenceStateModel:
 
     def test_conference_call_state_with_participants(self) -> None:
         from app.models.conference_state import ConferenceCallState
-        from app.models.participant import Participant, Role, CallStatus
+        from app.models.participant import CallStatus, Participant, Role
 
         p1 = Participant(phone_number="+111", name="Teacher", role=Role.TEACHER, call_status=CallStatus.CONNECTED)
         state = ConferenceCallState(conference_id="conf1", participants={"+111": p1})
@@ -359,8 +370,8 @@ class TestClassroomRepository:
 
     @pytest.mark.asyncio
     async def test_create_and_find_classroom(self, db) -> None:
-        from app.repositories.classroom_repository import ClassroomRepository
         from app.models.requests.school_requests import ClassroomCreate
+        from app.repositories.classroom_repository import ClassroomRepository
 
         repo = ClassroomRepository(db)
         classroom = ClassroomCreate(name="Class 1", schoolId="s1", teacher="t1")
@@ -370,8 +381,8 @@ class TestClassroomRepository:
 
     @pytest.mark.asyncio
     async def test_find_classrooms_by_school(self, db) -> None:
-        from app.repositories.classroom_repository import ClassroomRepository
         from app.models.requests.school_requests import ClassroomCreate
+        from app.repositories.classroom_repository import ClassroomRepository
 
         repo = ClassroomRepository(db)
         await repo.create(ClassroomCreate(name="Class A", schoolId="s1", teacher="t1"))
@@ -383,8 +394,8 @@ class TestClassroomRepository:
 
     @pytest.mark.asyncio
     async def test_find_classrooms_by_teacher(self, db) -> None:
-        from app.repositories.classroom_repository import ClassroomRepository
         from app.models.requests.school_requests import ClassroomCreate
+        from app.repositories.classroom_repository import ClassroomRepository
 
         repo = ClassroomRepository(db)
         await repo.create(ClassroomCreate(name="Class X", schoolId="s1", teacher="t1"))
@@ -409,8 +420,9 @@ class TestIVRRepository:
     @pytest.mark.asyncio
     async def test_save_and_find_fsm(self, db) -> None:
         import time
-        from app.repositories.ivr_repository import IVRRepository
+
         from app.models.ivr_state import IVRfsmDoc
+        from app.repositories.ivr_repository import IVRRepository
 
         repo = IVRRepository(db)
         doc = IVRfsmDoc(
@@ -530,7 +542,9 @@ class TestFSMOperations:
         assert op.score == 1
 
     def test_quiz_process_final_state_output(self) -> None:
-        from app.services.fsm.operations.quiz_process_state_output import QuizProcessFinalStateOutput
+        from app.services.fsm.operations.quiz_process_state_output import (
+            QuizProcessFinalStateOutput,
+        )
 
         op = QuizProcessFinalStateOutput()
         assert op is not None

--- a/platform/tests/unit/test_school_service_extra2.py
+++ b/platform/tests/unit/test_school_service_extra2.py
@@ -4,8 +4,9 @@ Extra unit coverage for school_service.py and school_controller helper paths.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 class TestSchoolServiceExtra:
@@ -40,8 +41,8 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_create_school_duplicate_email(self) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import ConflictError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
         existing_school = MagicMock()
@@ -78,8 +79,8 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_get_school_not_found(self) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
 
@@ -94,8 +95,8 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_get_school_tenant_mismatch(self) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
 
@@ -111,9 +112,9 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_update_school_not_found(self) -> None:
-        from app.services.school_service import SchoolService
         from app.models.requests.school_requests import SchoolUpdateRequest
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
 
@@ -129,9 +130,9 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_update_school_tenant_mismatch(self) -> None:
-        from app.services.school_service import SchoolService
         from app.models.requests.school_requests import SchoolUpdateRequest
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
 
@@ -146,8 +147,8 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_transfer_teacher_cross_tenant_blocked(self) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
         mock_teacher = MagicMock()
@@ -168,8 +169,8 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_transfer_teacher_cross_tenant_target_school_blocked(self) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
         mock_teacher = MagicMock()
@@ -240,8 +241,8 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_delete_school_not_found(self) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
 
@@ -308,8 +309,8 @@ class TestSchoolServiceExtra:
 
     @pytest.mark.asyncio
     async def test_get_classroom_not_found(self) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         mock_db = MagicMock()
 

--- a/platform/tests/unit/test_security_logging.py
+++ b/platform/tests/unit/test_security_logging.py
@@ -9,16 +9,13 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from io import StringIO
-from typing import AsyncGenerator
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/platform/tests/unit/test_service_bus_deep.py
+++ b/platform/tests/unit/test_service_bus_deep.py
@@ -5,9 +5,9 @@ content_controller additional paths, and users_controller additional routes.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # ServiceBusProvider — methods with handle=None (no Azure)
@@ -33,7 +33,7 @@ class TestServiceBusProviderNullHandles:
 
     @pytest.mark.asyncio
     async def test_complete_message_null_handle_returns_false(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
         p = self._make_provider()
         msg = QueueMessage(type=MessageType.CALL_WEBHOOK, payload={})
         result = await p.complete_message("call_webhook", msg)
@@ -41,7 +41,7 @@ class TestServiceBusProviderNullHandles:
 
     @pytest.mark.asyncio
     async def test_abandon_message_null_handle_returns_false(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
         p = self._make_provider()
         msg = QueueMessage(type=MessageType.DTMF_INPUT, payload={})
         result = await p.abandon_message("dtmf_input", msg)
@@ -49,7 +49,7 @@ class TestServiceBusProviderNullHandles:
 
     @pytest.mark.asyncio
     async def test_dead_letter_message_null_handle_returns_false(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
         p = self._make_provider()
         msg = QueueMessage(type=MessageType.CALL_EVENT, payload={})
         result = await p.dead_letter_message("call_event", msg, "test reason")
@@ -120,7 +120,7 @@ class TestAzureQueueHandle:
 
     @pytest.mark.asyncio
     async def test_complete_message_not_in_map_returns_false(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         handle = self._make_handle()
         msg = QueueMessage(type=MessageType.CALL_WEBHOOK, payload={})
@@ -129,7 +129,7 @@ class TestAzureQueueHandle:
 
     @pytest.mark.asyncio
     async def test_abandon_message_not_in_map_returns_false(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         handle = self._make_handle()
         msg = QueueMessage(type=MessageType.CALL_WEBHOOK, payload={})
@@ -138,7 +138,7 @@ class TestAzureQueueHandle:
 
     @pytest.mark.asyncio
     async def test_dead_letter_not_in_map_returns_false(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         handle = self._make_handle()
         msg = QueueMessage(type=MessageType.CALL_WEBHOOK, payload={})
@@ -147,7 +147,7 @@ class TestAzureQueueHandle:
 
     @pytest.mark.asyncio
     async def test_complete_message_in_map_success(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         handle = self._make_handle()
         msg = QueueMessage(type=MessageType.CALL_WEBHOOK, payload={})
@@ -161,7 +161,7 @@ class TestAzureQueueHandle:
 
     @pytest.mark.asyncio
     async def test_abandon_message_in_map_success(self) -> None:
-        from app.providers.service_bus import QueueMessage, MessageType
+        from app.providers.service_bus import MessageType, QueueMessage
 
         handle = self._make_handle()
         msg = QueueMessage(type=MessageType.DTMF_INPUT, payload={})
@@ -174,7 +174,6 @@ class TestAzureQueueHandle:
 
     @pytest.mark.asyncio
     async def test_receive_returns_empty_on_exception(self) -> None:
-        from app.providers.service_bus import QueueMessage
 
         handle = self._make_handle()
         handle._receiver.receive_messages = AsyncMock(side_effect=Exception("recv failed"))
@@ -208,6 +207,7 @@ class TestWebhookControllerDeep:
     async def test_answer_endpoint_public(self) -> None:
         from httpx import ASGITransport, AsyncClient
         from mongomock_motor import AsyncMongoMockClient
+
         from app.main import app
         from app.platform.auth.dependencies import get_db
 
@@ -228,6 +228,7 @@ class TestWebhookControllerDeep:
     async def test_event_endpoint_completed_status(self) -> None:
         from httpx import ASGITransport, AsyncClient
         from mongomock_motor import AsyncMongoMockClient
+
         from app.main import app
         from app.platform.auth.dependencies import get_db
 
@@ -255,6 +256,7 @@ class TestWebhookControllerDeep:
     async def test_event_endpoint_answered_status(self) -> None:
         from httpx import ASGITransport, AsyncClient
         from mongomock_motor import AsyncMongoMockClient
+
         from app.main import app
         from app.platform.auth.dependencies import get_db
 
@@ -282,6 +284,7 @@ class TestWebhookControllerDeep:
     async def test_dtmf_webhook_no_auth_404_or_200(self) -> None:
         from httpx import ASGITransport, AsyncClient
         from mongomock_motor import AsyncMongoMockClient
+
         from app.main import app
         from app.platform.auth.dependencies import get_db
 

--- a/platform/tests/unit/test_telemetry_auth.py
+++ b/platform/tests/unit/test_telemetry_auth.py
@@ -5,9 +5,7 @@ Unit tests for telemetry and JWT auth core.
 from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta, timezone
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -186,7 +184,7 @@ class TestJWT:
         from app.platform.settings import get_settings
 
         settings = get_settings()
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         bad_payload = {
             "sub": "user-123",
             "role": "teacher",
@@ -209,7 +207,7 @@ class TestJWT:
 
         from app.platform.error_handling import UnauthorizedError
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         payload = {
             "sub": "user-123",
             "role": "teacher",

--- a/platform/tests/unit/test_tts_and_insti.py
+++ b/platform/tests/unit/test_tts_and_insti.py
@@ -5,9 +5,10 @@ conference_event_dispatcher, and more repositories coverage.
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # TTS service — pure helper functions (no network / SDK needed)
@@ -195,8 +196,8 @@ class TestIVRServiceCacheHelpers:
         ivr_service._latest_fsm_id = original
 
     def test_set_and_get_latest_fsm_id(self) -> None:
-        from app.services.ivr_service import get_latest_fsm_id, set_latest_fsm_id
         from app.services import ivr_service
+        from app.services.ivr_service import get_latest_fsm_id, set_latest_fsm_id
 
         original = ivr_service._latest_fsm_id
         set_latest_fsm_id("fsm-test-123")
@@ -390,22 +391,20 @@ class TestConferenceEventDispatcher:
     @pytest.mark.asyncio
     async def test_dispatch_conference_event_unknown_status(self) -> None:
         """Dispatching unknown status to non-existent conference returns gracefully."""
+
         from app.services.conference_event_dispatcher import dispatch_conference_event
-        from unittest.mock import AsyncMock
 
         mgr = self._make_manager()
         caller_state_mgr = MagicMock()
 
         # Should not raise even with no conference found
-        try:
+        with contextlib.suppress(Exception):
             await dispatch_conference_event(
                 event_data={"status": "unknown_xyz"},
                 conference_id="conf_test_999",
                 conference_manager=mgr,
                 caller_state_manager=caller_state_mgr,
             )
-        except Exception:
-            pass  # Errors about missing conference are fine
 
     @pytest.mark.asyncio
     async def test_dispatch_conversation_event_unknown(self) -> None:
@@ -413,13 +412,11 @@ class TestConferenceEventDispatcher:
 
         mgr = self._make_manager()
 
-        try:
+        with contextlib.suppress(Exception):
             await dispatch_conversation_event(
                 event_data={"type": "unknown:event:type"},
                 conference_manager=mgr,
             )
-        except Exception:
-            pass
 
 
 # ---------------------------------------------------------------------------
@@ -436,8 +433,8 @@ class TestCallRepository:
 
     @pytest.mark.asyncio
     async def test_create_and_find_call_log(self, db) -> None:
-        from app.repositories.call_repository import CallRepository
         from app.models.call import CallLog
+        from app.repositories.call_repository import CallRepository
 
         repo = CallRepository(db)
         log = CallLog(
@@ -475,8 +472,8 @@ class TestConferenceRepository:
 
     @pytest.mark.asyncio
     async def test_create_and_find_conference(self, db) -> None:
-        from app.repositories.conference_repository import ConferenceRepository
         from app.models.conference_state import ConferenceCallState
+        from app.repositories.conference_repository import ConferenceRepository
 
         repo = ConferenceRepository(db)
         state = ConferenceCallState(conference_id="conf1", is_running=True)
@@ -510,8 +507,8 @@ class TestContentRepository:
 
     @pytest.mark.asyncio
     async def test_create_and_find_content(self, db) -> None:
-        from app.repositories.content_repository import ContentRepository
         from app.models.requests.content_requests import ContentCreate
+        from app.repositories.content_repository import ContentRepository
 
         repo = ContentRepository(db)
         content_create = ContentCreate(
@@ -601,8 +598,8 @@ class TestSchoolServiceAdditional:
 
     @pytest.mark.asyncio
     async def test_get_school_not_found(self, db) -> None:
-        from app.services.school_service import SchoolService
         from app.platform.error_handling import NotFoundError
+        from app.services.school_service import SchoolService
 
         with pytest.raises(NotFoundError):
             await SchoolService(db).get_school("000000000000000000000000", "t1")
@@ -671,8 +668,8 @@ class TestUserServiceAdditional:
 
     @pytest.mark.asyncio
     async def test_get_user_not_found(self, db) -> None:
-        from app.services.user_service import get_user
         from app.platform.error_handling import NotFoundError
+        from app.services.user_service import get_user
 
         current = {"sub": "teacher1", "role": "teacher", "tenant_id": "t1"}
         with pytest.raises(NotFoundError):
@@ -702,10 +699,8 @@ class TestUserServiceAdditional:
         user = await register_teacher(tc, db)
 
         current = {"sub": str(user.id), "role": "teacher", "tenant_id": "t1"}
-        try:
+        with contextlib.suppress(Exception):
             await delete_user(str(user.id), current, db)
-        except Exception:
-            pass
 
 
 # ---------------------------------------------------------------------------
@@ -741,7 +736,7 @@ class TestAuthServiceTenant:
 
     @pytest.mark.asyncio
     async def test_login_tenant_success(self, db) -> None:
-        from app.services.auth_service import TenantCreate, register_tenant, login
+        from app.services.auth_service import TenantCreate, login, register_tenant
 
         data = TenantCreate(name="Login Org", email="login@test.com", password="loginpass")
         await register_tenant(data, db)
@@ -751,8 +746,8 @@ class TestAuthServiceTenant:
 
     @pytest.mark.asyncio
     async def test_login_wrong_password_raises(self, db) -> None:
-        from app.services.auth_service import TenantCreate, register_tenant, login
         from app.platform.error_handling import UnauthorizedError
+        from app.services.auth_service import TenantCreate, login, register_tenant
 
         data = TenantCreate(name="Wrong Pass Org", email="wrong@test.com", password="correctpass")
         await register_tenant(data, db)
@@ -769,7 +764,5 @@ class TestAuthServiceTenant:
         user = await register_tenant(data, db)
 
         current = {"sub": str(user.id), "role": "tenant"}
-        try:
-            updated = await update_user(str(user.id), {"hashed_password": "newhash"}, current, db)
-        except Exception:
-            pass  # Cross-tenant or permission issues OK
+        with contextlib.suppress(Exception):
+            await update_user(str(user.id), {"hashed_password": "newhash"}, current, db)

--- a/platform/tests/unit/test_tts_redis_extra.py
+++ b/platform/tests/unit/test_tts_redis_extra.py
@@ -4,9 +4,9 @@ Coverage for tts_service pure functions and redis_conference_store utilities.
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # tts_service — pure function coverage

--- a/platform/tests/unit/test_users_authz.py
+++ b/platform/tests/unit/test_users_authz.py
@@ -155,12 +155,12 @@ class TestAssertSameTenant:
         tenant_id = str(ObjectId())
         current_user = {"sub": "user-1", "role": "teacher", "tenant_id": tenant_id}
         # Should not raise
-        assert_same_tenant(current_user, tenant_id) is None
+        assert_same_tenant(current_user, tenant_id)
 
     def test_assert_same_tenant_blocks_mismatched_ids(self):
         """Different tenant IDs must raise ForbiddenError."""
-        from app.platform.error_handling import ForbiddenError
         from app.platform.authz.tenant_scope import assert_same_tenant
+        from app.platform.error_handling import ForbiddenError
 
         current_user = {
             "sub": "user-1",
@@ -179,7 +179,7 @@ class TestAssertSameTenant:
         sub = str(ObjectId())
         current_user = {"sub": sub, "role": "tenant", "tenant_id": ""}
         # Should not raise — sub == resource_tenant_id
-        assert_same_tenant(current_user, sub) is None
+        assert_same_tenant(current_user, sub)
 
 
 # ---------------------------------------------------------------------------

--- a/platform/tools/parity_check.py
+++ b/platform/tools/parity_check.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -78,7 +77,6 @@ def _check_endpoint(
     raw_path: str = endpoint["path"]
     required_auth: bool = endpoint["required_auth"]
     expected_codes: list[int] = endpoint["expected_status_codes"]
-    description: str = endpoint.get("description", "")
 
     path = _resolve_path(raw_path)
     url = base_url.rstrip("/") + path

--- a/platform/tools/run_parity_check.py
+++ b/platform/tools/run_parity_check.py
@@ -29,8 +29,8 @@ _mock_client = AsyncMongoMockClient()
 _mock_db = _mock_client["seeds_parity"]
 _db_mod._database = _mock_db  # type: ignore[assignment]
 
-from app.main import app
-from app.platform.auth.dependencies import get_db
+from app.main import app  # noqa: E402
+from app.platform.auth.dependencies import get_db  # noqa: E402
 
 
 async def _override_db():
@@ -68,7 +68,7 @@ async def run() -> int:
     endpoints = contract.get("endpoints", [])
 
     print(f"Parity check: {contract.get('description', 'backend_p1')}")
-    print(f"Transport:    in-process ASGITransport (mongomock-motor)")
+    print("Transport:    in-process ASGITransport (mongomock-motor)")
     print(f"Endpoints:    {len(endpoints)}")
     print("-" * 70)
 


### PR DESCRIPTION
### Summary

- Removes `backend-server` (Node), `conference-v2` (Python), `IVRv2` (Python) from deploy matrix
- Adds `platform-service` (Python/Docker, port 4000) as unified replacement in both workflows
- Staging deploys to Render via `PLATFORM_RENDER_DEPLOY_HOOK_URL`
- Prod deploys to Azure App Service `platform-service` via `PLATFORM_AZURE_PUBLISH_PROFILE`
- `content-webapp` and `teacher-webapp` matrix entries unchanged — frontend API URL rekeying is follow-up

### Pre-merge checklist

- [x] `PLATFORM_AZURE_PUBLISH_PROFILE` secret added to GitHub repo
- [x] `PLATFORM_RENDER_DEPLOY_HOOK_URL` secret added to GitHub repo
- [x] Azure App Service `platform-service` provisioned (Linux, Container, S1)
- [x] Render `platform` service provisioned pointing at `ghcr.io/A4i-tech/seeds/platform:staging`
- [ ] Env vars set in Azure App Service Configuration and Render environment (ref: `platform/env.example`)

### Test plan

- [x] CI passes — Poetry install + pytest run clean for `platform` context
- [ ] On merge to `a4i/staging` — Render deploy hook fires, platform service starts and responds
- [ ] `content-webapp` and `teacher-webapp` builds unaffected
- [ ] Teams notification shows correct status