### PR TITLE
changes needed in Teacher-webapp and contentwebapp

### DIFF
--- a/ContentWebApp/src/components/AddQuiz.js
+++ b/ContentWebApp/src/components/AddQuiz.js
@@ -2,12 +2,7 @@ import { useState, useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useNavigate } from "react-router-dom";
 import { contentService } from "../services/contentService";
-import {
-  transformQuizItem,
-  extractQuestionText,
-  extractQuestionOptions,
-  getCorrectOptionIndex,
-} from "../utils/quizDataTransform";
+import { transformQuizItem, extractQuestionText } from "../utils/quizDataTransform";
 
 const ANSWER_OPTION_CONFIG = [
   { name: "optionA", label: "Option A", idx: 0 },
@@ -57,12 +52,13 @@ const AddQuiz = ({ quiz }) => {
       };
       setMetadata(quizMetadata);
       const questions = transformedQuiz.questions;
-      const inputFieldsData = questions.map((questionItem) => {
+      const quizOptions = transformedQuiz.options;
+      const quizCorrectAnswers = transformedQuiz.correctAnswers;
+      const inputFieldsData = questions.map((questionItem, index) => {
         const questionText = extractQuestionText(questionItem);
-        const options = extractQuestionOptions(questionItem);
-        const optionTexts = [...options];
+        const optionTexts = [...quizOptions[index]];
         while (optionTexts.length < 4) optionTexts.push("");
-        const correctIndex = getCorrectOptionIndex(questionItem, optionTexts);
+        const correctIndex = quizCorrectAnswers[index];
         return {
           question: questionText,
           optionA: optionTexts[0],
@@ -111,19 +107,24 @@ const AddQuiz = ({ quiz }) => {
       mcq.correctAnswer !== undefined ? mcq.correctAnswer : 0
     );
 
+    const titleObj = {
+      english: metadata.title,
+      local: languageLower === "en" ? metadata.title : metadata.localTitle,
+    };
+    const themeObj = {
+      english: metadata.theme,
+      local: languageLower === "en" ? metadata.theme : metadata.localTheme,
+    };
+
     const payload = {
       ...metadata,
       questions,
       options,
       correctAnswers,
-      // Theme fields expected by backend quiz creation (mirror AddStory behavior)
-      theme: metadata.theme,
-      localTheme:
-        languageLower === "en" ? metadata.theme : metadata.localTheme,
-      // Title fields expected by backend quiz creation (mirror AddStory behavior)
-      title: metadata.title,
-      localTitle:
-        languageLower === "en" ? metadata.title : metadata.localTitle,
+      title: titleObj,
+      theme: themeObj,
+      localTitle: titleObj.local,
+      localTheme: themeObj.local,
       type: "quiz",
       id: quiz ? (quiz._id || quiz.id) : uuidv4(),
     };

--- a/ContentWebApp/src/components/AddStory.js
+++ b/ContentWebApp/src/components/AddStory.js
@@ -104,7 +104,8 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
         const itemTheme = item.theme?.english;
         return (
           item.language.toLowerCase() === language.toLowerCase() &&
-          itemTheme.toLowerCase() === theme.toLowerCase()
+          itemTheme.toLowerCase() === theme.toLowerCase() &&
+          item.id !== content?.id
         );
       });
       const titleMap = {};
@@ -117,7 +118,7 @@ const AddStory = ({ content, contentType, onContentTypeChange }) => {
       });
       setTitlesUnderTheme(titleMap);
     },
-    [allContent],
+    [allContent, content],
   );
 
   const handleLanguageChange = (event) => {

--- a/ContentWebApp/src/components/AllContent/AnalyticsTab/DashboardStats.js
+++ b/ContentWebApp/src/components/AllContent/AnalyticsTab/DashboardStats.js
@@ -39,11 +39,11 @@ const DashboardStats = ({ dashboard }) => {
               </thead>
               <tbody>
                 {schools.map((school) => (
-                  <tr key={school._id} className="table-row-white">
+                  <tr key={school.id} className="table-row-white">
                     <td className="table-cell">{school.name}</td>
-                    <td className="table-cell">{school.teacherCount}</td>
-                    <td className="table-cell">{school.studentCount}</td>
-                    <td className="table-cell">{school.classCount}</td>
+                    <td className="table-cell">{school.teacher_count ?? "—"}</td>
+                    <td className="table-cell">{school.student_count ?? "—"}</td>
+                    <td className="table-cell">{school.class_count ?? "—"}</td>
                   </tr>
                 ))}
               </tbody>

--- a/ContentWebApp/src/components/QuizDetails.js
+++ b/ContentWebApp/src/components/QuizDetails.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { transformQuizItem, extractQuestionText, extractQuestionOptions, getCorrectOptionIndex } from "../utils/quizDataTransform";
+import { transformQuizItem, extractQuestionText } from "../utils/quizDataTransform";
 
 const QuizDetails = ({ quiz }) => {
   const transformed = transformQuizItem(quiz);
@@ -7,7 +7,9 @@ const QuizDetails = ({ quiz }) => {
   const titleLocal = transformed.title?.local ?? quiz.localTitle;
   const themeEnglish = transformed.theme?.english ?? transformed.theme;
   const themeLocal = transformed.theme?.local ?? quiz.localTheme;
-  const questions = transformed.questions || [];
+  const questions = transformed.questions;
+  const quizOptions = quiz.options;
+  const quizCorrectAnswers = quiz.correctAnswers;
 
   return (
     <>
@@ -17,7 +19,7 @@ const QuizDetails = ({ quiz }) => {
           <div>Title</div>
           <p>
             <b>{titleEnglish}</b>
-            {titleLocal && (
+            {titleLocal && titleLocal !== titleEnglish && (
               <>
                 <br />
                 <b>{titleLocal}</b>
@@ -37,7 +39,7 @@ const QuizDetails = ({ quiz }) => {
           <div>Theme</div>
           <p>
             <b>{themeEnglish}</b>
-            {themeLocal && (
+            {themeLocal && themeLocal !== themeEnglish && (
               <>
                 <br />
                 <b>{themeLocal}</b>
@@ -60,8 +62,8 @@ const QuizDetails = ({ quiz }) => {
       </div>
       {questions.map((questionItem, index) => {
         const questionText = extractQuestionText(questionItem);
-        const options = extractQuestionOptions(questionItem);
-        const correctIndex = getCorrectOptionIndex(questionItem, options);
+        const options = quizOptions[index];
+        const correctIndex = quizCorrectAnswers[index];
         const optionLabels = ["A", "B", "C", "D"];
         return (
           <div key={index} className="quiz-question-block">

--- a/ContentWebApp/src/services/contentService.js
+++ b/ContentWebApp/src/services/contentService.js
@@ -137,6 +137,9 @@ export const contentService = {
       headers: getAuthHeaders(),
     });
 
+    if (response && !response.id && response._id) {
+      return { ...response, id: response._id };
+    }
     return response;
   },
 };

--- a/ContentWebApp/tests/components/AddQuiz.test.js
+++ b/ContentWebApp/tests/components/AddQuiz.test.js
@@ -73,28 +73,12 @@ describe("AddQuiz", () => {
       language: "en",
       positiveMarks: 2,
       negativeMarks: 1,
-      questions: [
-        {
-          question: { text: "Q1?" },
-          options: [
-            { id: "opt1", text: "A1" },
-            { id: "opt2", text: "B1" },
-            { id: "opt3", text: "C1" },
-            { id: "opt4", text: "D1" },
-          ],
-          correct_option_id: "opt1",
-        },
-        {
-          question: { text: "Q2?" },
-          options: [
-            { id: "opt5", text: "A2" },
-            { id: "opt6", text: "B2" },
-            { id: "opt7", text: "C2" },
-            { id: "opt8", text: "D2" },
-          ],
-          correct_option_id: "opt5",
-        },
+      questions: ["Q1?", "Q2?"],
+      options: [
+        ["A1", "B1", "C1", "D1"],
+        ["A2", "B2", "C2", "D2"],
       ],
+      correctAnswers: [0, 0],
       id: "quiz-1",
     };
     render(

--- a/Teacher-App/app/src/androidTest/java/com/example/seeds/database/LogDaoTest.kt
+++ b/Teacher-App/app/src/androidTest/java/com/example/seeds/database/LogDaoTest.kt
@@ -31,7 +31,7 @@ class LogDaoTest {
 
     @Test
     fun insert_and_getAll_returnsInsertedLog() = runBlocking {
-        dao.insert(LogEntity(logText = "Test log", time = "2024-01-01", user = "teacher-1", priority = 1))
+        dao.insert(LogEntity(id = "1", logText = "Test log", time = "2024-01-01", user = "teacher-1", priority = 1))
         val result = dao.getAll()
         assertThat(result).hasSize(1)
         assertThat(result.first().logText).isEqualTo("Test log")
@@ -39,7 +39,7 @@ class LogDaoTest {
 
     @Test
     fun delete_removesSpecifiedIds() = runBlocking {
-        dao.insert(LogEntity(logText = "To delete", time = "2024-01-01", user = "teacher-1", priority = 1))
+        dao.insert(LogEntity(id = "1", logText = "To delete", time = "2024-01-01", user = "teacher-1", priority = 1))
         val all = dao.getAll()
         dao.delete(all.map { it.id })
         assertThat(dao.getAll()).isEmpty()
@@ -47,15 +47,15 @@ class LogDaoTest {
 
     @Test
     fun insert_multipleEntries_allPersisted() = runBlocking {
-        dao.insert(LogEntity(logText = "Log 1", time = "2024-01-01", user = "t1", priority = 1))
-        dao.insert(LogEntity(logText = "Log 2", time = "2024-01-02", user = "t1", priority = 2))
+        dao.insert(LogEntity(id = "1", logText = "Log 1", time = "2024-01-01", user = "t1", priority = 1))
+        dao.insert(LogEntity(id = "2", logText = "Log 2", time = "2024-01-02", user = "t1", priority = 2))
         assertThat(dao.getAll()).hasSize(2)
     }
 
     @Test
     fun delete_onlyRemovesSpecifiedIds() = runBlocking {
-        dao.insert(LogEntity(logText = "Keep", time = "2024-01-01", user = "t1", priority = 1))
-        dao.insert(LogEntity(logText = "Remove", time = "2024-01-02", user = "t1", priority = 2))
+        dao.insert(LogEntity(id = "1", logText = "Keep", time = "2024-01-01", user = "t1", priority = 1))
+        dao.insert(LogEntity(id = "2", logText = "Remove", time = "2024-01-02", user = "t1", priority = 2))
         val toRemove = dao.getAll().filter { it.logText == "Remove" }.map { it.id }
         dao.delete(toRemove)
         val remaining = dao.getAll()

--- a/Teacher-App/app/src/androidTest/java/com/example/seeds/di/FakeSeedsService.kt
+++ b/Teacher-App/app/src/androidTest/java/com/example/seeds/di/FakeSeedsService.kt
@@ -45,8 +45,7 @@ class FakeSeedsService : SeedsService {
     }
 
     override suspend fun getClassroomById(classId: String): ClassroomDto =
-        classroomsToReturn.firstOrNull { it._id == classId }
-            ?: ClassroomDto(_id = classId, name = "Unknown", teacher = "", students = emptyList(), leaders = emptyList())
+        ClassroomDto(id = classId, name = "Unknown", teacher = "", students = emptyList(), leaders = emptyList())
 
     override suspend fun getAllContent(limit: Int, cursor: String?): PaginatedResponse<Content> {
         idlingResource.increment()
@@ -62,7 +61,7 @@ class FakeSeedsService : SeedsService {
     override suspend fun getParticipants(): List<Student> = emptyList()
 
     override suspend fun saveClassroom(classroom: ClassroomSaveDto): ClassroomDto =
-        ClassroomDto(_id = classroom._id ?: "new-id", name = classroom.name, teacher = classroom.teacher,
+        ClassroomDto(id = classroom._id ?: "new-id", name = classroom.name, teacher = classroom.teacher,
             students = emptyList(), leaders = emptyList())
 
     override suspend fun deleteClassroom(classId: String) = Unit

--- a/Teacher-App/app/src/androidTest/java/com/example/seeds/e2e/ClassroomToCallE2ETest.kt
+++ b/Teacher-App/app/src/androidTest/java/com/example/seeds/e2e/ClassroomToCallE2ETest.kt
@@ -56,9 +56,9 @@ class ClassroomToCallE2ETest {
         IdlingRegistry.getInstance().register(TestAppModule.fakeService.idlingResource)
         hiltRule.inject()
         TestAppModule.fakeService.classroomsToReturn = listOf(
-            ClassroomDto(_id = "cls-1", name = "Alpha Class", teacher = "teacher-1",
+            ClassroomDto(id = "cls-1", name = "Alpha Class", teacher = "teacher-1",
                 students = emptyList(), leaders = emptyList()),
-            ClassroomDto(_id = "cls-2", name = "Beta Group", teacher = "teacher-1",
+            ClassroomDto(id = "cls-2", name = "Beta Group", teacher = "teacher-1",
                 students = emptyList(), leaders = emptyList())
         )
         scenario = ActivityScenario.launch(MainActivity::class.java)

--- a/Teacher-App/app/src/main/java/com/example/seeds/dao/LogDao.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/dao/LogDao.kt
@@ -15,5 +15,5 @@ interface LogDao {
     suspend fun getAll(): List<LogEntity>
 
     @Query("delete from log where id in (:logs)")
-    suspend fun delete(logs: List<Int>)
+    suspend fun delete(logs: List<String>)
 }

--- a/Teacher-App/app/src/main/java/com/example/seeds/database/LogEntity.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/database/LogEntity.kt
@@ -4,8 +4,8 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "log")
 class LogEntity(
-    @PrimaryKey(autoGenerate = true)
-    val id: Int = 0,
+    @PrimaryKey
+    val id: String,
     val logText: String,
     val time: String,
     val user: String,

--- a/Teacher-App/app/src/main/java/com/example/seeds/model/Content.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/model/Content.kt
@@ -12,11 +12,11 @@ data class Content(
     val title: LocalizedContent?,       // JSON object
     val theme: LocalizedContent?,
     val audioContent: List<AudioContent> = emptyList(),
-    val isPullModel: Boolean,
-    val isTeacherApp: Boolean,
-    val createdBy: String,
-    val creation_time: Long,
-    val isDeleted: Boolean
+    val isPullModel: Boolean = false,
+    val isTeacherApp: Boolean = false,
+    val createdBy: String = "",
+    val creation_time: Long = 0L,
+    val isDeleted: Boolean = false
 ) : Parcelable {
     val id: String get() = _id
     val titleText: String get() = title?.english ?: "Unknown Title"   

--- a/Teacher-App/app/src/main/java/com/example/seeds/network/ClassroomDto.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/network/ClassroomDto.kt
@@ -3,25 +3,85 @@ package com.example.seeds.network
 import android.content.Context
 import com.example.seeds.model.Classroom
 import com.example.seeds.model.Student
-import com.squareup.moshi.JsonClass
-import se.ansman.kotshi.JsonSerializable
-
-@JsonSerializable
-@JsonClass(generateAdapter = true)
-data class StudentRefDto(
-    var _id: String,
-    var name: String,
-    var phoneNumber: String,
-)
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
 
 data class ClassroomDto(
-    var _id: String? = null,
+    var id: String? = null,
     var name: String,
     var teacher: String,
-    var students: List<StudentRefDto>,
-    var leaders: List<StudentRefDto>,
+    var students: List<String>,
+    var leaders: List<String>,
     var contentIds: List<String>? = null,
-)
+) {
+    companion object {
+        @FromJson
+        fun fromJson(reader: JsonReader): ClassroomDto {
+            var id: String? = null
+            var name = ""
+            var teacher = ""
+            val students = mutableListOf<String>()
+            val leaders = mutableListOf<String>()
+            var contentIds: List<String>? = null
+
+            reader.beginObject()
+            while (reader.hasNext()) {
+                when (reader.nextName()) {
+                    "id" -> id = reader.nextString()
+                    "name" -> name = reader.nextString()
+                    "teacher" -> teacher = reader.nextString()
+                    "students" -> readFlexibleIds(reader, students)
+                    "leaders" -> readFlexibleIds(reader, leaders)
+                    "contentIds" -> contentIds = mutableListOf<String>().also { list ->
+                        reader.beginArray()
+                        while (reader.hasNext()) list.add(reader.nextString())
+                        reader.endArray()
+                    }
+                    else -> reader.skipValue()
+                }
+            }
+            reader.endObject()
+            return ClassroomDto(id = id, name = name, teacher = teacher,
+                students = students, leaders = leaders, contentIds = contentIds)
+        }
+
+        private fun readFlexibleIds(reader: JsonReader, out: MutableList<String>) {
+            reader.beginArray()
+            while (reader.hasNext()) {
+                when (reader.peek()) {
+                    JsonReader.Token.STRING -> out.add(reader.nextString())
+                    JsonReader.Token.BEGIN_OBJECT -> {
+                        reader.beginObject()
+                        var sid: String? = null
+                        while (reader.hasNext()) {
+                            if (reader.nextName() == "id") sid = reader.nextString() else reader.skipValue()
+                        }
+                        reader.endObject()
+                        sid?.let { out.add(it) }
+                    }
+                    else -> reader.skipValue()
+                }
+            }
+            reader.endArray()
+        }
+
+        @ToJson
+        fun toJson(writer: JsonWriter, value: ClassroomDto) {
+            writer.beginObject()
+            writer.name("id").value(value.id)
+            writer.name("name").value(value.name)
+            writer.name("teacher").value(value.teacher)
+            writer.name("students").beginArray(); value.students.forEach { writer.value(it) }; writer.endArray()
+            writer.name("leaders").beginArray(); value.leaders.forEach { writer.value(it) }; writer.endArray()
+            value.contentIds?.let { ids ->
+                writer.name("contentIds").beginArray(); ids.forEach { writer.value(it) }; writer.endArray()
+            }
+            writer.endObject()
+        }
+    }
+}
 
 /** Separate DTO used when saving (POST /class) — sends student ObjectIds as plain strings */
 data class ClassroomSaveDto(
@@ -33,24 +93,17 @@ data class ClassroomSaveDto(
     var contentIds: List<String>? = null,
 )
 
-fun ClassroomDto.asDomainModel(
-    context: Context
-): Classroom {
+fun ClassroomDto.asDomainModel(context: Context): Classroom {
     val prefs = context.getSharedPreferences("sharedPref", Context.MODE_PRIVATE)
     val teacherId = prefs.getString("teacher_id", "") ?: ""
-
     return Classroom(
-        _id,
+        id,
         name,
         teacherId,
-        students.map { Student(phoneNumber = it.phoneNumber, name = it.name, _id = it._id) },
-        leaders.map { Student(phoneNumber = it.phoneNumber, name = it.name, _id = it._id) },
+        students.map { Student(phoneNumber = "", name = "", _id = it) },
+        leaders.map { Student(phoneNumber = "", name = "", _id = it) },
         contentIds ?: emptyList()
     )
 }
 
-fun List<ClassroomDto>.asDomainModel(
-    context: Context
-): List<Classroom> {
-    return map { it.asDomainModel(context) }
-}
+fun List<ClassroomDto>.asDomainModel(context: Context): List<Classroom> = map { it.asDomainModel(context) }

--- a/Teacher-App/app/src/main/java/com/example/seeds/network/ConferenceSSEClient.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/network/ConferenceSSEClient.kt
@@ -4,8 +4,8 @@ import android.util.Log
 import com.launchdarkly.eventsource.EventHandler
 import com.launchdarkly.eventsource.EventSource
 import com.launchdarkly.eventsource.MessageEvent
-import okhttp3.Headers
 import java.net.URI
+import java.net.URLEncoder
 import java.time.Duration
 
 class ConferenceSSEClient {
@@ -42,12 +42,8 @@ class ConferenceSSEClient {
             }
         }
 
-        eventSource = EventSource.Builder(handler, URI.create(url))
-            .headers(
-                Headers.Builder()
-                    .add("Authorization", "Bearer $authToken")
-                    .build()
-            )
+        val urlWithToken = "$url?token=${URLEncoder.encode(authToken, "UTF-8")}"
+        eventSource = EventSource.Builder(handler, URI.create(urlWithToken))
             .reconnectTime(Duration.ofSeconds(3))
             .build()
 

--- a/Teacher-App/app/src/main/java/com/example/seeds/network/Service.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/network/Service.kt
@@ -217,6 +217,7 @@ fun provideService(@ApplicationContext context: Context): SeedsService {
     }
 
     val moshi = Moshi.Builder()
+        .add(ClassroomDto.Companion)
         .add(ApplicationJsonAdapterFactory)
         .build()
 

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallSettingsViewModel.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallSettingsViewModel.kt
@@ -85,14 +85,16 @@ class CallSettingsViewModel @Inject constructor(
     private suspend fun repairClassroomNames(classroom: Classroom): Classroom {
         return try {
             val directoryMap = teacherStudentsDirectory.studentsByPhone()
-            
+            val byId = directoryMap.values.filter { it._id != null }.associateBy { it._id!! }
+
             val fixedStudents = classroom.students.map { student ->
-                val correctDetails = directoryMap[student.phoneNumber] 
+                val correctDetails = directoryMap[student.phoneNumber]
                     ?: directoryMap[student.phoneNumber.removePrefix("91")]
                     ?: directoryMap["91${student.phoneNumber}"]
+                    ?: byId[student._id]
 
                 if (correctDetails != null) {
-                    student.copy(name = correctDetails.name)
+                    student.copy(name = correctDetails.name, phoneNumber = correctDetails.phoneNumber)
                 } else {
                     student
                 }

--- a/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/ui/call/CallViewModel.kt
@@ -207,6 +207,7 @@ class CallViewModel @Inject constructor(
         get() = _conferenceHoldDetected
 
     private val holdState = AtomicBoolean(false)
+    private val conferenceEverRunning = AtomicBoolean(false)
     private val _holdDetectedEvent = MutableLiveData<Event<Unit>>()
     val holdDetectedEvent: LiveData<Event<Unit>>
         get() = _holdDetectedEvent
@@ -465,7 +466,8 @@ class CallViewModel @Inject constructor(
 
             // --- Check if conference is still running ---
             val isRunning = json.get("is_running")?.asBoolean
-            if (isRunning == false) {
+            if (isRunning == true) conferenceEverRunning.set(true)
+            if (isRunning == false && conferenceEverRunning.get()) {
                 Log.i(TAG, "Conference has ended (is_running=false), navigating back")
                 _navigateBack.postValue(true)
                 return

--- a/Teacher-App/app/src/main/java/com/example/seeds/utils/TimberRemoteTree.kt
+++ b/Teacher-App/app/src/main/java/com/example/seeds/utils/TimberRemoteTree.kt
@@ -24,7 +24,7 @@ class TimberRemoteTree(val database: LogDao,
         val timestamp = System.currentTimeMillis()
         val time = timeFormat.format(Date(timestamp))
         try {
-            val remoteLog = LogEntity(logText = "$tag $message", time = time,
+            val remoteLog = LogEntity(id = UUID.randomUUID().toString(), logText = "$tag $message", time = time,
              user = teacherPhoneNumber, priority = priority)
             coroutineScope.launch {
                 database.insert(remoteLog)

--- a/Teacher-App/app/src/test/java/com/example/seeds/network/SeedsServiceTest.kt
+++ b/Teacher-App/app/src/test/java/com/example/seeds/network/SeedsServiceTest.kt
@@ -105,7 +105,7 @@ class SeedsServiceTest {
 
     @Test
     fun `getClassroomById sends GET with classId in path`() = runTest {
-        val json = """{"_id":"cls-1","name":"Test","teacher":"t1","students":[],"leaders":[]}"""
+        val json = """{"id":"cls-1","name":"Test","teacher":"t1","students":[],"leaders":[]}"""
         mockWebServer.enqueue(MockResponse().setBody(json).setResponseCode(200))
         service.getClassroomById("cls-1")
         val request = mockWebServer.takeRequest()

--- a/Teacher-App/app/src/test/java/com/example/seeds/repository/ClassroomRepositoryTest.kt
+++ b/Teacher-App/app/src/test/java/com/example/seeds/repository/ClassroomRepositoryTest.kt
@@ -22,8 +22,8 @@ class ClassroomRepositoryTest {
 
     @Test
     fun `getAllClassrooms returns list sorted descending by id`() = runTest {
-        val dto1 = ClassroomDto(_id = "cls-1", name = "Alpha", teacher = "t", students = emptyList(), leaders = emptyList())
-        val dto2 = ClassroomDto(_id = "cls-2", name = "Beta", teacher = "t", students = emptyList(), leaders = emptyList())
+        val dto1 = ClassroomDto(id = "cls-1", name = "Alpha", teacher = "t", students = emptyList(), leaders = emptyList())
+        val dto2 = ClassroomDto(id = "cls-2", name = "Beta", teacher = "t", students = emptyList(), leaders = emptyList())
         coEvery { mockService.getAllClassrooms() } returns listOf(dto1, dto2)
 
         val result = repository.getAllClassrooms()
@@ -44,7 +44,7 @@ class ClassroomRepositoryTest {
     @Test
     fun `saveClassroom calls network and returns domain model`() = runTest {
         val classroom = ClassroomTestBuilder.build(id = "cls-1", name = "Test Class")
-        val returnedDto = ClassroomDto(_id = "cls-1", name = "Test Class", teacher = "", students = emptyList(), leaders = emptyList())
+        val returnedDto = ClassroomDto(id = "cls-1", name = "Test Class", teacher = "", students = emptyList(), leaders = emptyList())
         coEvery { mockService.saveClassroom(any()) } returns returnedDto
 
         val result = repository.saveClassroom(classroom)
@@ -66,8 +66,9 @@ class ClassroomRepositoryTest {
 
     @Test
     fun `getClassroomById returns mapped domain model`() = runTest {
-        val dto = ClassroomDto(_id = "cls-99", name = "Room 99", teacher = "t", students = emptyList(), leaders = emptyList())
+        val dto = ClassroomDto(id = "cls-99", name = "Room 99", teacher = "t", students = emptyList(), leaders = emptyList())
         coEvery { mockService.getClassroomById("cls-99") } returns dto
+
 
         val result = repository.getClassroomById("cls-99")
 

--- a/teacher-webapp/src/pages/ClassroomDetail.js
+++ b/teacher-webapp/src/pages/ClassroomDetail.js
@@ -130,7 +130,8 @@ const ClassroomDetail = () => {
     }
 
     try {
-      const sseEp = SSE_ENDPOINTS.CONFERENCE.TEACHER_CONNECT(conferenceId);
+      const token = localStorage.getItem("authToken");
+      const sseEp = `${SSE_ENDPOINTS.CONFERENCE.TEACHER_CONNECT(conferenceId)}?token=${encodeURIComponent(token || "")}`;
       const eventSource = new EventSource(sseEp);
       eventSourceRef.current = eventSource;
 
@@ -320,10 +321,10 @@ const ClassroomDetail = () => {
   };
 
 
-  const isLeader = (studentId) => classroom.leaders?.some((l) => l._id === studentId);
+  const isLeader = (studentId) => classroom.leaders?.some((l) => l.id === studentId);
 
   if (conferenceStarted) {
-    return <DetailsPage classroomName={classroom?.name} classroomId={classroom?._id} />;
+    return <DetailsPage classroomName={classroom?.name} classroomId={classroom?.id} />;
   }
 
   if (loading) {
@@ -457,10 +458,10 @@ const ClassroomDetail = () => {
             <List sx={{ mt: 2 }}>
               {classroom.students.map((student, index) => {
                 const selected = isStudentSelected(student.phoneNumber);
-                const studentIsLeader = isLeader(student._id);
+                const studentIsLeader = isLeader(student.id);
 
                 return (
-                  <React.Fragment key={student._id}>
+                  <React.Fragment key={student.id}>
                     {index > 0 && <Divider />}
                     <ListItem
                       sx={{
@@ -502,7 +503,7 @@ const ClassroomDetail = () => {
             <Box sx={{ mt: 2, display: "flex", flexWrap: "wrap", gap: 1 }}>
               {classroom.leaders.map((leader) => (
                 <Chip
-                  key={leader._id}
+                  key={leader.id}
                   label={leader.name}
                   color="secondary"
                   icon={<SchoolIcon />}
@@ -547,7 +548,7 @@ const ClassroomDetail = () => {
               <FormControlLabel value="" control={<Radio />} label="No leader" />
               {selectedStudents.map((student) => {
                 const normalizedPhone = normalizePhoneNumber(student.phoneNumber);
-                const studentIsLeader = isLeader(student._id);
+                const studentIsLeader = isLeader(student.id);
                 return (
                   <FormControlLabel
                     key={normalizedPhone}

--- a/teacher-webapp/src/pages/ClassroomForm.js
+++ b/teacher-webapp/src/pages/ClassroomForm.js
@@ -70,11 +70,11 @@ const ClassroomForm = () => {
       setErrorMsg("");
       const data = await getClassroomById(classroomId);
       setFormData({
-        _id: data._id,
-        name: data.name || "",
-        students: (data.students || []).map((s) => (typeof s === "object" ? s._id : s)),
-        leaders: (data.leaders || []).map((l) => (typeof l === "object" ? l._id : l)),
-        contentIds: data.contentIds || [],
+        id: data.id,
+        name: data.name,
+        students: data.students,
+        leaders: data.leaders,
+        contentIds: data.contentIds,
       });
     } catch (err) {
       setErrorMsg("Failed to load classroom. Please try again.");
@@ -98,7 +98,7 @@ const ClassroomForm = () => {
       errors.name = "Class name is required";
     }
 
-    const studentSet = new Set(formData.students);
+    const studentSet = new Set(formData.students.map((s) => s.id));
     if (studentSet.size !== formData.students.length) {
       errors.students = "Duplicate students are not allowed";
     }
@@ -117,26 +117,24 @@ const ClassroomForm = () => {
   const handleAddStudent = (event, value) => {
     if (!value) return;
 
-    const studentId = value._id;
-
-    if (formData.students.includes(studentId)) {
+    if (formData.students.some((s) => s.id === value.id)) {
       showToast.error("Student already added to classroom");
       return;
     }
 
     setFormData({
       ...formData,
-      students: [...formData.students, studentId],
+      students: [...formData.students, value],
     });
     if (validationErrors.students) {
       setValidationErrors({ ...validationErrors, students: "" });
     }
   };
 
-  const handleRemoveStudent = (studentPhone) => {
+  const handleRemoveStudent = (studentId) => {
     setFormData({
       ...formData,
-      students: formData.students.filter((s) => s !== studentPhone),
+      students: formData.students.filter((s) => s.id !== studentId),
     });
   };
 
@@ -172,10 +170,6 @@ const ClassroomForm = () => {
   const handleBack = () => {
     navigate("/classrooms");
   };
-
-  const getStudentById = useCallback((id) => {
-    return teacherStudentsList.find((s) => s._id === id);
-  }, [teacherStudentsList]);
 
   if (loading || isLoadingStudents) {
     return <LoadingSpinner />;
@@ -242,7 +236,7 @@ const ClassroomForm = () => {
             <Box sx={{ mb: 3 }}>
               <Autocomplete
                 options={teacherStudentsList.filter(
-                  (s) => !formData.students.includes(s._id)
+                  (s) => !formData.students.some((fs) => fs.id === s.id)
                 )}
                 getOptionLabel={(option) => `${option.name} - ${option.phoneNumber}`}
                 onChange={handleAddStudent}
@@ -285,31 +279,28 @@ const ClassroomForm = () => {
               </Paper>
             ) : (
               <List sx={{ bgcolor: "background.paper", borderRadius: 1 }}>
-                {formData.students.map((id, index) => {
-                  const student = getStudentById(id);
-                  return (
-                    <React.Fragment key={id}>
-                      {index > 0 && <Divider />}
-                      <ListItem
-                        secondaryAction={
-                          <IconButton
-                            edge="end"
-                            onClick={() => handleRemoveStudent(id)}
-                            sx={{ color: "error.main" }}
-                          >
-                            <DeleteIcon />
-                          </IconButton>
-                        }
-                      >
-                        <ListItemText
-                          primary={student ? student.name : id}
-                          secondary={student ? student.phoneNumber : id}
-                          primaryTypographyProps={{ fontWeight: 500 }}
-                        />
-                      </ListItem>
-                    </React.Fragment>
-                  );
-                })}
+                {formData.students.map((student, index) => (
+                  <React.Fragment key={student.id}>
+                    {index > 0 && <Divider />}
+                    <ListItem
+                      secondaryAction={
+                        <IconButton
+                          edge="end"
+                          onClick={() => handleRemoveStudent(student.id)}
+                          sx={{ color: "error.main" }}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      }
+                    >
+                      <ListItemText
+                        primary={student.name}
+                        secondary={student.phoneNumber}
+                        primaryTypographyProps={{ fontWeight: 500 }}
+                      />
+                    </ListItem>
+                  </React.Fragment>
+                ))}
               </List>
             )}
           </CardContent>

--- a/teacher-webapp/src/pages/ClassroomList.js
+++ b/teacher-webapp/src/pages/ClassroomList.js
@@ -83,7 +83,7 @@ const ClassroomList = () => {
 
   const handleDeleteConfirm = async () => {
     try {
-      await deleteClassroom(classroomToDelete._id);
+      await deleteClassroom(classroomToDelete.id);
       showToast.success("Classroom deleted successfully");
       setDeleteDialogOpen(false);
       setClassroomToDelete(null);
@@ -284,7 +284,7 @@ const ClassroomList = () => {
       ) : (
         <Grid container spacing={3}>
           {classrooms.map((classroom) => (
-            <Grid item xs={12} sm={6} md={4} key={classroom._id}>
+            <Grid item xs={12} sm={6} md={4} key={classroom.id}>
               <Card
                 sx={{
                   height: "100%",
@@ -324,14 +324,14 @@ const ClassroomList = () => {
                 <CardActions sx={{ justifyContent: "space-between", px: 2, pb: 2 }}>
                   <Button
                     size="small"
-                    onClick={() => handleView(classroom._id)}
+                    onClick={() => handleView(classroom.id)}
                   >
                     View
                   </Button>
                   <Box>
                     <IconButton
                       size="small"
-                      onClick={() => handleEdit(classroom._id)}
+                      onClick={() => handleEdit(classroom.id)}
                       sx={{ color: "primary.main" }}
                     >
                       <EditIcon />

--- a/teacher-webapp/src/services/classroomService.js
+++ b/teacher-webapp/src/services/classroomService.js
@@ -17,12 +17,13 @@ export const createClassroom = async (classroomData) => {
 };
 
 export const updateClassroom = async (classroomData) => {
-  try {
-    const response = await axiosInstance.post(API_ENDPOINTS.CLASSROOM.UPDATE, classroomData);
-    return response.data;
-  } catch (error) {
-    throw new Error("Failed to update classroom");
-  }
+  const payload = {
+    ...classroomData,
+    students: classroomData.students.map((s) => (typeof s === "object" ? s.id : s)),
+    leaders: classroomData.leaders.map((l) => (typeof l === "object" ? l.id : l)),
+  };
+  const response = await axiosInstance.post(API_ENDPOINTS.CLASSROOM.UPDATE, payload);
+  return response.data;
 };
 
 export const deleteClassroom = async (classId) => {

--- a/teacher-webapp/src/services/teacherService.js
+++ b/teacher-webapp/src/services/teacherService.js
@@ -20,5 +20,5 @@ export const getCurrentTeacher = async () => {
  */
 export const getSchoolStudents = async () => {
   const response = await axiosInstance.get(API_ENDPOINTS.GET_STUDENTS);
-  return response.data;
+  return response.data.map((s) => (s.id ? s : { ...s, id: s._id }));
 };


### PR DESCRIPTION
Re-opens the changes from PR #243.
## Summary
- Teacher and classroom pages use stable IDs across classroom, student, and conference flows
- Quiz creation and detail views support updated question/answer data format
- Fixed duplicate-title and duplicate-student checks when editing existing content
- Conference connections work reliably with token-based access\n- Content, classroom, and analytics screens handle missing or renamed fields gracefully