### PR TITLE
Harden CORS policy for staging/production environments

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -71,7 +71,7 @@ cp env.example .env
 | `AZURE_STORAGE_CONNECTION_STRING` | for content/audio | Azure Blob Storage connection string |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | no | App Insights (telemetry disabled if absent) |
 | `WS_CONTROL_SECRET` | for prod | Shared secret for websocket-service control channel |
-| `CORS_ALLOWED_ORIGINS` | for prod | Comma-separated allowed origins (ignored in development) |
+| `CORS_ALLOWED_ORIGINS` | for staging/prod | Comma-separated allowed origins (ignored in development; if unset, staging/prod reject all cross-origin requests) |
 
 ## Run
 

--- a/platform/app/platform/security.py
+++ b/platform/app/platform/security.py
@@ -2,13 +2,14 @@
 Security middleware for SEEDS Platform.
 
 Provides:
-  - CORS policy (wildcard in dev/staging, restricted in production)
+  - CORS policy (wildcard in development only, explicit allow-list in staging/production)
   - Security headers on every response
   - Global + per-route rate limiting via slowapi
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from fastapi import Request
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
     from app.platform.settings import Settings
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -38,13 +41,17 @@ limiter = Limiter(key_func=get_remote_address, default_limits=["5000/15minutes"]
 
 def _cors_origins(settings: Settings) -> list[str]:
     """Return the list of allowed origins based on the active environment."""
-    if settings.env in ("development", "staging"):
+    if settings.env == "development":
         return ["*"]
     raw = settings.cors_allowed_origins.strip()
-    if not raw or raw == "*":
-        # production should be explicit – return ["*"] only if explicitly set
-        return [o.strip() for o in raw.split(",") if o.strip()] or ["*"]
-    return [o.strip() for o in raw.split(",") if o.strip()]
+    origins = [o.strip() for o in raw.split(",") if o.strip()]
+    if not origins:
+        logger.warning(
+            "CORS_ALLOWED_ORIGINS is not set for env=%r; no cross-origin requests "
+            "will be allowed until it is configured.",
+            settings.env,
+        )
+    return origins
 
 
 # ---------------------------------------------------------------------------

--- a/platform/app/platform/settings.py
+++ b/platform/app/platform/settings.py
@@ -173,9 +173,9 @@ class Settings(BaseSettings):
     # ---------------------------------------------------------------------------
     # CORS
     # ---------------------------------------------------------------------------
-    # Comma-separated list of allowed origins for production.
-    # In development/staging "*" is always used regardless of this value.
-    cors_allowed_origins: str = "*"
+    # Comma-separated list of allowed origins for staging/production.
+    # In development "*" is always used regardless of this value.
+    cors_allowed_origins: str = ""
 
     # ---------------------------------------------------------------------------
     # WebSocket control secret (Phase 11 security hardening)

--- a/platform/env.example
+++ b/platform/env.example
@@ -66,6 +66,11 @@ DEFAULT_WELCOME_LANGUAGE=kannada
 LOG_TO_FILE=false
 LOG_FILE_PATH=runtime.log
 
+# ── Security ──────────────────────────────────────────────────────────────────
+# Comma-separated allowed origins. Required for staging/production — if unset,
+# CORS rejects all cross-origin requests (ignored in development, where "*" is used).
+CORS_ALLOWED_ORIGINS=
+
 # ── Audio analysis / transcription (ConferenceV2) ─────────────────────────────
 AUDIO_ANALYSIS_ENABLED=true
 AUDIO_SILENCE_THRESHOLD=300

--- a/platform/tests/unit/test_security_logging.py
+++ b/platform/tests/unit/test_security_logging.py
@@ -157,6 +157,23 @@ async def test_cors_restricted_prod() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("env", ["staging", "production"])
+async def test_cors_fails_closed_when_unset(env: str) -> None:
+    """If CORS_ALLOWED_ORIGINS is unset in staging/production, no origin is allowed."""
+    app = _make_app(env=env, cors_origins="")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.options(
+            "/ping",
+            headers={"Origin": "https://app.seeds.org", "Access-Control-Request-Method": "GET"},
+        )
+
+    ac_origin = response.headers.get("access-control-allow-origin", "")
+    assert ac_origin != "https://app.seeds.org"
+    assert ac_origin != "*"
+
+
+@pytest.mark.asyncio
 async def test_error_envelope_format() -> None:
     """AppError must be wrapped in the standard error envelope."""
     app = _make_app(include_error_route=True)


### PR DESCRIPTION
## Summary
- This PR enhances the CORS policy to enforce an explicit allow-list for staging and production environments, ensuring that if `CORS_ALLOWED_ORIGINS` is unset, all cross-origin requests are rejected.

