### PR TITLE
Update SubodhaService for tenant quiz overrides and canonical storage

### DIFF
--- a/ContentWebApp/src/components/SyncHistoryPage.js
+++ b/ContentWebApp/src/components/SyncHistoryPage.js
@@ -11,6 +11,7 @@ import { SyncAllProgress } from "./AllContent/shared/SyncAllProgress";
 import "./AllContent/shared/pageShell.css";
 import "./AllContent/shared/cards.css";
 import "./AllContent/shared/buttons.css";
+import "./AllContent/shared/utilities.css";
 import "./AllContent/shared/tables.css";
 import "./AllContent/ContentTab/css/ContentTab.css";
 import "./ContentDetails.css";
@@ -53,6 +54,7 @@ const SyncHistoryPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [expandedId, setExpandedId] = useState(null);
+  const [itemsByJob, setItemsByJob] = useState({});
 
   const load = useCallback(async () => {
     try {
@@ -74,6 +76,46 @@ const SyncHistoryPage = () => {
   useEffect(() => {
     if (!syncingAll) load();
   }, [syncingAll, load]);
+
+  const loadJobItems = useCallback(async (jobId, after) => {
+    setItemsByJob((prev) => ({
+      ...prev,
+      [jobId]: { ...(prev[jobId] || { items: [] }), loading: true, error: null },
+    }));
+    try {
+      const data = await contentAggregatorService.getSyncJobItems(jobId, { limit: 50, after });
+      setItemsByJob((prev) => {
+        const existing = prev[jobId]?.items || [];
+        return {
+          ...prev,
+          [jobId]: {
+            items: after ? [...existing, ...data.items] : data.items,
+            nextCursor: data.next_cursor,
+            hasMore: Boolean(data.next_cursor),
+            loading: false,
+            error: null,
+            loaded: true,
+          },
+        };
+      });
+    } catch (err) {
+      setItemsByJob((prev) => ({
+        ...prev,
+        [jobId]: { ...(prev[jobId] || { items: [] }), loading: false, error: err.message },
+      }));
+    }
+  }, []);
+
+  const toggleExpand = useCallback(
+    (jobId) => {
+      const nextExpanded = expandedId === jobId ? null : jobId;
+      setExpandedId(nextExpanded);
+      if (nextExpanded && !itemsByJob[nextExpanded]?.loaded) {
+        loadJobItems(nextExpanded);
+      }
+    },
+    [expandedId, itemsByJob, loadJobItems]
+  );
 
   return (
     <div className="page-shell">
@@ -98,12 +140,13 @@ const SyncHistoryPage = () => {
         <ul className="sync-history-job-list">
           {jobs.map((job) => {
             const isExpanded = expandedId === job.job_id;
+            const jobItems = itemsByJob[job.job_id];
             return (
               <li key={job.job_id} className="sync-history-job">
                 <button
                   type="button"
                   className="sync-history-job-summary"
-                  onClick={() => setExpandedId(isExpanded ? null : job.job_id)}
+                  onClick={() => toggleExpand(job.job_id)}
                 >
                   {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                   <span className="sync-history-job-scope">
@@ -118,10 +161,16 @@ const SyncHistoryPage = () => {
                     {job.stats.failed} failed
                   </span>
                 </button>
-                {isExpanded && job.items.length === 0 && (
+                {isExpanded && jobItems?.loading && !jobItems.loaded && (
+                  <p className="table-cell-secondary sync-history-empty">Loading…</p>
+                )}
+                {isExpanded && jobItems?.error && (
+                  <p className="content-details-error">Error: {jobItems.error}</p>
+                )}
+                {isExpanded && jobItems?.loaded && jobItems.items.length === 0 && (
                   <p className="table-cell-secondary sync-history-empty">No courses processed yet.</p>
                 )}
-                {isExpanded && job.items.length > 0 && (
+                {isExpanded && jobItems?.loaded && jobItems.items.length > 0 && (
                   <div className="sync-history-table-outer">
                   <div className="table-wrapper">
                     <table className="content-table">
@@ -135,7 +184,7 @@ const SyncHistoryPage = () => {
                         </tr>
                       </thead>
                       <tbody>
-                        {job.items.map((c, i) => (
+                        {jobItems.items.map((c, i) => (
                           <tr key={`${c.source_id}-${i}`}>
                             <td className="table-cell table-cell-truncate">
                               <MiddleEllipsis text={c.source_id} />
@@ -151,6 +200,18 @@ const SyncHistoryPage = () => {
                       </tbody>
                     </table>
                   </div>
+                  {jobItems.hasMore && (
+                    <div className="load-more-wrapper">
+                      <button
+                        type="button"
+                        className="secondary-button"
+                        disabled={jobItems.loading}
+                        onClick={() => loadJobItems(job.job_id, jobItems.nextCursor)}
+                      >
+                        {jobItems.loading ? "Loading more..." : "Load more"}
+                      </button>
+                    </div>
+                  )}
                   </div>
                 )}
               </li>

--- a/ContentWebApp/src/hooks/useContent.js
+++ b/ContentWebApp/src/hooks/useContent.js
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { contentService } from "../services/contentService";
 import { contentAggregatorService } from "../services/contentAggregatorService";
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 20;
 
 const mapContentAggregatorCourse = (course) => ({
   id: course.id,
@@ -25,20 +25,29 @@ export const useContent = () => {
     nextCursor: null,
     hasMore: false,
   });
+  const [coursePaginationInfo, setCoursePaginationInfo] = useState({
+    nextCursor: null,
+    hasMore: false,
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [isFiltered, setIsFiltered] = useState(false);
   const isFilteredRef = useRef(isFiltered);
   isFilteredRef.current = isFiltered;
 
-  const loadContentAggregatorCourses = useCallback(async () => {
+  const loadContentAggregatorCourses = useCallback(async (cursor = null) => {
     try {
-      const courses = await contentAggregatorService.getCourses();
+      const { courses, next_cursor: nextCursor, has_more: hasMore } = await contentAggregatorService.getCourses(
+        cursor
+      );
       const mapped = courses.map(mapContentAggregatorCourse);
       setAllContent((prevAll) => {
-        const merged = [...prevAll.filter((item) => item.source !== "subodha"), ...mapped];
+        const merged = cursor
+          ? [...prevAll, ...mapped]
+          : [...prevAll.filter((item) => item.source !== "subodha"), ...mapped];
         if (!isFilteredRef.current) setContent(merged);
         return merged;
       });
+      setCoursePaginationInfo({ nextCursor, hasMore });
     } catch (error) {
       console.error("Error loading content aggregator courses:", error);
     }
@@ -91,44 +100,56 @@ export const useContent = () => {
    * Load more content (pagination)
    */
   const loadMore = useCallback(async () => {
-    if (!paginationInfo.hasMore || !paginationInfo.nextCursor || isLoading) {
+    if (isLoading) {
       return;
     }
 
-    setIsLoading(true);
-    const ac = new AbortController();
+    if (paginationInfo.hasMore && paginationInfo.nextCursor) {
+      setIsLoading(true);
+      const ac = new AbortController();
 
-    try {
-      const { data, nextCursor, hasMore } = await fetchContent(paginationInfo.nextCursor, ac.signal);
+      try {
+        const { data, nextCursor, hasMore } = await fetchContent(paginationInfo.nextCursor, ac.signal);
 
-      if (!data.length) {
-        setPaginationInfo({ nextCursor: null, hasMore: false });
-        return;
-      }
-
-      setAllContent((prevAll) => {
-        const existingIds = new Set(prevAll.map((c) => c.id));
-        const merged = [...prevAll];
-        data.forEach((item) => {
-          if (!existingIds.has(item.id)) {
-            merged.push(item);
-          }
-        });
-        if (!isFiltered) {
-          setContent(merged);
+        if (!data.length) {
+          setPaginationInfo({ nextCursor: null, hasMore: false });
+          return;
         }
-        return merged;
-      });
 
-      setPaginationInfo({ nextCursor, hasMore });
-    } catch (error) {
-      if (error.name !== "AbortError") {
-        console.error("Error loading more content:", error);
+        setAllContent((prevAll) => {
+          const existingIds = new Set(prevAll.map((c) => c.id));
+          const merged = [...prevAll];
+          data.forEach((item) => {
+            if (!existingIds.has(item.id)) {
+              merged.push(item);
+            }
+          });
+          if (!isFiltered) {
+            setContent(merged);
+          }
+          return merged;
+        });
+
+        setPaginationInfo({ nextCursor, hasMore });
+      } catch (error) {
+        if (error.name !== "AbortError") {
+          console.error("Error loading more content:", error);
+        }
+      } finally {
+        setIsLoading(false);
       }
-    } finally {
-      setIsLoading(false);
+      return;
     }
-  }, [paginationInfo, fetchContent, isFiltered, isLoading]);
+
+    if (coursePaginationInfo.hasMore && coursePaginationInfo.nextCursor) {
+      setIsLoading(true);
+      try {
+        await loadContentAggregatorCourses(coursePaginationInfo.nextCursor);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  }, [paginationInfo, coursePaginationInfo, fetchContent, isFiltered, isLoading, loadContentAggregatorCourses]);
 
   /**
    * Delete content item
@@ -192,7 +213,10 @@ export const useContent = () => {
     content,
     allContent,
     isLoading,
-    paginationInfo,
+    paginationInfo: {
+      nextCursor: paginationInfo.nextCursor,
+      hasMore: paginationInfo.hasMore || coursePaginationInfo.hasMore,
+    },
     isFiltered,
     loadMore,
     deleteContent,

--- a/ContentWebApp/src/hooks/useContent.js
+++ b/ContentWebApp/src/hooks/useContent.js
@@ -35,22 +35,18 @@ export const useContent = () => {
   isFilteredRef.current = isFiltered;
 
   const loadContentAggregatorCourses = useCallback(async (cursor = null) => {
-    try {
-      const { courses, next_cursor: nextCursor, has_more: hasMore } = await contentAggregatorService.getCourses(
-        cursor
-      );
-      const mapped = courses.map(mapContentAggregatorCourse);
-      setAllContent((prevAll) => {
-        const merged = cursor
-          ? [...prevAll, ...mapped]
-          : [...prevAll.filter((item) => item.source !== "subodha"), ...mapped];
-        if (!isFilteredRef.current) setContent(merged);
-        return merged;
-      });
-      setCoursePaginationInfo({ nextCursor, hasMore });
-    } catch (error) {
-      console.error("Error loading content aggregator courses:", error);
-    }
+    const { courses, next_cursor: nextCursor, has_more: hasMore } = await contentAggregatorService.getCourses(
+      cursor
+    );
+    const mapped = courses.map(mapContentAggregatorCourse);
+    setAllContent((prevAll) => {
+      const merged = cursor
+        ? [...prevAll, ...mapped]
+        : [...prevAll.filter((item) => item.source !== "subodha"), ...mapped];
+      if (!isFilteredRef.current) setContent(merged);
+      return merged;
+    });
+    setCoursePaginationInfo({ nextCursor, hasMore });
   }, []);
 
   useEffect(() => {
@@ -61,8 +57,8 @@ export const useContent = () => {
    * Fetch content with optional cursor for pagination
    * Error handling is delegated to contentService
    */
-  const fetchContent = useCallback(async (cursor = null, signal = null) => {
-    const page = await contentService.getContent(cursor, PAGE_SIZE, signal);
+  const fetchContent = useCallback(async (cursor = null) => {
+    const page = await contentService.getContent(cursor, PAGE_SIZE);
     return { data: page.items, nextCursor: page.next_cursor, hasMore: page.has_more };
   }, []);
 
@@ -82,10 +78,6 @@ export const useContent = () => {
         });
         setPaginationInfo({ nextCursor, hasMore });
         setIsFiltered(false);
-      } catch (error) {
-        if (error.name !== "AbortError") {
-          console.error("Error loading initial content:", error);
-        }
       } finally {
         setIsLoading(false);
       }
@@ -106,10 +98,9 @@ export const useContent = () => {
 
     if (paginationInfo.hasMore && paginationInfo.nextCursor) {
       setIsLoading(true);
-      const ac = new AbortController();
 
       try {
-        const { data, nextCursor, hasMore } = await fetchContent(paginationInfo.nextCursor, ac.signal);
+        const { data, nextCursor, hasMore } = await fetchContent(paginationInfo.nextCursor);
 
         if (!data.length) {
           setPaginationInfo({ nextCursor: null, hasMore: false });
@@ -131,10 +122,6 @@ export const useContent = () => {
         });
 
         setPaginationInfo({ nextCursor, hasMore });
-      } catch (error) {
-        if (error.name !== "AbortError") {
-          console.error("Error loading more content:", error);
-        }
       } finally {
         setIsLoading(false);
       }
@@ -171,16 +158,7 @@ export const useContent = () => {
         // Show success message
         alert(`${contentType.charAt(0).toUpperCase() + contentType.slice(1)} deleted successfully.`);
       } catch (error) {
-        console.error("Error deleting content:", error);
-        let errorMessage = error.response?.data?.error || error.message || "Failed to delete content";
-        try {
-          const parsed = JSON.parse(errorMessage);
-          errorMessage = parsed?.error || parsed?.message || errorMessage;
-        } catch (_) {}
-        if (errorMessage === "Content not found" || errorMessage === "Unauthorized") {
-          errorMessage = "You do not have permission to delete this item.";
-        }
-        alert(`Error deleting ${contentType}: ${errorMessage}`);
+        alert(`Error deleting ${contentType}: ${error.message}`);
       }
     },
     []

--- a/ContentWebApp/src/services/contentAggregatorService.js
+++ b/ContentWebApp/src/services/contentAggregatorService.js
@@ -7,12 +7,12 @@ export const contentAggregatorService = {
    * Fetch all courses previously synced from Subodha.
    * @returns {Promise<Array>}
    */
-  async getCourses() {
-    const response = await apiFetch(`${SEEDS_URL}/content-aggregators/courses`, {
+  async getCourses(cursor = null, limit = 20) {
+    const query = buildQueryString({ cursor, limit });
+    return apiFetch(`${SEEDS_URL}/content-aggregators/courses?${query}`, {
       method: "GET",
       headers: getAuthHeaders(),
     });
-    return response.courses;
   },
 
   /**
@@ -119,6 +119,20 @@ export const contentAggregatorService = {
       method: "GET",
       headers: getAuthHeaders(),
     });
+  },
+
+  /**
+   * Paginated per-item sync results for a job.
+   * @param {string} jobId
+   * @param {{limit?: number, after?: string}} params
+   * @returns {Promise<{items: Array<Object>, next_cursor: string|null, total: number}>}
+   */
+  async getSyncJobItems(jobId, { limit = 50, after } = {}) {
+    const qs = buildQueryString({ limit, after });
+    return apiFetch(
+      `${SEEDS_URL}/content-aggregators/sync/status/${encodeURIComponent(jobId)}/items${qs ? `?${qs}` : ""}`,
+      { method: "GET", headers: getAuthHeaders() }
+    );
   },
 
   /**

--- a/ContentWebApp/src/services/contentService.js
+++ b/ContentWebApp/src/services/contentService.js
@@ -11,7 +11,7 @@ export const contentService = {
    * @param {AbortSignal} signal - Abort signal for cancellation
    * @returns {Promise<{data: Array, pagination: Object}>}
    */
-  async getContent(cursor = null, limit = 50, signal = null) {
+  async getContent(cursor = null, limit = 20, signal = null) {
     const params = { limit };
     if (cursor) {
       params.cursor = cursor;

--- a/platform/app/aggregators/models.py
+++ b/platform/app/aggregators/models.py
@@ -146,7 +146,6 @@ _CONTENT_TYPE_BY_ITEM_TYPE: dict[ItemType, type] = {
 
 @dataclass
 class CanonicalNode:
-    tenant_id: str
     source_type: str
     source_id: str
     root_id: str
@@ -166,7 +165,7 @@ class CanonicalNode:
 
     def to_doc(self) -> dict[str, object]:
         return {
-            "tenant_id": self.tenant_id, "source_type": self.source_type, "source_id": self.source_id,
+            "source_type": self.source_type, "source_id": self.source_id,
             "root_id": self.root_id, "parent_id": self.parent_id, "order": self.order,
             "node_kind": self.node_kind.value, "item_type": self.item_type.value if self.item_type else None,
             "display_name": self.display_name, "content": self.content.to_dict() if self.content else None,
@@ -182,7 +181,7 @@ class CanonicalNode:
         if doc["content"] is not None and item_type is not None:
             content = _CONTENT_TYPE_BY_ITEM_TYPE[item_type].from_dict(doc["content"])
         return cls(
-            tenant_id=doc["tenant_id"], source_type=doc["source_type"], source_id=doc["source_id"],
+            source_type=doc["source_type"], source_id=doc["source_id"],
             root_id=doc["root_id"], parent_id=doc["parent_id"], order=doc["order"],
             node_kind=NodeKind(doc["node_kind"]), item_type=item_type, display_name=doc["display_name"],
             content=content, lms_url=doc["lms_url"], native_type=doc["native_type"],

--- a/platform/app/aggregators/subodha_adapter.py
+++ b/platform/app/aggregators/subodha_adapter.py
@@ -58,7 +58,7 @@ class SubodhaAdapter(SourceAdapter):
         now = _now()
 
         course_node = CanonicalNode(
-            tenant_id="", source_type=self.source_type, source_id=course_source_id, root_id=course_source_id,
+            source_type=self.source_type, source_id=course_source_id, root_id=course_source_id,
             parent_id=None, order=0, node_kind=NodeKind.CONTAINER, item_type=None,
             display_name=native_course["name"], content=None, lms_url=None, native_type="course",
             source_metadata={
@@ -84,7 +84,7 @@ class SubodhaAdapter(SourceAdapter):
         def make_container(block_id: str, parent_id: str, native_type: str, order: int) -> CanonicalNode:
             block = blocks.get(block_id, {})
             return CanonicalNode(
-                tenant_id="", source_type=self.source_type, source_id=block_id, root_id=course_source_id,
+                source_type=self.source_type, source_id=block_id, root_id=course_source_id,
                 parent_id=parent_id, order=order, node_kind=NodeKind.CONTAINER, item_type=None,
                 display_name=block.get("display_name") or "", content=None, lms_url=None,
                 native_type=native_type, source_metadata={}, last_run_id=run_id, fetched_at=now, created_at=now, updated_at=now,
@@ -99,7 +99,7 @@ class SubodhaAdapter(SourceAdapter):
             else:
                 raw = block.get("student_view_data")
             node = CanonicalNode(
-                tenant_id="", source_type=self.source_type, source_id=block_id, root_id=course_source_id,
+                source_type=self.source_type, source_id=block_id, root_id=course_source_id,
                 parent_id=parent_id, order=order, node_kind=NodeKind.ITEM, item_type=item_type,
                 display_name=block.get("display_name") or "", content=None, lms_url=block.get("lms_web_url") or "",
                 native_type=native_type, source_metadata={}, last_run_id=run_id, fetched_at=now, created_at=now, updated_at=now,

--- a/platform/app/aggregators/sync_job_models.py
+++ b/platform/app/aggregators/sync_job_models.py
@@ -1,6 +1,8 @@
 """Sync job domain model — typed DTOs for contentAggregatorSyncJobs."""
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 
@@ -34,6 +36,14 @@ class SyncStats:
     def from_doc(cls, doc: dict[str, int]) -> SyncStats:
         return cls(saved=doc["saved"], skipped=doc["skipped"], empty=doc["empty"], failed=doc["failed"])
 
+    @classmethod
+    def from_items(cls, items: Iterable[SyncItemResult]) -> SyncStats:
+        counts = Counter(i.status for i in items)
+        return cls(saved=counts["saved"], skipped=counts["skipped"], empty=counts["empty"], failed=counts["failed"])
+
+    def total(self) -> int:
+        return self.saved + self.skipped + self.empty + self.failed
+
 
 @dataclass
 class SyncJob:
@@ -46,17 +56,13 @@ class SyncJob:
     started_at: str
     finished_at: str | None
     total_items: int
-    processed: int
-    stats: SyncStats
-    items: list[SyncItemResult]
     error: str | None
 
     def to_doc(self) -> dict[str, object]:
         return {
             "_id": self.job_id, "tenant_id": self.tenant_id, "source_type": self.source_type, "scope": self.scope,
             "source_id": self.source_id, "status": self.status, "started_at": self.started_at,
-            "finished_at": self.finished_at, "total_items": self.total_items, "processed": self.processed,
-            "stats": self.stats.to_doc(), "items": [i.to_doc() for i in self.items], "error": self.error,
+            "finished_at": self.finished_at, "total_items": self.total_items, "error": self.error,
         }
 
     @classmethod
@@ -64,6 +70,5 @@ class SyncJob:
         return cls(
             job_id=doc["_id"], tenant_id=doc["tenant_id"], source_type=doc["source_type"], scope=doc["scope"],
             source_id=doc["source_id"], status=doc["status"], started_at=doc["started_at"], finished_at=doc["finished_at"],
-            total_items=doc["total_items"], processed=doc["processed"], stats=SyncStats.from_doc(doc["stats"]),
-            items=[SyncItemResult.from_doc(i) for i in doc["items"]], error=doc["error"],
+            total_items=doc["total_items"], error=doc["error"],
         )

--- a/platform/app/controllers/content_aggregator_controller.py
+++ b/platform/app/controllers/content_aggregator_controller.py
@@ -12,13 +12,17 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
 from fastapi.responses import StreamingResponse
 
 from app.models.user import UserRole
 from app.platform.auth.dependencies import get_current_user
 from app.platform.error_handling import ConflictError, ForbiddenError, NotFoundError
 from app.providers.subodha_client import SubodhaClient, get_subodha_client
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+    get_content_aggregator_sync_job_item_repo,
+)
 from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
     get_content_aggregator_sync_job_repo,
@@ -59,6 +63,7 @@ async def _run_sync_job(
     service: SubodhaService,
     client: SubodhaClient,
     job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
     *,
     only_new: bool,
     dry_run: bool,
@@ -74,13 +79,13 @@ async def _run_sync_job(
             all_courses = await client.list_all_courses()
 
         await service.run_sync(
-            tenant_id, client, job_repo, job_id, all_courses, course_ids=course_ids,
+            tenant_id, client, job_repo, item_repo, job_id, all_courses, course_ids=course_ids,
             limit=limit if limit is not None else (len(course_ids) if course_ids is not None else None),
             dry_run=dry_run,
         )
-        await finish_job(job_repo, tenant_id, job_id, "completed")
+        await finish_job(job_repo, item_repo, tenant_id, job_id, "completed")
     except Exception as exc:  # noqa: BLE001
-        await finish_job(job_repo, tenant_id, job_id, "failed", error=str(exc))
+        await finish_job(job_repo, item_repo, tenant_id, job_id, "failed", error=str(exc))
 
 
 async def _run_course_sync_job(
@@ -89,15 +94,16 @@ async def _run_course_sync_job(
     service: SubodhaService,
     client: SubodhaClient,
     job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
     course_id: str,
     *,
     dry_run: bool,
 ) -> None:
     try:
-        await service.run_single_course_sync(tenant_id, client, job_repo, job_id, course_id, dry_run=dry_run)
-        await finish_job(job_repo, tenant_id, job_id, "completed")
+        await service.run_single_course_sync(tenant_id, client, job_repo, item_repo, job_id, course_id, dry_run=dry_run)
+        await finish_job(job_repo, item_repo, tenant_id, job_id, "completed")
     except Exception as exc:  # noqa: BLE001
-        await finish_job(job_repo, tenant_id, job_id, "failed", error=str(exc))
+        await finish_job(job_repo, item_repo, tenant_id, job_id, "failed", error=str(exc))
 
 
 @router.get("/diff", summary="Diff live Subodha courses against stored courses")
@@ -117,6 +123,7 @@ async def start_sync(
     service: SubodhaService = Depends(get_subodha_service),
     client: SubodhaClient = Depends(get_subodha_client),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
+    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> dict[str, str]:
     body = body or {}
     tenant_id = user.get("tenant_id", "")
@@ -125,18 +132,24 @@ async def start_sync(
         raise ConflictError("A Subodha sync-all job")
     job = await create_job(job_repo, tenant_id=tenant_id, source_type=SOURCE_TYPE, scope="all", source_id=None, total_items=0)
     background_tasks.add_task(
-        _run_sync_job, tenant_id, job.job_id, service, client, job_repo,
+        _run_sync_job, tenant_id, job.job_id, service, client, job_repo, item_repo,
         only_new=bool(body.get("onlyNew", False)), dry_run=bool(body.get("dryRun", False)), limit=body.get("limit"),
     )
     return {"job_id": job.job_id}
 
 
-@router.get("/courses", summary="List synced courses")
+@router.get("/courses", summary="List synced courses (cursor pagination)")
 async def list_courses(
+    limit: int = Query(20, ge=1, le=200),
+    cursor: str | None = None,
     user: dict[str, Any] = Depends(_require_aggregator_access),
     service: SubodhaService = Depends(get_subodha_service),
 ) -> dict[str, Any]:
-    return {"courses": await service.get_content_list(user.get("tenant_id", ""))}
+    all_courses = await service.get_content_list(user.get("tenant_id", ""), cursor=cursor, limit=limit)
+    has_more = len(all_courses) > limit
+    courses = all_courses[:limit]
+    next_cursor = courses[-1]["id"] if has_more and courses else None
+    return {"courses": courses, "next_cursor": next_cursor, "has_more": has_more}
 
 
 @router.get("/courses/{course_id}", summary="Get a synced course's full content (blocks) for viewing")
@@ -191,6 +204,7 @@ async def sync_course(
     service: SubodhaService = Depends(get_subodha_service),
     client: SubodhaClient = Depends(get_subodha_client),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
+    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> dict[str, str]:
     body = body or {}
     tenant_id = user.get("tenant_id", "")
@@ -199,7 +213,7 @@ async def sync_course(
         raise ConflictError(f'A sync for course "{course_id}"')
     job = await create_job(job_repo, tenant_id=tenant_id, source_type=SOURCE_TYPE, scope="course", source_id=course_id, total_items=1)
     background_tasks.add_task(
-        _run_course_sync_job, tenant_id, job.job_id, service, client, job_repo, course_id, dry_run=bool(body.get("dryRun", False))
+        _run_course_sync_job, tenant_id, job.job_id, service, client, job_repo, item_repo, course_id, dry_run=bool(body.get("dryRun", False))
     )
     return {"job_id": job.job_id}
 
@@ -209,32 +223,64 @@ async def get_sync_status(
     job_id: str,
     user: dict[str, Any] = Depends(_require_aggregator_access),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
+    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> dict[str, Any]:
-    job = await job_repo.get_job(user.get("tenant_id", ""), job_id)
+    tenant_id = user.get("tenant_id", "")
+    job = await job_repo.get_job(tenant_id, job_id)
     if job is None:
         raise NotFoundError("Job", job_id)
-    return serialize_job(job)
+    stats = await item_repo.get_stats(tenant_id, job_id)
+    return serialize_job(job, stats)
+
+
+@router.get("/sync/status/{job_id}/items", summary="Paginated per-item sync results for a job")
+async def get_sync_job_items(
+    job_id: str,
+    limit: int = Query(20, ge=1, le=200),
+    after: str | None = None,
+    user: dict[str, Any] = Depends(_require_aggregator_access),
+    job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
+    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
+) -> dict[str, Any]:
+    tenant_id = user.get("tenant_id", "")
+    job = await job_repo.get_job(tenant_id, job_id)
+    if job is None:
+        raise NotFoundError("Job", job_id)
+    items, next_cursor, total = await item_repo.list_by_job_page(tenant_id, job_id, limit=limit, after=after)
+    return {"items": [i.to_doc() for i in items], "next_cursor": next_cursor, "total": total}
 
 
 @router.get("/sync/jobs", summary="List past sync jobs (history)")
 async def get_sync_jobs(
-    limit: int = 20,
+    limit: int = Query(20, ge=1, le=200),
     scope: str | None = None,
     course_id: str | None = None,
     user: dict[str, Any] = Depends(_require_tenant),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
+    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> dict[str, Any]:
-    jobs = await job_repo.list_jobs(user.get("tenant_id", ""), SOURCE_TYPE, limit=limit, scope=scope, source_id=course_id)
-    return {"jobs": [serialize_job(j) for j in jobs]}
+    tenant_id = user.get("tenant_id", "")
+    job_list = await job_repo.list_jobs(tenant_id, SOURCE_TYPE, limit=limit, scope=scope, source_id=course_id)
+    payloads = []
+    for j in job_list:
+        stats = await item_repo.get_stats(tenant_id, j.job_id)
+        payloads.append(serialize_job(j, stats))
+    return {"jobs": payloads}
 
 
 @router.get("/sync/jobs/active", summary="List currently-running sync jobs (for resume after logout/login)")
 async def get_active_jobs(
     user: dict[str, Any] = Depends(_require_tenant),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
+    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> dict[str, Any]:
-    jobs = await job_repo.get_active_jobs(user.get("tenant_id", ""), SOURCE_TYPE)
-    return {"jobs": [serialize_job(j) for j in jobs]}
+    tenant_id = user.get("tenant_id", "")
+    jobs = await job_repo.get_active_jobs(tenant_id, SOURCE_TYPE)
+    payloads = []
+    for j in jobs:
+        stats = await item_repo.get_stats(tenant_id, j.job_id)
+        payloads.append(serialize_job(j, stats))
+    return {"jobs": payloads}
 
 
 @router.get("/sync/stream/{job_id}", summary="SSE stream of live job progress")
@@ -242,11 +288,12 @@ async def stream_job(
     job_id: str,
     user: dict[str, Any] = Depends(_require_aggregator_access),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
+    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> StreamingResponse:
     tenant_id = user.get("tenant_id", "")
 
     async def _format() -> Any:
-        async for event in subscribe(job_repo, tenant_id, job_id):
+        async for event in subscribe(job_repo, item_repo, tenant_id, job_id):
             yield f"data: {json.dumps(event, default=str)}\n\n"
 
     return StreamingResponse(_format(), media_type="text/event-stream")

--- a/platform/app/controllers/content_controller.py
+++ b/platform/app/controllers/content_controller.py
@@ -241,7 +241,7 @@ async def list_content(
     exp_name: str | None = Query(None),
     ids: list[str] | None = Query(None),
     only_teacher_app: bool | None = Query(None),
-    limit: int = Query(15, ge=1, le=200),
+    limit: int = Query(20, ge=1, le=200),
     cursor: str | None = None,
     user: dict[str, Any] = Depends(_require_content_read),
     service: ContentService = Depends(get_content_service),

--- a/platform/app/repositories/content_aggregator_item_override_repository.py
+++ b/platform/app/repositories/content_aggregator_item_override_repository.py
@@ -1,0 +1,43 @@
+"""Content aggregator item override repository — per-tenant quiz edits layered
+over the shared canonical contentAggregators node, so one tenant editing a
+question/choices via SubodhaService.update_problem_block doesn't change what
+every other tenant sharing that node sees.
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+
+from fastapi import Depends
+from pymongo.asynchronous.database import AsyncDatabase
+
+from app.platform.auth.dependencies import get_db
+
+
+class ContentAggregatorItemOverrideRepository:
+    COLLECTION_NAME: ClassVar[str] = "contentAggregatorItemOverrides"
+
+    def __init__(self, db: AsyncDatabase) -> None:
+        self._col = db[self.COLLECTION_NAME]
+
+    async def upsert(
+        self, tenant_id: str, source_type: str, source_id: str, question: str, choices: list[dict[str, object]]
+    ) -> None:
+        await self._col.update_one(
+            {"tenant_id": tenant_id, "source_type": source_type, "source_id": source_id},
+            {"$set": {"question": question, "choices": choices}},
+            upsert=True,
+        )
+
+    async def list_by_tree(
+        self, tenant_id: str, source_type: str, source_ids: list[str]
+    ) -> dict[str, dict[str, object]]:
+        docs = await self._col.find(
+            {"tenant_id": tenant_id, "source_type": source_type, "source_id": {"$in": source_ids}}
+        ).to_list(length=None)
+        return {d["source_id"]: d for d in docs}
+
+
+def get_content_aggregator_item_override_repo(
+    db: AsyncDatabase = Depends(get_db),
+) -> ContentAggregatorItemOverrideRepository:
+    return ContentAggregatorItemOverrideRepository(db)

--- a/platform/app/repositories/content_aggregator_repository.py
+++ b/platform/app/repositories/content_aggregator_repository.py
@@ -1,17 +1,22 @@
-"""Content aggregator repository — universal, source-agnostic, tenant-scoped
-PyMongo async data access for the contentAggregators collection.
+"""Content aggregator repository — per-tenant PyMongo async data access for
+the contentAggregators collection. Every node (container or item) is one
+document scoped by tenant_id — two tenants syncing the same course each get
+their own full copy, no cross-tenant sharing.
 
-Every node (container or item) is one document. DTO<->dict conversion happens
-only here (CanonicalNode.to_doc()/from_doc()) — callers work with CanonicalNode.
+DTO<->dict conversion happens only here (CanonicalNode.to_doc()/from_doc())
+— callers work with CanonicalNode.
 """
 from __future__ import annotations
 
-import asyncio
 from typing import ClassVar
 
+from pymongo import UpdateOne
 from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import BulkWriteError
 
-from app.aggregators.models import CanonicalNode, ContentPayload
+from app.aggregators.models import CanonicalNode
+
+_DUPLICATE_KEY_ERROR_CODE = 11000
 
 
 class ContentAggregatorRepository:
@@ -20,18 +25,27 @@ class ContentAggregatorRepository:
     def __init__(self, db: AsyncDatabase) -> None:
         self._col = db[self.COLLECTION_NAME]
 
-    async def upsert_tree(self, tenant_id: str, source_type: str, root_id: str, nodes: list[CanonicalNode]) -> None:
-        if nodes:
-            await asyncio.gather(
-                *(
-                    self._col.replace_one(
-                        {"tenant_id": tenant_id, "source_type": source_type, "root_id": root_id, "source_id": n.source_id},
-                        n.to_doc(),
-                        upsert=True,
-                    )
-                    for n in nodes
+    async def upsert_tree(
+        self, tenant_id: str, source_type: str, root_id: str, nodes: list[CanonicalNode], *, batch_size: int = 20
+    ) -> None:
+        for i in range(0, len(nodes), batch_size):
+            batch = nodes[i : i + batch_size]
+            try:
+                await self._col.bulk_write(
+                    [
+                        UpdateOne(
+                            {"tenant_id": tenant_id, "source_type": source_type, "root_id": root_id, "source_id": n.source_id},
+                            {"$set": n.to_doc() | {"tenant_id": tenant_id}},
+                            upsert=True,
+                        )
+                        for n in batch
+                    ],
+                    ordered=False,
                 )
-            )
+            except BulkWriteError as exc:
+                write_errors = exc.details.get("writeErrors", [])
+                if any(err.get("code") != _DUPLICATE_KEY_ERROR_CODE for err in write_errors):
+                    raise
         await self._col.delete_many(
             {
                 "tenant_id": tenant_id,
@@ -40,6 +54,13 @@ class ContentAggregatorRepository:
                 "source_id": {"$nin": [n.source_id for n in nodes]},
             }
         )
+
+    async def is_enrolled(self, tenant_id: str, source_type: str, root_id: str) -> bool:
+        doc = await self._col.find_one(
+            {"tenant_id": tenant_id, "source_type": source_type, "source_id": root_id, "parent_id": None},
+            {"_id": 1},
+        )
+        return doc is not None
 
     async def get_tree(self, tenant_id: str, source_type: str, root_id: str) -> list[CanonicalNode]:
         docs = await (
@@ -50,25 +71,31 @@ class ContentAggregatorRepository:
         return [CanonicalNode.from_doc(d) for d in docs]
 
     async def get_root(self, tenant_id: str, source_type: str, root_id: str) -> CanonicalNode | None:
-        doc = await self._col.find_one(
-            {"tenant_id": tenant_id, "source_type": source_type, "source_id": root_id, "parent_id": None}
-        )
+        doc = await self._col.find_one({"tenant_id": tenant_id, "source_type": source_type, "source_id": root_id, "parent_id": None})
         return CanonicalNode.from_doc(doc) if doc else None
 
-    async def list_roots(self, tenant_id: str, source_type: str) -> list[CanonicalNode]:
-        docs = await self._col.find({"tenant_id": tenant_id, "source_type": source_type, "parent_id": None}).to_list(length=None)
+    async def list_roots(
+        self,
+        tenant_id: str,
+        source_type: str,
+        *,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> list[CanonicalNode]:
+        query: dict = {"tenant_id": tenant_id, "source_type": source_type, "parent_id": None}
+        if cursor is not None:
+            query["source_id"] = {"$gt": cursor}
+        find = self._col.find(query).sort("source_id", 1)
+        if limit is not None:
+            find = find.limit(limit)
+        docs = await find.to_list(length=None)
         return [CanonicalNode.from_doc(d) for d in docs]
 
     async def stored_root_ids(self, tenant_id: str, source_type: str) -> set[str]:
-        return set(await self._col.distinct("source_id", {"tenant_id": tenant_id, "source_type": source_type, "parent_id": None}))
+        return set(
+            await self._col.distinct("source_id", {"tenant_id": tenant_id, "source_type": source_type, "parent_id": None})
+        )
 
     async def delete_tree(self, tenant_id: str, source_type: str, root_id: str) -> int:
         result = await self._col.delete_many({"tenant_id": tenant_id, "source_type": source_type, "root_id": root_id})
         return result.deleted_count
-
-    async def update_item_content(self, tenant_id: str, source_type: str, source_id: str, content: ContentPayload) -> int:
-        result = await self._col.update_one(
-            {"tenant_id": tenant_id, "source_type": source_type, "source_id": source_id},
-            {"$set": {"content": content.to_dict()}},
-        )
-        return result.modified_count

--- a/platform/app/repositories/content_aggregator_sync_job_item_repository.py
+++ b/platform/app/repositories/content_aggregator_sync_job_item_repository.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bson import ObjectId
+from fastapi import Depends
+from pymongo.asynchronous.database import AsyncDatabase
+
+from app.aggregators.sync_job_models import SyncItemResult, SyncStats
+from app.platform.auth.dependencies import get_db
+
+
+class ContentAggregatorSyncJobItemRepository:
+    COLLECTION_NAME: ClassVar[str] = "contentAggregatorSyncJobItems"
+
+    def __init__(self, db: AsyncDatabase) -> None:
+        self._col = db[self.COLLECTION_NAME]
+
+    async def insert(self, tenant_id: str, job_id: str, entry: SyncItemResult) -> None:
+        doc = entry.to_doc()
+        doc["tenant_id"] = tenant_id
+        doc["job_id"] = job_id
+        await self._col.insert_one(doc)
+
+    async def list_by_job(self, tenant_id: str, job_id: str) -> list[SyncItemResult]:
+        docs = await self._col.find({"tenant_id": tenant_id, "job_id": job_id}).to_list(length=None)
+        return [SyncItemResult.from_doc(d) for d in docs]
+
+    async def list_by_job_page(
+        self, tenant_id: str, job_id: str, *, limit: int = 50, after: str | None = None
+    ) -> tuple[list[SyncItemResult], str | None, int]:
+        query: dict[str, object] = {"tenant_id": tenant_id, "job_id": job_id}
+        if after:
+            query["_id"] = {"$gt": ObjectId(after)}
+        docs = await self._col.find(query).sort("_id", 1).limit(limit).to_list(length=limit)
+        total = await self._col.count_documents({"tenant_id": tenant_id, "job_id": job_id})
+        next_cursor = str(docs[-1]["_id"]) if len(docs) == limit else None
+        return [SyncItemResult.from_doc(d) for d in docs], next_cursor, total
+
+    async def get_stats(self, tenant_id: str, job_id: str) -> SyncStats:
+        pipeline = [
+            {"$match": {"tenant_id": tenant_id, "job_id": job_id}},
+            {"$group": {"_id": "$status", "count": {"$sum": 1}}},
+        ]
+        cursor = await self._col.aggregate(pipeline)
+        counts = {d["_id"]: d["count"] async for d in cursor}
+        return SyncStats(
+            saved=counts.get("saved", 0), skipped=counts.get("skipped", 0),
+            empty=counts.get("empty", 0), failed=counts.get("failed", 0),
+        )
+
+
+def get_content_aggregator_sync_job_item_repo(db: AsyncDatabase = Depends(get_db)) -> ContentAggregatorSyncJobItemRepository:
+    return ContentAggregatorSyncJobItemRepository(db)

--- a/platform/app/repositories/content_aggregator_sync_job_repository.py
+++ b/platform/app/repositories/content_aggregator_sync_job_repository.py
@@ -12,7 +12,7 @@ from fastapi import Depends
 from pymongo import ReturnDocument
 from pymongo.asynchronous.database import AsyncDatabase
 
-from app.aggregators.sync_job_models import SyncItemResult, SyncJob, SyncStats
+from app.aggregators.sync_job_models import SyncJob
 from app.platform.auth.dependencies import get_db
 
 
@@ -28,7 +28,7 @@ class ContentAggregatorSyncJobRepository:
         job = SyncJob(
             job_id=job_id, tenant_id=tenant_id, source_type=source_type, scope=scope, source_id=source_id,
             status="running", started_at=datetime.now(UTC).isoformat(), finished_at=None,
-            total_items=total_items, processed=0, stats=SyncStats(), items=[], error=None,
+            total_items=total_items, error=None,
         )
         await self._col.insert_one(job.to_doc())
         return job
@@ -36,14 +36,6 @@ class ContentAggregatorSyncJobRepository:
     async def set_total_items(self, tenant_id: str, job_id: str, total: int) -> SyncJob | None:
         doc = await self._col.find_one_and_update(
             {"_id": job_id, "tenant_id": tenant_id}, {"$set": {"total_items": total}}, return_document=ReturnDocument.AFTER
-        )
-        return SyncJob.from_doc(doc) if doc else None
-
-    async def append_item_result(self, tenant_id: str, job_id: str, entry: SyncItemResult) -> SyncJob | None:
-        doc = await self._col.find_one_and_update(
-            {"_id": job_id, "tenant_id": tenant_id},
-            {"$push": {"items": entry.to_doc()}, "$inc": {"processed": 1, f"stats.{entry.status}": 1}},
-            return_document=ReturnDocument.AFTER,
         )
         return SyncJob.from_doc(doc) if doc else None
 

--- a/platform/app/services/content_aggregator_sync_jobs.py
+++ b/platform/app/services/content_aggregator_sync_jobs.py
@@ -8,7 +8,10 @@ import asyncio
 import uuid
 from collections.abc import AsyncIterator
 
-from app.aggregators.sync_job_models import SyncItemResult, SyncJob
+from app.aggregators.sync_job_models import SyncItemResult, SyncJob, SyncStats
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
 from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
 )
@@ -16,7 +19,7 @@ from app.repositories.content_aggregator_sync_job_repository import (
 _subscribers: dict[str, list[asyncio.Queue]] = {}
 
 
-def serialize_job(job: SyncJob) -> dict[str, object]:
+def serialize_job(job: SyncJob, stats: SyncStats) -> dict[str, object]:
     return {
         "job_id": job.job_id,
         "scope": job.scope,
@@ -25,9 +28,8 @@ def serialize_job(job: SyncJob) -> dict[str, object]:
         "started_at": job.started_at,
         "finished_at": job.finished_at,
         "total_courses": job.total_items,
-        "processed": job.processed,
-        "stats": job.stats.to_doc(),
-        "items": [i.to_doc() for i in job.items],
+        "processed": stats.total(),
+        "stats": stats.to_doc(),
         "error": job.error,
     }
 
@@ -46,43 +48,72 @@ async def create_job(
     )
 
 
-async def set_total(repo: ContentAggregatorSyncJobRepository, tenant_id: str, job_id: str, total: int) -> None:
-    job = await repo.set_total_items(tenant_id, job_id, total)
+async def set_total(
+    job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
+    tenant_id: str,
+    job_id: str,
+    total: int,
+) -> None:
+    job = await job_repo.set_total_items(tenant_id, job_id, total)
     if job is not None:
-        _broadcast(job_id, {"event": "progress", "job": serialize_job(job)})
+        stats = await item_repo.get_stats(tenant_id, job_id)
+        _broadcast(job_id, {"event": "progress", "job": serialize_job(job, stats)})
 
 
-async def record_item_result(repo: ContentAggregatorSyncJobRepository, tenant_id: str, job_id: str, entry: SyncItemResult) -> None:
-    job = await repo.append_item_result(tenant_id, job_id, entry)
+async def record_item_result(
+    job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
+    tenant_id: str,
+    job_id: str,
+    entry: SyncItemResult,
+) -> None:
+    await item_repo.insert(tenant_id, job_id, entry)
+    job = await job_repo.get_job(tenant_id, job_id)
     if job is not None:
-        _broadcast(job_id, {"event": "progress", "job": serialize_job(job)})
+        stats = await item_repo.get_stats(tenant_id, job_id)
+        _broadcast(job_id, {"event": "progress", "job": serialize_job(job, stats)})
 
 
 async def finish_job(
-    repo: ContentAggregatorSyncJobRepository, tenant_id: str, job_id: str, status: str, *, error: str | None = None
+    job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
+    tenant_id: str,
+    job_id: str,
+    status: str,
+    *,
+    error: str | None = None,
 ) -> None:
-    job = await repo.set_job_status(tenant_id, job_id, status, error=error)
+    job = await job_repo.set_job_status(tenant_id, job_id, status, error=error)
     if job is not None:
-        _broadcast(job_id, {"event": "done", "job": serialize_job(job)})
+        stats = await item_repo.get_stats(tenant_id, job_id)
+        _broadcast(job_id, {"event": "done", "job": serialize_job(job, stats)})
     _subscribers.pop(job_id, None)
 
 
-async def subscribe(repo: ContentAggregatorSyncJobRepository, tenant_id: str, job_id: str) -> AsyncIterator[dict[str, object]]:
-    current = await repo.get_job(tenant_id, job_id)
+async def subscribe(
+    job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
+    tenant_id: str,
+    job_id: str,
+) -> AsyncIterator[dict[str, object]]:
+    current = await job_repo.get_job(tenant_id, job_id)
     if current is None:
         return
+    stats = await item_repo.get_stats(tenant_id, job_id)
     if current.status != "running":
-        yield {"event": "done", "job": serialize_job(current)}
+        yield {"event": "done", "job": serialize_job(current, stats)}
         return
-    yield {"event": "progress", "job": serialize_job(current)}
+    yield {"event": "progress", "job": serialize_job(current, stats)}
 
     queue: asyncio.Queue = asyncio.Queue()
     subs = _subscribers.setdefault(job_id, [])
     subs.append(queue)
     try:
-        current = await repo.get_job(tenant_id, job_id)
+        current = await job_repo.get_job(tenant_id, job_id)
         if current is not None and current.status != "running":
-            yield {"event": "done", "job": serialize_job(current)}
+            stats = await item_repo.get_stats(tenant_id, job_id)
+            yield {"event": "done", "job": serialize_job(current, stats)}
             return
         while True:
             event = await queue.get()

--- a/platform/app/services/content_aggregator_sync_jobs.py
+++ b/platform/app/services/content_aggregator_sync_jobs.py
@@ -69,10 +69,11 @@ async def record_item_result(
     entry: SyncItemResult,
 ) -> None:
     await item_repo.insert(tenant_id, job_id, entry)
-    job = await job_repo.get_job(tenant_id, job_id)
-    if job is not None:
-        stats = await item_repo.get_stats(tenant_id, job_id)
-        _broadcast(job_id, {"event": "progress", "job": serialize_job(job, stats)})
+    if _subscribers.get(job_id):
+        job = await job_repo.get_job(tenant_id, job_id)
+        if job is not None:
+            stats = await item_repo.get_stats(tenant_id, job_id)
+            _broadcast(job_id, {"event": "progress", "job": serialize_job(job, stats)})
 
 
 async def finish_job(

--- a/platform/app/services/subodha_service.py
+++ b/platform/app/services/subodha_service.py
@@ -17,12 +17,18 @@ from pymongo.asynchronous.database import AsyncDatabase
 
 from app.aggregators.models import BlobContext, QuizContent
 from app.aggregators.subodha_adapter import SubodhaAdapter
-from app.aggregators.sync_job_models import SyncItemResult
+from app.aggregators.sync_job_models import SyncItemResult, SyncStats
 from app.platform.auth.dependencies import get_db
 from app.platform.settings import get_settings
 from app.providers.blob_storage import BlobStorageProvider
 from app.providers.subodha_client import SubodhaClient, SubodhaCourse
+from app.repositories.content_aggregator_item_override_repository import (
+    ContentAggregatorItemOverrideRepository,
+)
 from app.repositories.content_aggregator_repository import ContentAggregatorRepository
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
 from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
 )
@@ -92,6 +98,7 @@ class SubodhaService:
 
     def __init__(self, db: AsyncDatabase, blob: BlobStorageProvider | None = None) -> None:
         self._repo = ContentAggregatorRepository(db)
+        self._override_repo = ContentAggregatorItemOverrideRepository(db)
         self._blob = blob if blob is not None else BlobStorageProvider()
         self._settings = get_settings()
         self._adapter = SubodhaAdapter()
@@ -103,8 +110,8 @@ class SubodhaService:
         existing = next((n for n in tree if n.source_id == block_id), None)
         if existing is None or not isinstance(existing.content, QuizContent):
             return 0
-        updated = QuizContent(raw_html_url=existing.content.raw_html_url, question=question, choices=choices)
-        return await self._repo.update_item_content(tenant_id, self.SOURCE_TYPE, block_id, updated)
+        await self._override_repo.upsert(tenant_id, self.SOURCE_TYPE, block_id, question, choices)
+        return 1
 
     async def get_course_diff(self, tenant_id: str, client: SubodhaClient) -> CourseDiffResult:
         live_courses, stored_ids = await asyncio.gather(
@@ -123,8 +130,10 @@ class SubodhaService:
             "liveCourses": live_courses,
         }
 
-    async def get_content_list(self, tenant_id: str) -> list[dict[str, Any]]:
-        roots = await self._repo.list_roots(tenant_id, self.SOURCE_TYPE)
+    async def get_content_list(
+        self, tenant_id: str, *, cursor: str | None = None, limit: int = 20
+    ) -> list[dict[str, Any]]:
+        roots = await self._repo.list_roots(tenant_id, self.SOURCE_TYPE, cursor=cursor, limit=limit + 1)
         return [
             {
                 "id": r.source_id,
@@ -141,9 +150,20 @@ class SubodhaService:
         ]
 
     async def get_course(self, tenant_id: str, source_id: str) -> LegacyCourseDoc | None:
+        if not await self._repo.is_enrolled(tenant_id, self.SOURCE_TYPE, source_id):
+            return None
         tree = await self._repo.get_tree(tenant_id, self.SOURCE_TYPE, source_id)
         if not tree:
             return None
+        overrides = await self._override_repo.list_by_tree(tenant_id, self.SOURCE_TYPE, [n.source_id for n in tree])
+        for node in tree:
+            override = overrides.get(node.source_id)
+            if override and isinstance(node.content, QuizContent):
+                node.content = QuizContent(
+                    raw_html_url=node.content.raw_html_url,
+                    question=override["question"],
+                    choices=override["choices"],
+                )
         return await to_course_doc(tree, self._blob)
 
     async def delete_course(self, tenant_id: str, source_id: str) -> int:
@@ -180,8 +200,6 @@ class SubodhaService:
             if existing_root is not None and existing_root.source_metadata.get("content_hash") == content_hash:
                 return {"status": "skipped", "courseId": course_id}
 
-            for node in nodes:
-                node.tenant_id = tenant_id
             processed = await self._adapter.process_nodes(nodes, self._blob_ctx_factory(course_id), self._blob)
             for node in processed:
                 if node.parent_id is None:
@@ -196,6 +214,7 @@ class SubodhaService:
         tenant_id: str,
         client: SubodhaClient,
         job_repo: ContentAggregatorSyncJobRepository,
+        item_repo: ContentAggregatorSyncJobItemRepository,
         job_id: str,
         all_courses: list[SubodhaCourse],
         *,
@@ -215,7 +234,7 @@ class SubodhaService:
             to_process = to_process[:limit]
 
         logger.info("[subodha] %d of %d courses queued", len(to_process), len(all_courses))
-        await set_total(job_repo, tenant_id, job_id, len(to_process))
+        await set_total(job_repo, item_repo, tenant_id, job_id, len(to_process))
 
         semaphore = asyncio.Semaphore(self._settings.subodha_course_concurrency)
         session_box = {"cookie": session_cookie}
@@ -241,7 +260,7 @@ class SubodhaService:
                     source_id=result["courseId"], name=course.get("name") or "", status=result["status"],
                     error=result.get("error"), at=datetime.now(UTC).isoformat(),
                 )
-                await record_item_result(job_repo, tenant_id, job_id, entry)
+                await record_item_result(job_repo, item_repo, tenant_id, job_id, entry)
 
                 async with lock:
                     processed_count += 1
@@ -251,11 +270,11 @@ class SubodhaService:
 
         await asyncio.gather(*(process_one(c) for c in to_process))
 
-        stored = await job_repo.get_job(tenant_id, job_id)
-        stats = stored.stats.to_doc() if stored else {}
+        items = await item_repo.list_by_job(tenant_id, job_id)
+        stats = SyncStats.from_items(items).to_doc()
         permanent_failures = [
             {"courseId": c.source_id, "error": c.error or ""}
-            for c in (stored.items if stored else [])
+            for c in items
             if c.status == "failed"
         ]
         summary = {
@@ -263,7 +282,7 @@ class SubodhaService:
             "startedAt": started_at,
             "finishedAt": datetime.now(UTC).isoformat(),
             "totalCourses": len(all_courses),
-            "processed": stored.processed if stored else processed_count,
+            "processed": len(items),
             "stats": stats,
             "permanentFailures": permanent_failures,
             "dlqProcessed": 0,
@@ -276,6 +295,7 @@ class SubodhaService:
         tenant_id: str,
         client: SubodhaClient,
         job_repo: ContentAggregatorSyncJobRepository,
+        item_repo: ContentAggregatorSyncJobItemRepository,
         job_id: str,
         course_id: str,
         *,
@@ -289,16 +309,16 @@ class SubodhaService:
         if course is None:
             raise ValueError(f"Course not found on Subodha: {course_id}")
 
-        await set_total(job_repo, tenant_id, job_id, 1)
+        await set_total(job_repo, item_repo, tenant_id, job_id, 1)
         result = await self.process_course(tenant_id, client, course, session_cookie, job_id, dry_run)
         entry = SyncItemResult(
             source_id=result["courseId"], name=course.get("name") or "", status=result["status"],
             error=result.get("error"), at=datetime.now(UTC).isoformat(),
         )
-        await record_item_result(job_repo, tenant_id, job_id, entry)
+        await record_item_result(job_repo, item_repo, tenant_id, job_id, entry)
 
-        stored = await job_repo.get_job(tenant_id, job_id)
-        stats = stored.stats.to_doc() if stored else {}
+        items = await item_repo.list_by_job(tenant_id, job_id)
+        stats = SyncStats.from_items(items).to_doc()
         permanent_failures = (
             [{"courseId": course_id, "error": result.get("error", "")}] if result["status"] == "failed" else []
         )

--- a/platform/tests/integration/test_content_aggregator_controller_jobs.py
+++ b/platform/tests/integration/test_content_aggregator_controller_jobs.py
@@ -145,7 +145,7 @@ async def test_courses_are_isolated_between_tenants(client, mock_db):
 
     repo = ContentAggregatorRepository(mock_db)
     node = CanonicalNode(
-        tenant_id="tenant-a", source_type="subodha", source_id="course-1", root_id="course-1", parent_id=None,
+        source_type="subodha", source_id="course-1", root_id="course-1", parent_id=None,
         order=0, node_kind=NodeKind.CONTAINER, item_type=None, display_name="A's course", content=None,
         lms_url=None, native_type="course", source_metadata={}, last_run_id="run-1",
         fetched_at="x", created_at="x", updated_at="x",

--- a/platform/tests/integration/test_content_aggregator_controller_jobs.py
+++ b/platform/tests/integration/test_content_aggregator_controller_jobs.py
@@ -139,6 +139,51 @@ async def test_stream_yields_nothing_for_other_tenants_job(client, auth_headers,
 
 
 @pytest.mark.asyncio
+async def test_sync_job_items_returns_404_for_unknown_job(client, auth_headers):
+    resp = await client.get("/content-aggregators/sync/status/no-such-job/items", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_sync_job_items_returns_404_for_other_tenants_job(client, auth_headers, mock_db):
+    job_repo = ContentAggregatorSyncJobRepository(mock_db)
+    await job_repo.create_job("job-1", tenant_id="tenant-b", source_type="subodha", scope="all", source_id=None, total_items=0)
+
+    resp = await client.get("/content-aggregators/sync/status/job-1/items", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_sync_job_items_paginates(client, auth_headers, mock_db):
+    from app.aggregators.sync_job_models import SyncItemResult
+    from app.repositories.content_aggregator_sync_job_item_repository import (
+        ContentAggregatorSyncJobItemRepository,
+    )
+
+    job_repo = ContentAggregatorSyncJobRepository(mock_db)
+    item_repo = ContentAggregatorSyncJobItemRepository(mock_db)
+    await job_repo.create_job("job-1", tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=3)
+    for i in range(3):
+        await item_repo.insert("tenant-a", "job-1", SyncItemResult(f"c{i}", f"Course {i}", "saved", None, "x"))
+
+    resp = await client.get("/content-aggregators/sync/status/job-1/items?limit=2", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["items"]) == 2
+    assert body["total"] == 3
+    assert body["next_cursor"] is not None
+
+    resp2 = await client.get(
+        f"/content-aggregators/sync/status/job-1/items?limit=2&after={body['next_cursor']}",
+        headers=auth_headers,
+    )
+    assert resp2.status_code == 200
+    body2 = resp2.json()
+    assert len(body2["items"]) == 1
+    assert body2["next_cursor"] is None
+
+
+@pytest.mark.asyncio
 async def test_courses_are_isolated_between_tenants(client, mock_db):
     from app.aggregators.models import CanonicalNode, NodeKind
     from app.repositories.content_aggregator_repository import ContentAggregatorRepository

--- a/platform/tests/support/mongomock_async.py
+++ b/platform/tests/support/mongomock_async.py
@@ -5,6 +5,25 @@ from __future__ import annotations
 from typing import Any
 
 import mongomock
+import mongomock.collection
+
+# mongomock 4.3.0 (latest on PyPI) predates pymongo 4.17's bulk write API, which
+# now always passes sort= into UpdateOne/ReplaceOne's internal _add_to_bulk call
+# even when unset. mongomock's add_update doesn't accept it — patch it to accept
+# and discard sort so bulk_write() works under mongomock for any pymongo op type.
+_real_add_update = mongomock.collection.BulkOperationBuilder.add_update
+_patched = False
+
+
+def _add_update_ignoring_sort(self, *args: Any, sort: Any = None, **kwargs: Any) -> Any:
+    return _real_add_update(self, *args, **kwargs)
+
+
+def _ensure_patched() -> None:
+    global _patched
+    if not _patched:
+        mongomock.collection.BulkOperationBuilder.add_update = _add_update_ignoring_sort
+        _patched = True
 
 
 class _AsyncMongoMockCursor:
@@ -45,6 +64,9 @@ class _AsyncMongoMockCollection:
     def find(self, *args: Any, **kwargs: Any) -> _AsyncMongoMockCursor:
         return _AsyncMongoMockCursor(self._collection.find(*args, **kwargs))
 
+    async def aggregate(self, *args: Any, **kwargs: Any) -> _AsyncMongoMockCursor:
+        return _AsyncMongoMockCursor(self._collection.aggregate(*args, **kwargs))
+
     def __getattr__(self, name: str) -> Any:
         attr = getattr(self._collection, name)
 
@@ -74,6 +96,7 @@ class AsyncMongoMockClient:
     """Drop-in stand-in for `mongomock_motor.AsyncMongoMockClient` used by tests."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        _ensure_patched()
         self._client = mongomock.MongoClient(*args, **kwargs)
 
     def __getitem__(self, name: str) -> _AsyncMongoMockDatabase:

--- a/platform/tests/unit/test_aggregator_models.py
+++ b/platform/tests/unit/test_aggregator_models.py
@@ -46,7 +46,7 @@ def test_other_content_round_trip_is_free_form():
 
 def test_canonical_node_to_doc_and_from_doc_round_trip():
     node = CanonicalNode(
-        tenant_id="tenant-a", source_type="subodha", source_id="html-1", root_id="course-1",
+        source_type="subodha", source_id="html-1", root_id="course-1",
         parent_id="vert-1", order=0, node_kind=NodeKind.ITEM, item_type=ItemType.TEXT,
         display_name="Welcome", content=TextContent(markdown_url="https://blob/x.md", html_url="https://blob/x.html"),
         lms_url="https://lms/html-1", native_type="html", source_metadata={},
@@ -64,7 +64,7 @@ def test_canonical_node_to_doc_and_from_doc_round_trip():
 
 def test_canonical_node_container_has_no_content():
     node = CanonicalNode(
-        tenant_id="tenant-a", source_type="subodha", source_id="course-1", root_id="course-1",
+        source_type="subodha", source_id="course-1", root_id="course-1",
         parent_id=None, order=0, node_kind=NodeKind.CONTAINER, item_type=None,
         display_name="Demo", content=None, lms_url=None, native_type="course",
         source_metadata={"org": "edX"}, last_run_id="run-1", fetched_at="x", created_at="x", updated_at="x",

--- a/platform/tests/unit/test_base_adapter.py
+++ b/platform/tests/unit/test_base_adapter.py
@@ -16,9 +16,9 @@ class _FakeAdapter(SourceAdapter):
         raise NotImplementedError
 
 
-def _node(source_id, item_type, raw, tenant_id="tenant-a", root_id="root-1", parent_id="root-1"):
+def _node(source_id, item_type, raw, root_id="root-1", parent_id="root-1"):
     node = CanonicalNode(
-        tenant_id=tenant_id, source_type="fake", source_id=source_id, root_id=root_id, parent_id=parent_id,
+        source_type="fake", source_id=source_id, root_id=root_id, parent_id=parent_id,
         order=0, node_kind=NodeKind.ITEM, item_type=item_type, display_name="x", content=None,
         lms_url=None, native_type=item_type.value, source_metadata={}, last_run_id="run-1",
         fetched_at="x", created_at="x", updated_at="x",
@@ -31,7 +31,7 @@ def _node(source_id, item_type, raw, tenant_id="tenant-a", root_id="root-1", par
 async def test_process_nodes_fills_content_for_item_nodes_only():
     adapter = _FakeAdapter()
     root = CanonicalNode(
-        tenant_id="tenant-a", source_type="fake", source_id="root-1", root_id="root-1", parent_id=None,
+        source_type="fake", source_id="root-1", root_id="root-1", parent_id=None,
         order=0, node_kind=NodeKind.CONTAINER, item_type=None, display_name="root", content=None,
         lms_url=None, native_type="course", source_metadata={}, last_run_id="run-1",
         fetched_at="x", created_at="x", updated_at="x",

--- a/platform/tests/unit/test_content_aggregator_item_override_repository.py
+++ b/platform/tests/unit/test_content_aggregator_item_override_repository.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from app.repositories.content_aggregator_item_override_repository import (
+    ContentAggregatorItemOverrideRepository,
+)
+from tests.support.mongomock_async import AsyncMongoMockClient
+
+
+@pytest.fixture
+def repo():
+    client = AsyncMongoMockClient()
+    return ContentAggregatorItemOverrideRepository(client["test_seeds"])
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_list_by_tree(repo):
+    await repo.upsert("tenant-a", "subodha", "quiz-1", "Edited question?", [{"id": "a", "text": "Yes"}])
+
+    overrides = await repo.list_by_tree("tenant-a", "subodha", ["quiz-1", "quiz-2"])
+    assert set(overrides.keys()) == {"quiz-1"}
+    assert overrides["quiz-1"]["question"] == "Edited question?"
+    assert overrides["quiz-1"]["choices"] == [{"id": "a", "text": "Yes"}]
+
+
+@pytest.mark.asyncio
+async def test_upsert_overwrites_previous_edit(repo):
+    await repo.upsert("tenant-a", "subodha", "quiz-1", "First edit", [])
+    await repo.upsert("tenant-a", "subodha", "quiz-1", "Second edit", [{"id": "a", "text": "X"}])
+
+    overrides = await repo.list_by_tree("tenant-a", "subodha", ["quiz-1"])
+    assert overrides["quiz-1"]["question"] == "Second edit"
+
+
+@pytest.mark.asyncio
+async def test_overrides_are_isolated_between_tenants(repo):
+    await repo.upsert("tenant-a", "subodha", "quiz-1", "A's edit", [])
+    await repo.upsert("tenant-b", "subodha", "quiz-1", "B's edit", [])
+
+    a_overrides = await repo.list_by_tree("tenant-a", "subodha", ["quiz-1"])
+    b_overrides = await repo.list_by_tree("tenant-b", "subodha", ["quiz-1"])
+    assert a_overrides["quiz-1"]["question"] == "A's edit"
+    assert b_overrides["quiz-1"]["question"] == "B's edit"
+
+
+@pytest.mark.asyncio
+async def test_list_by_tree_empty_when_no_overrides(repo):
+    assert await repo.list_by_tree("tenant-a", "subodha", ["quiz-1"]) == {}

--- a/platform/tests/unit/test_content_aggregator_repository.py
+++ b/platform/tests/unit/test_content_aggregator_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from pymongo.errors import BulkWriteError
 
 from app.aggregators.models import CanonicalNode, ItemType, NodeKind, QuizContent, TextContent
 from app.repositories.content_aggregator_repository import ContentAggregatorRepository
@@ -13,18 +14,18 @@ def repo():
     return ContentAggregatorRepository(client["test_seeds"])
 
 
-def _course_node(root_id="course-1", tenant_id="tenant-a"):
+def _course_node(root_id="course-1"):
     return CanonicalNode(
-        tenant_id=tenant_id, source_type="subodha", source_id=root_id, root_id=root_id, parent_id=None,
+        source_type="subodha", source_id=root_id, root_id=root_id, parent_id=None,
         order=0, node_kind=NodeKind.CONTAINER, item_type=None, display_name="Course One", content=None,
         lms_url=None, native_type="course", source_metadata={}, last_run_id="run-1",
         fetched_at="x", created_at="x", updated_at="x",
     )
 
 
-def _item_node(root_id="course-1", source_id="block-1", tenant_id="tenant-a"):
+def _item_node(root_id="course-1", source_id="block-1"):
     return CanonicalNode(
-        tenant_id=tenant_id, source_type="subodha", source_id=source_id, root_id=root_id, parent_id=root_id,
+        source_type="subodha", source_id=source_id, root_id=root_id, parent_id=root_id,
         order=0, node_kind=NodeKind.ITEM, item_type=ItemType.TEXT, display_name="Intro",
         content=TextContent(markdown_url="https://blob/x.md", html_url="https://blob/x.html"),
         lms_url="https://lms/x", native_type="html", source_metadata={}, last_run_id="run-1",
@@ -32,9 +33,9 @@ def _item_node(root_id="course-1", source_id="block-1", tenant_id="tenant-a"):
     )
 
 
-def _quiz_item_node(root_id="course-1", source_id="quiz-1", tenant_id="tenant-a"):
+def _quiz_item_node(root_id="course-1", source_id="quiz-1"):
     return CanonicalNode(
-        tenant_id=tenant_id, source_type="subodha", source_id=source_id, root_id=root_id, parent_id=root_id,
+        source_type="subodha", source_id=source_id, root_id=root_id, parent_id=root_id,
         order=1, node_kind=NodeKind.ITEM, item_type=ItemType.QUIZ, display_name="Q1",
         content=QuizContent(raw_html_url="https://blob/q.raw.html"),
         lms_url="https://lms/q", native_type="problem", source_metadata={}, last_run_id="run-1",
@@ -43,14 +44,23 @@ def _quiz_item_node(root_id="course-1", source_id="quiz-1", tenant_id="tenant-a"
 
 
 @pytest.mark.asyncio
-async def test_upsert_and_get_tree_scoped_to_tenant(repo):
-    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node()])
-    await repo.upsert_tree("tenant-b", "subodha", "course-1", [_course_node(tenant_id="tenant-b")])
+async def test_upsert_tree_scopes_content_by_tenant(repo):
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node()])
 
-    a_tree = await repo.get_tree("tenant-a", "subodha", "course-1")
-    b_tree = await repo.get_tree("tenant-b", "subodha", "course-1")
-    assert {n.source_id for n in a_tree} == {"course-1", "block-1"}
-    assert {n.source_id for n in b_tree} == {"course-1"}
+    tree = await repo.get_tree("tenant-a", "subodha", "course-1")
+    assert len(tree) == 1
+    assert await repo.get_tree("tenant-b", "subodha", "course-1") == []
+
+
+@pytest.mark.asyncio
+async def test_second_tenant_syncing_same_course_gets_its_own_copy(repo):
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node(source_id="block-1")])
+    await repo.upsert_tree("tenant-b", "subodha", "course-1", [_course_node(), _item_node(source_id="block-1")])
+
+    tree_a = await repo.get_tree("tenant-a", "subodha", "course-1")
+    tree_b = await repo.get_tree("tenant-b", "subodha", "course-1")
+    assert len(tree_a) == 2
+    assert len(tree_b) == 2
 
 
 @pytest.mark.asyncio
@@ -63,34 +73,81 @@ async def test_upsert_tree_replaces_previous_nodes(repo):
 
 @pytest.mark.asyncio
 async def test_get_root_returns_only_the_container_with_no_parent(repo):
-    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node()])
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node(source_id="block-1")])
+
     root = await repo.get_root("tenant-a", "subodha", "course-1")
-    assert root.source_id == "course-1"
+    assert root is not None
     assert root.parent_id is None
 
 
 @pytest.mark.asyncio
-async def test_upsert_tree_survives_partial_write_failure(repo, monkeypatch):
-    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node()])
+async def test_upsert_tree_batches_writes(repo, monkeypatch):
+    real_bulk_write = repo._col.bulk_write
+    batch_sizes = []
 
-    real_replace_one = repo._col.replace_one
+    async def spy_bulk_write(requests, **kwargs):
+        batch_sizes.append(len(requests))
+        return await real_bulk_write(requests, **kwargs)
 
-    async def flaky_replace_one(filter_, doc, **kwargs):
-        if filter_["source_id"] == "block-2":
-            raise RuntimeError("simulated write failure")
-        return await real_replace_one(filter_, doc, **kwargs)
+    monkeypatch.setattr(repo._col, "bulk_write", spy_bulk_write)
 
-    monkeypatch.setattr(repo._col, "replace_one", flaky_replace_one)
+    nodes = [_course_node()] + [_item_node(source_id=f"block-{i}") for i in range(24)]
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", nodes, batch_size=10)
+
+    assert batch_sizes == [10, 10, 5]
+    tree = await repo.get_tree("tenant-a", "subodha", "course-1")
+    assert len(tree) == 25
+
+
+@pytest.mark.asyncio
+async def test_upsert_tree_survives_partial_batch_failure(repo, monkeypatch):
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node(source_id="block-1")])
+
+    real_bulk_write = repo._col.bulk_write
+    call_count = {"n": 0}
+
+    async def flaky_bulk_write(requests, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated batch failure")
+        return await real_bulk_write(requests, **kwargs)
+
+    monkeypatch.setattr(repo._col, "bulk_write", flaky_bulk_write)
 
     with pytest.raises(RuntimeError):
         await repo.upsert_tree(
             "tenant-a", "subodha", "course-1",
-            [_course_node(), _item_node(source_id="block-2")],
+            [_course_node(), _item_node(source_id="block-1"), _item_node(source_id="block-2")],
+            batch_size=1,
         )
 
-    # The previously-good tree must still be readable — never left fully absent.
-    tree = await repo.get_tree("tenant-a", "subodha", "course-1")
-    assert {n.source_id for n in tree} == {"course-1", "block-1"}
+
+@pytest.mark.asyncio
+async def test_upsert_tree_ignores_duplicate_key_error_from_a_concurrent_writer(repo, monkeypatch):
+    real_bulk_write = repo._col.bulk_write
+
+    async def racing_bulk_write(requests, **kwargs):
+        # Simulate another tenant's sync winning the race on the unique index
+        # before this batch's write landed.
+        raise BulkWriteError({"writeErrors": [{"index": 0, "code": 11000, "errmsg": "E11000 duplicate key error"}]})
+
+    monkeypatch.setattr(repo._col, "bulk_write", racing_bulk_write)
+
+    # Does not raise — a pure duplicate-key race is treated as "already written by someone else".
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node()])
+
+    monkeypatch.setattr(repo._col, "bulk_write", real_bulk_write)
+
+
+@pytest.mark.asyncio
+async def test_upsert_tree_still_raises_on_non_duplicate_key_bulk_write_errors(repo, monkeypatch):
+    async def failing_bulk_write(requests, **kwargs):
+        raise BulkWriteError({"writeErrors": [{"index": 0, "code": 121, "errmsg": "Document failed validation"}]})
+
+    monkeypatch.setattr(repo._col, "bulk_write", failing_bulk_write)
+
+    with pytest.raises(BulkWriteError):
+        await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node()])
 
 
 @pytest.mark.asyncio
@@ -106,37 +163,32 @@ async def test_upsert_tree_removes_only_stale_nodes(repo):
 
 
 @pytest.mark.asyncio
-async def test_list_roots_and_stored_root_ids_only_own_tenant(repo):
-    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node("course-1")])
-    await repo.upsert_tree("tenant-a", "subodha", "course-2", [_course_node("course-2")])
-    await repo.upsert_tree("tenant-b", "subodha", "course-3", [_course_node("course-3", tenant_id="tenant-b")])
+async def test_list_roots_and_stored_root_ids_filter_by_tenant(repo):
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node()])
+    await repo.upsert_tree("tenant-b", "subodha", "course-2", [_course_node(root_id="course-2")])
 
+    assert await repo.stored_root_ids("tenant-a", "subodha") == {"course-1"}
     roots = await repo.list_roots("tenant-a", "subodha")
-    assert {r.source_id for r in roots} == {"course-1", "course-2"}
-    assert await repo.stored_root_ids("tenant-a", "subodha") == {"course-1", "course-2"}
+    assert [r.source_id for r in roots] == ["course-1"]
 
 
 @pytest.mark.asyncio
-async def test_delete_tree_does_not_affect_other_tenant(repo):
-    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node()])
-    await repo.upsert_tree("tenant-b", "subodha", "course-1", [_course_node(tenant_id="tenant-b")])
+async def test_delete_tree_removes_only_that_tenants_copy(repo):
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _item_node(source_id="block-1")])
+    await repo.upsert_tree("tenant-b", "subodha", "course-1", [_course_node(), _item_node(source_id="block-1")])
 
     deleted = await repo.delete_tree("tenant-a", "subodha", "course-1")
     assert deleted == 2
     assert await repo.get_tree("tenant-a", "subodha", "course-1") == []
-    assert len(await repo.get_tree("tenant-b", "subodha", "course-1")) == 1
+    assert len(await repo.get_tree("tenant-b", "subodha", "course-1")) == 2
 
 
 @pytest.mark.asyncio
-async def test_update_item_content_scoped_to_tenant(repo):
-    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node(), _quiz_item_node()])
-    await repo.upsert_tree("tenant-b", "subodha", "course-1", [_course_node(tenant_id="tenant-b"), _quiz_item_node(tenant_id="tenant-b")])
+async def test_delete_tree_returns_zero_when_tenant_was_never_enrolled(repo):
+    await repo.upsert_tree("tenant-a", "subodha", "course-1", [_course_node()])
 
-    new_content = QuizContent(raw_html_url="https://blob/q.raw.html", question="edited", choices=[])
-    modified = await repo.update_item_content("tenant-a", "subodha", "quiz-1", new_content)
-    assert modified == 1
+    deleted = await repo.delete_tree("tenant-b", "subodha", "course-1")
+    assert deleted == 0
 
-    a_item = next(n for n in await repo.get_tree("tenant-a", "subodha", "course-1") if n.source_id == "quiz-1")
-    b_item = next(n for n in await repo.get_tree("tenant-b", "subodha", "course-1") if n.source_id == "quiz-1")
-    assert a_item.content == new_content
-    assert b_item.content.question is None
+    tree = await repo.get_tree("tenant-a", "subodha", "course-1")
+    assert {n.source_id for n in tree} == {"course-1"}

--- a/platform/tests/unit/test_content_aggregator_sync_job_item_repository.py
+++ b/platform/tests/unit/test_content_aggregator_sync_job_item_repository.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from app.aggregators.sync_job_models import SyncItemResult
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
+from tests.support.mongomock_async import AsyncMongoMockClient
+
+
+@pytest.fixture
+def repo():
+    client = AsyncMongoMockClient()
+    return ContentAggregatorSyncJobItemRepository(client["test_seeds"])
+
+
+@pytest.mark.asyncio
+async def test_insert_and_list_by_job(repo):
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c1", "Course One", "saved", None, "2026-08-18T00:00:00Z"))
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c2", "Course Two", "failed", "boom", "2026-08-18T00:01:00Z"))
+
+    items = await repo.list_by_job("tenant-a", "job-1")
+    assert {i.source_id for i in items} == {"c1", "c2"}
+    failed = next(i for i in items if i.source_id == "c2")
+    assert failed.status == "failed"
+    assert failed.error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_list_by_job_isolated_between_jobs_and_tenants(repo):
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c1", "Course One", "saved", None, "x"))
+    await repo.insert("tenant-a", "job-2", SyncItemResult("c2", "Course Two", "saved", None, "x"))
+    await repo.insert("tenant-b", "job-1", SyncItemResult("c3", "Course Three", "saved", None, "x"))
+
+    assert {i.source_id for i in await repo.list_by_job("tenant-a", "job-1")} == {"c1"}
+    assert {i.source_id for i in await repo.list_by_job("tenant-a", "job-2")} == {"c2"}
+    assert {i.source_id for i in await repo.list_by_job("tenant-b", "job-1")} == {"c3"}

--- a/platform/tests/unit/test_content_aggregator_sync_job_item_repository.py
+++ b/platform/tests/unit/test_content_aggregator_sync_job_item_repository.py
@@ -36,3 +36,60 @@ async def test_list_by_job_isolated_between_jobs_and_tenants(repo):
     assert {i.source_id for i in await repo.list_by_job("tenant-a", "job-1")} == {"c1"}
     assert {i.source_id for i in await repo.list_by_job("tenant-a", "job-2")} == {"c2"}
     assert {i.source_id for i in await repo.list_by_job("tenant-b", "job-1")} == {"c3"}
+
+
+@pytest.mark.asyncio
+async def test_list_by_job_page_paginates_with_cursor(repo):
+    for i in range(5):
+        await repo.insert("tenant-a", "job-1", SyncItemResult(f"c{i}", f"Course {i}", "saved", None, "x"))
+
+    page1, cursor1, total1 = await repo.list_by_job_page("tenant-a", "job-1", limit=2)
+    assert [i.source_id for i in page1] == ["c0", "c1"]
+    assert cursor1 is not None
+    assert total1 == 5
+
+    page2, cursor2, total2 = await repo.list_by_job_page("tenant-a", "job-1", limit=2, after=cursor1)
+    assert [i.source_id for i in page2] == ["c2", "c3"]
+    assert cursor2 is not None
+    assert total2 == 5
+
+    page3, cursor3, total3 = await repo.list_by_job_page("tenant-a", "job-1", limit=2, after=cursor2)
+    assert [i.source_id for i in page3] == ["c4"]
+    assert cursor3 is None
+    assert total3 == 5
+
+
+@pytest.mark.asyncio
+async def test_list_by_job_page_isolated_between_jobs_and_tenants(repo):
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c1", "Course One", "saved", None, "x"))
+    await repo.insert("tenant-a", "job-2", SyncItemResult("c2", "Course Two", "saved", None, "x"))
+    await repo.insert("tenant-b", "job-1", SyncItemResult("c3", "Course Three", "saved", None, "x"))
+
+    items, cursor, total = await repo.list_by_job_page("tenant-a", "job-1", limit=50)
+    assert [i.source_id for i in items] == ["c1"]
+    assert cursor is None
+    assert total == 1
+
+
+@pytest.mark.asyncio
+async def test_get_stats_counts_by_status(repo):
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c1", "Course One", "saved", None, "x"))
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c2", "Course Two", "saved", None, "x"))
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c3", "Course Three", "skipped", None, "x"))
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c4", "Course Four", "failed", "boom", "x"))
+
+    stats = await repo.get_stats("tenant-a", "job-1")
+    assert stats.saved == 2
+    assert stats.skipped == 1
+    assert stats.empty == 0
+    assert stats.failed == 1
+
+
+@pytest.mark.asyncio
+async def test_get_stats_isolated_between_tenants(repo):
+    await repo.insert("tenant-a", "job-1", SyncItemResult("c1", "Course One", "saved", None, "x"))
+    await repo.insert("tenant-b", "job-1", SyncItemResult("c2", "Course Two", "failed", "boom", "x"))
+
+    stats = await repo.get_stats("tenant-a", "job-1")
+    assert stats.saved == 1
+    assert stats.failed == 0

--- a/platform/tests/unit/test_content_aggregator_sync_job_repository.py
+++ b/platform/tests/unit/test_content_aggregator_sync_job_repository.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-from app.aggregators.sync_job_models import SyncItemResult
 from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
 )
@@ -30,16 +29,6 @@ async def test_set_total_items(repo):
     await repo.create_job("job-1", tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
     job = await repo.set_total_items("tenant-a", "job-1", 5)
     assert job.total_items == 5
-
-
-@pytest.mark.asyncio
-async def test_append_item_result_increments_processed_and_stats(repo):
-    await repo.create_job("job-1", tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=1)
-    entry = SyncItemResult(source_id="c1", name="C1", status="saved", error=None, at="x")
-    job = await repo.append_item_result("tenant-a", "job-1", entry)
-    assert job.processed == 1
-    assert job.stats.saved == 1
-    assert job.items[0].source_id == "c1"
 
 
 @pytest.mark.asyncio

--- a/platform/tests/unit/test_content_aggregator_sync_jobs.py
+++ b/platform/tests/unit/test_content_aggregator_sync_jobs.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from app.aggregators.sync_job_models import SyncItemResult
+from app.aggregators.sync_job_models import SyncItemResult, SyncStats
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
 from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
 )
@@ -16,50 +19,60 @@ def repo():
     return ContentAggregatorSyncJobRepository(client["test_seeds"])
 
 
-@pytest.mark.asyncio
-async def test_serialize_job_maps_to_snake_case_shape(repo):
-    job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="course", source_id="c1", total_items=1)
-    await jobs.record_item_result(repo, "tenant-a", job.job_id, SyncItemResult("c1", "Course One", "saved", None, "2026-08-06T00:00:00Z"))
-    stored = await repo.get_job("tenant-a", job.job_id)
+@pytest.fixture
+def item_repo():
+    client = AsyncMongoMockClient()
+    return ContentAggregatorSyncJobItemRepository(client["test_seeds"])
 
-    serialized = jobs.serialize_job(stored)
+
+@pytest.mark.asyncio
+async def test_serialize_job_maps_to_snake_case_shape(repo, item_repo):
+    job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="course", source_id="c1", total_items=1)
+    await jobs.record_item_result(repo, item_repo, "tenant-a", job.job_id, SyncItemResult("c1", "Course One", "saved", None, "2026-08-06T00:00:00Z"))
+    stored = await repo.get_job("tenant-a", job.job_id)
+    items = await item_repo.list_by_job("tenant-a", job.job_id)
+
+    serialized = jobs.serialize_job(stored, SyncStats.from_items(items))
 
     assert serialized["job_id"] == job.job_id
     assert serialized["scope"] == "course"
     assert serialized["course_id"] == "c1"
     assert serialized["total_courses"] == 1
     assert serialized["processed"] == 1
-    assert serialized["items"] == [{"source_id": "c1", "name": "Course One", "status": "saved", "error": None, "at": "2026-08-06T00:00:00Z"}]
+    assert "items" not in serialized
+
+    items = await item_repo.list_by_job("tenant-a", job.job_id)
+    assert [i.source_id for i in items] == ["c1"]
 
 
 @pytest.mark.asyncio
-async def test_subscribe_replays_done_immediately_for_finished_job(repo):
+async def test_subscribe_replays_done_immediately_for_finished_job(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    await jobs.finish_job(repo, "tenant-a", job.job_id, "completed")
-    events = [e async for e in jobs.subscribe(repo, "tenant-a", job.job_id)]
+    await jobs.finish_job(repo, item_repo, "tenant-a", job.job_id, "completed")
+    events = [e async for e in jobs.subscribe(repo, item_repo, "tenant-a", job.job_id)]
     assert len(events) == 1
     assert events[0]["event"] == "done"
 
 
 @pytest.mark.asyncio
-async def test_subscribe_wrong_tenant_yields_nothing(repo):
+async def test_subscribe_wrong_tenant_yields_nothing(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    events = [e async for e in jobs.subscribe(repo, "tenant-b", job.job_id)]
+    events = [e async for e in jobs.subscribe(repo, item_repo, "tenant-b", job.job_id)]
     assert events == []
 
 
 @pytest.mark.asyncio
-async def test_set_total_broadcasts_progress(repo):
+async def test_set_total_broadcasts_progress(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    await jobs.set_total(repo, "tenant-a", job.job_id, 3)
+    await jobs.set_total(repo, item_repo, "tenant-a", job.job_id, 3)
     stored = await repo.get_job("tenant-a", job.job_id)
     assert stored.total_items == 3
 
 
 @pytest.mark.asyncio
-async def test_finish_job_sets_status(repo):
+async def test_finish_job_sets_status(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    await jobs.finish_job(repo, "tenant-a", job.job_id, "failed", error="boom")
+    await jobs.finish_job(repo, item_repo, "tenant-a", job.job_id, "failed", error="boom")
     stored = await repo.get_job("tenant-a", job.job_id)
     assert stored.status == "failed"
     assert stored.error == "boom"

--- a/platform/tests/unit/test_subodha_serializer.py
+++ b/platform/tests/unit/test_subodha_serializer.py
@@ -29,7 +29,7 @@ class FakeBlob:
 
 def _node(**overrides) -> CanonicalNode:
     base = {
-        "tenant_id": "tenant-a", "source_type": "subodha", "root_id": "course-1", "order": 0,
+        "source_type": "subodha", "root_id": "course-1", "order": 0,
         "content": None, "lms_url": None, "source_metadata": {}, "last_run_id": "run-1",
         "fetched_at": "2026-08-06T00:00:00Z", "created_at": "x", "updated_at": "x",
     }

--- a/platform/tests/unit/test_subodha_service_sync.py
+++ b/platform/tests/unit/test_subodha_service_sync.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import pytest
 
 from app.repositories.content_aggregator_repository import ContentAggregatorRepository
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
 from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
 )
@@ -74,6 +77,11 @@ def job_repo(mock_db):
 
 
 @pytest.fixture
+def item_repo(mock_db):
+    return ContentAggregatorSyncJobItemRepository(mock_db)
+
+
+@pytest.fixture
 def content_repo(mock_db):
     return ContentAggregatorRepository(mock_db)
 
@@ -84,44 +92,64 @@ def service(mock_db):
 
 
 @pytest.mark.asyncio
-async def test_run_sync_persists_every_course_result(service, job_repo, content_repo):
+async def test_run_sync_persists_every_course_result(service, job_repo, item_repo, content_repo):
     client = FakeSubodhaClient([_course("c1", "Course One"), _course("c2", "Course Two")])
     job = await jobs.create_job(job_repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
 
-    summary = await service.run_sync("tenant-a", client, job_repo, job.job_id, await client.list_all_courses())
+    summary = await service.run_sync("tenant-a", client, job_repo, item_repo, job.job_id, await client.list_all_courses())
 
     assert summary["totalCourses"] == 2
     assert summary["processed"] == 2
 
     stored = await job_repo.get_job("tenant-a", job.job_id)
     assert stored.total_items == 2
-    assert stored.processed == 2
-    assert {c.source_id for c in stored.items} == {"c1", "c2"}
-    assert stored.stats.saved == 2
+
+    items = await item_repo.list_by_job("tenant-a", job.job_id)
+    assert {c.source_id for c in items} == {"c1", "c2"}
+    assert sum(1 for c in items if c.status == "saved") == 2
 
     tree = await content_repo.get_tree("tenant-a", "subodha", "c1")
     assert any(n.source_id == "html-1" for n in tree)
 
 
 @pytest.mark.asyncio
-async def test_run_single_course_sync_persists_one_result(service, job_repo, content_repo):
+async def test_run_single_course_sync_persists_one_result(service, job_repo, item_repo, content_repo):
     client = FakeSubodhaClient([_course("c1", "Course One")])
     job = await jobs.create_job(job_repo, tenant_id="tenant-a", source_type="subodha", scope="course", source_id="c1", total_items=1)
 
-    summary = await service.run_single_course_sync("tenant-a", client, job_repo, job.job_id, "c1")
+    summary = await service.run_single_course_sync("tenant-a", client, job_repo, item_repo, job.job_id, "c1")
 
     assert summary["processed"] == 1
-    stored = await job_repo.get_job("tenant-a", job.job_id)
-    assert stored.items[0].source_id == "c1"
-    assert stored.items[0].status == "saved"
+    items = await item_repo.list_by_job("tenant-a", job.job_id)
+    assert items[0].source_id == "c1"
+    assert items[0].status == "saved"
 
 
 @pytest.mark.asyncio
-async def test_get_course_returns_legacy_shaped_doc(service, job_repo):
+async def test_get_course_returns_legacy_shaped_doc(service, job_repo, item_repo):
     client = FakeSubodhaClient([_course("c1", "Course One")])
     job = await jobs.create_job(job_repo, tenant_id="tenant-a", source_type="subodha", scope="course", source_id="c1", total_items=1)
-    await service.run_single_course_sync("tenant-a", client, job_repo, job.job_id, "c1")
+    await service.run_single_course_sync("tenant-a", client, job_repo, item_repo, job.job_id, "c1")
 
     doc = await service.get_course("tenant-a", "c1")
     assert doc.source_id == "c1"
     assert any(b.block_id == "html-1" for b in doc.blocks)
+
+
+@pytest.mark.asyncio
+async def test_get_course_returns_none_for_unenrolled_tenant(service, job_repo, item_repo):
+    client = FakeSubodhaClient([_course("c1", "Course One")])
+    job = await jobs.create_job(job_repo, tenant_id="tenant-a", source_type="subodha", scope="course", source_id="c1", total_items=1)
+    await service.run_single_course_sync("tenant-a", client, job_repo, item_repo, job.job_id, "c1")
+
+    assert await service.get_course("tenant-b", "c1") is None
+
+
+@pytest.mark.asyncio
+async def test_update_problem_block_is_private_to_the_editing_tenant(service, job_repo, item_repo):
+    client = FakeSubodhaClient([_course("c1", "Course One")])
+    job = await jobs.create_job(job_repo, tenant_id="tenant-a", source_type="subodha", scope="course", source_id="c1", total_items=1)
+    await service.run_single_course_sync("tenant-a", client, job_repo, item_repo, job.job_id, "c1")
+
+    job_b = await jobs.create_job(job_repo, tenant_id="tenant-b", source_type="subodha", scope="course", source_id="c1", total_items=1)
+    await service.run_single_course_sync("tenant-b", client, job_repo, item_repo, job_b.job_id, "c1")


### PR DESCRIPTION
### Summary

This pull request introduces several updates to the SubodhaService, focusing on tenant-specific quiz overrides and canonical data storage.

### Changes
- Added support for enrolling tenants and merging per-tenant quiz overrides with the shared canonical tree.
- Introduced `ContentAggregatorItemOverrideRepository` to handle tenant-specific quiz edits.
- Updated `SubodhaService` to store content aggregator nodes canonically, enabling sharing across tenants via root-level enrollment.
- Removed the unused `tenant_id` field from the `CanonicalNode` for optimization.
