### PR TITLE
test(platform): raise coverage 73% -> 80% and stop telemetry leaking into tests

### DIFF
--- a/platform/tests/conftest.py
+++ b/platform/tests/conftest.py
@@ -14,10 +14,9 @@ os.environ.setdefault("ENV", "development")
 os.environ.setdefault("MONGO_DB_CONNECTION_STRING", "")
 os.environ.setdefault("DB_CONNECTION", "")
 os.environ.setdefault("AUTH_TYPE", "jwt")
-os.environ.setdefault(
-    "APPLICATIONINSIGHTS_CONNECTION_STRING",
-    "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake.example.com/",
-)
+# Telemetry must stay off by default: a connection string here makes importing
+# app.main start Azure Monitor exporter threads that call out to the network.
+os.environ.pop("APPLICATIONINSIGHTS_CONNECTION_STRING", None)
 
 
 @pytest.fixture(autouse=True)

--- a/platform/tests/integration/test_playback_controller.py
+++ b/platform/tests/integration/test_playback_controller.py
@@ -1,0 +1,207 @@
+"""Playback endpoints — ownership, URL/argument validation, and the event actually queued."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.platform.auth.dependencies import get_db
+from app.platform.auth.jwt import create_access_token
+from app.repositories.conference_repository import ConferenceOwnershipRepository
+from app.services.confevents.pause_content_event import PauseContentEvent
+from app.services.confevents.play_content_event import PlayContentEvent
+from app.services.confevents.resume_content_event import ResumeContentEvent
+from app.services.confevents.seek_content_event import SeekContentEvent
+from app.services.confevents.set_playback_speed_event import SetPlaybackSpeedEvent
+from tests.support.mongomock_async import AsyncMongoMockClient
+
+CONF_ID = "conf-1"
+OWNER_ID = "user-1"
+TENANT_ID = "tenant-1"
+AUDIO_URL = "https://blob.test/output-container/c1/1.0.mp3"
+
+
+@pytest_asyncio.fixture
+async def mock_db():
+    client = AsyncMongoMockClient()
+    db = client["seeds_test_playback_ctrl"]
+    await ConferenceOwnershipRepository(db).create(
+        CONF_ID, created_by=OWNER_ID, tenant_id=TENANT_ID, teacher_phone="+911111111111"
+    )
+    yield db
+    await client.close()
+
+
+@pytest.fixture
+def conf():
+    conf = MagicMock()
+    conf.queue_event = AsyncMock()
+    return conf
+
+
+@pytest_asyncio.fixture
+async def client(mock_db, conf):
+    async def _override_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override_db
+    manager = MagicMock()
+    manager.get_conference.return_value = conf
+    transport = ASGITransport(app=app)
+    with patch("app.platform.lifespan.get_conference_manager", return_value=manager):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            ac.manager = manager
+            yield ac
+    app.dependency_overrides.clear()
+
+
+def _headers(user_id=OWNER_ID, tenant_id=TENANT_ID):
+    token = create_access_token({"sub": user_id, "role": "teacher", "tenant_id": tenant_id})
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestOwnership:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("path", "params"),
+        [
+            (f"/conference/playaudio/{CONF_ID}", {"url": AUDIO_URL}),
+            (f"/conference/pauseaudio/{CONF_ID}", None),
+            (f"/conference/resumeaudio/{CONF_ID}", None),
+            (f"/conference/seekaudio/{CONF_ID}", {"delta_seconds": 10}),
+            (f"/conference/setplaybackspeed/{CONF_ID}", {"speed": 1.5}),
+        ],
+    )
+    async def test_every_endpoint_requires_authentication(self, client, path, params) -> None:
+        assert (await client.put(path, params=params)).status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_a_non_owner_is_forbidden(self, client, conf) -> None:
+        resp = await client.put(
+            f"/conference/pauseaudio/{CONF_ID}", headers=_headers(user_id="someone-else")
+        )
+        assert resp.status_code == 403
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_owner_from_another_tenant_is_forbidden(self, client, conf) -> None:
+        resp = await client.put(
+            f"/conference/pauseaudio/{CONF_ID}", headers=_headers(tenant_id="tenant-2")
+        )
+        assert resp.status_code == 403
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_conference_is_404(self, client) -> None:
+        resp = await client.put("/conference/pauseaudio/nope", headers=_headers())
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_a_conference_that_is_owned_but_no_longer_live_is_404(self, client) -> None:
+        client.manager.get_conference.return_value = None
+        resp = await client.put(f"/conference/pauseaudio/{CONF_ID}", headers=_headers())
+        assert resp.status_code == 404
+
+
+class TestPlayAudio:
+    @pytest.mark.asyncio
+    async def test_queues_a_play_event_with_the_url(self, client, conf) -> None:
+        resp = await client.put(
+            f"/conference/playaudio/{CONF_ID}", params={"url": AUDIO_URL}, headers=_headers()
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"message": "Event Queued for execution"}
+        queued = conf.queue_event.await_args.args[0]
+        assert isinstance(queued, PlayContentEvent)
+        assert queued.url == AUDIO_URL
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("url", ["http://blob.test/a.mp3", "ftp://blob.test/a.mp3", "a.mp3"])
+    async def test_rejects_a_non_https_url(self, client, conf, url) -> None:
+        resp = await client.put(
+            f"/conference/playaudio/{CONF_ID}", params={"url": url}, headers=_headers()
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Audio URL must use HTTPS"
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_url_is_required(self, client) -> None:
+        resp = await client.put(f"/conference/playaudio/{CONF_ID}", headers=_headers())
+        assert resp.status_code == 422
+
+
+class TestPauseResume:
+    @pytest.mark.asyncio
+    async def test_pause_queues_a_pause_event(self, client, conf) -> None:
+        resp = await client.put(f"/conference/pauseaudio/{CONF_ID}", headers=_headers())
+        assert resp.status_code == 200
+        assert isinstance(conf.queue_event.await_args.args[0], PauseContentEvent)
+
+    @pytest.mark.asyncio
+    async def test_resume_queues_a_resume_event(self, client, conf) -> None:
+        resp = await client.put(f"/conference/resumeaudio/{CONF_ID}", headers=_headers())
+        assert resp.status_code == 200
+        assert isinstance(conf.queue_event.await_args.args[0], ResumeContentEvent)
+
+
+class TestSeekAudio:
+    @pytest.mark.asyncio
+    async def test_a_relative_seek_queues_a_delta(self, client, conf) -> None:
+        resp = await client.put(
+            f"/conference/seekaudio/{CONF_ID}", params={"delta_seconds": -15}, headers=_headers()
+        )
+        assert resp.status_code == 200
+        queued = conf.queue_event.await_args.args[0]
+        assert isinstance(queued, SeekContentEvent)
+        assert (queued.delta_seconds, queued.position_seconds) == (-15, None)
+
+    @pytest.mark.asyncio
+    async def test_an_absolute_seek_queues_a_position(self, client, conf) -> None:
+        resp = await client.put(
+            f"/conference/seekaudio/{CONF_ID}",
+            params={"position_seconds": 42.5},
+            headers=_headers(),
+        )
+        assert resp.status_code == 200
+        queued = conf.queue_event.await_args.args[0]
+        assert (queued.delta_seconds, queued.position_seconds) == (None, 42.5)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "params", [None, {"delta_seconds": 10, "position_seconds": 42.5}], ids=["neither", "both"]
+    )
+    async def test_exactly_one_seek_argument_is_required(self, client, conf, params) -> None:
+        resp = await client.put(
+            f"/conference/seekaudio/{CONF_ID}", params=params, headers=_headers()
+        )
+        assert resp.status_code == 400
+        assert "Exactly one of delta_seconds or position_seconds" in resp.json()["detail"]
+        conf.queue_event.assert_not_awaited()
+
+
+class TestSetPlaybackSpeed:
+    @pytest.mark.asyncio
+    async def test_queues_a_speed_event(self, client, conf) -> None:
+        resp = await client.put(
+            f"/conference/setplaybackspeed/{CONF_ID}", params={"speed": 1.5}, headers=_headers()
+        )
+        assert resp.status_code == 200
+        queued = conf.queue_event.await_args.args[0]
+        assert isinstance(queued, SetPlaybackSpeedEvent)
+        assert queued.speed == 1.5
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("speed", [0.4, 2.1])
+    async def test_a_speed_outside_the_supported_range_is_rejected(
+        self, client, conf, speed
+    ) -> None:
+        resp = await client.put(
+            f"/conference/setplaybackspeed/{CONF_ID}", params={"speed": speed}, headers=_headers()
+        )
+        assert resp.status_code == 422
+        conf.queue_event.assert_not_awaited()

--- a/platform/tests/unit/test_audio_protocols.py
+++ b/platform/tests/unit/test_audio_protocols.py
@@ -1,0 +1,28 @@
+"""The audio pipeline's structural protocols — consumers check shape, not inheritance."""
+
+from __future__ import annotations
+
+from app.services.audio.protocols import HoldDetectorProtocol, TranscriberProtocol
+
+
+class DuckTranscriber:
+    async def process_chunk(self, audio_data: bytes):
+        return {"text": "hello"}
+
+
+class DuckHoldDetector:
+    async def detect(self, text: str):
+        return {"on_hold": False}
+
+
+def test_anything_with_process_chunk_counts_as_a_transcriber() -> None:
+    assert isinstance(DuckTranscriber(), TranscriberProtocol)
+
+
+def test_anything_with_detect_counts_as_a_hold_detector() -> None:
+    assert isinstance(DuckHoldDetector(), HoldDetectorProtocol)
+
+
+def test_the_protocols_are_not_interchangeable() -> None:
+    assert not isinstance(DuckTranscriber(), HoldDetectorProtocol)
+    assert not isinstance(DuckHoldDetector(), TranscriberProtocol)

--- a/platform/tests/unit/test_blob_service.py
+++ b/platform/tests/unit/test_blob_service.py
@@ -1,0 +1,95 @@
+"""Content-audio helpers over the blob storage provider — container and blob-name routing."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services import blob_service
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    provider = MagicMock()
+    provider.upload_file = AsyncMock(return_value="https://blob/uploaded")
+    provider.generate_sas_url = AsyncMock(return_value="https://blob/audio?sig=abc")
+    monkeypatch.setattr(blob_service, "_get_provider", lambda: provider)
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_upload_content_audio_targets_the_output_container(provider) -> None:
+    url = await blob_service.upload_content_audio("c1", b"pcm")
+    assert url == "https://blob/uploaded"
+    provider.upload_file.assert_awaited_once_with(
+        "output-container", "c1/1.0.mp3", b"pcm", "audio/wav"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_content_audio_honours_a_custom_suffix(provider) -> None:
+    await blob_service.upload_content_audio("c1", b"pcm", suffix="2.0.mp3")
+    assert provider.upload_file.await_args.args[1] == "c1/2.0.mp3"
+
+
+@pytest.mark.asyncio
+async def test_content_audio_url_is_a_one_hour_sas(provider) -> None:
+    assert await blob_service.get_content_audio_url("c1") == "https://blob/audio?sig=abc"
+    provider.generate_sas_url.assert_awaited_once_with(
+        "output-container", "c1/1.0.mp3", expiry_hours=1
+    )
+
+
+@pytest.mark.asyncio
+async def test_title_audio_goes_to_the_titles_container_as_mpeg(provider) -> None:
+    await blob_service.upload_title_audio("c1", b"mp3")
+    provider.upload_file.assert_awaited_once_with(
+        "experience-titles", "c1/1.0.mp3", b"mp3", "audio/mpeg"
+    )
+
+
+@pytest.mark.asyncio
+async def test_theme_audio_goes_to_the_theme_container_keyed_by_english_name(provider) -> None:
+    await blob_service.upload_theme_audio("Science", b"mp3")
+    provider.upload_file.assert_awaited_once_with(
+        "theme-titles", "Science/1.0.mp3", b"mp3", "audio/mpeg"
+    )
+
+
+@pytest.mark.asyncio
+async def test_theme_audio_exists_when_the_blob_has_properties(provider) -> None:
+    blob = MagicMock()
+    blob.get_blob_properties = AsyncMock(return_value={"size": 1})
+    provider.get_container_client.return_value.get_blob_client.return_value = blob
+
+    assert await blob_service.theme_audio_exists("Science") is True
+    provider.get_container_client.assert_called_once_with("theme-titles")
+
+
+@pytest.mark.asyncio
+async def test_theme_audio_does_not_exist_when_the_lookup_fails(provider) -> None:
+    blob = MagicMock()
+    blob.get_blob_properties = AsyncMock(side_effect=RuntimeError("BlobNotFound"))
+    provider.get_container_client.return_value.get_blob_client.return_value = blob
+
+    assert await blob_service.theme_audio_exists("Missing") is False
+
+
+@pytest.mark.asyncio
+async def test_theme_audio_url_is_the_plain_blob_url(provider) -> None:
+    blob = MagicMock(url="https://blob/theme-titles/Science/1.0.mp3")
+    provider.get_container_client.return_value.get_blob_client.return_value = blob
+
+    assert await blob_service.get_theme_audio_url("Science") == (
+        "https://blob/theme-titles/Science/1.0.mp3"
+    )
+    provider.get_container_client.return_value.get_blob_client.assert_called_once_with(
+        "Science/1.0.mp3"
+    )
+
+
+def test_get_provider_returns_the_blob_storage_singleton() -> None:
+    from app.providers.blob_storage import get_blob_storage_provider
+
+    assert blob_service._get_provider() is get_blob_storage_provider()

--- a/platform/tests/unit/test_conference_event_dispatcher.py
+++ b/platform/tests/unit/test_conference_event_dispatcher.py
@@ -1,0 +1,190 @@
+"""Vonage webhook → ConferenceEvent routing. Errors must never escape a BackgroundTask."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.participant import CallStatus
+from app.services.conference_event_dispatcher import (
+    dispatch_conference_event,
+    dispatch_conversation_event,
+)
+
+CONF_ID = "conf-1"
+
+
+def _dtmf_payload(digit: str = "1", to_number: str = "+911111111111", type_: str = "audio:dtmf"):
+    return {
+        "type": type_,
+        "body": {
+            "digit": digit,
+            "duration": 100,
+            "dtmf_seq": 1,
+            "channel": {
+                "id": "ch1",
+                "type": "phone",
+                "to": {"type": "phone", "number": to_number},
+                "from": {"type": "phone", "number": "+912222222222"},
+            },
+        },
+    }
+
+
+@pytest.fixture
+def conf():
+    conf = MagicMock()
+    conf.conf_id = CONF_ID
+    conf.queue_event = AsyncMock()
+    return conf
+
+
+@pytest.fixture
+def manager(conf):
+    manager = MagicMock()
+    manager.get_conference.return_value = conf
+    manager.get_conference_from_phone_number.return_value = conf
+    return manager
+
+
+@pytest.fixture
+def caller_state():
+    state = MagicMock()
+    state.update_state = AsyncMock()
+    return state
+
+
+async def _settle():
+    """Let the fire-and-forget caller-state task run."""
+    await asyncio.sleep(0)
+
+
+class TestConferenceEvent:
+    @pytest.mark.asyncio
+    async def test_answered_queues_a_connected_status_change(
+        self, manager, conf, caller_state
+    ) -> None:
+        await dispatch_conference_event(
+            {"status": "answered", "to": "+911111111111"}, CONF_ID, manager, caller_state
+        )
+        await _settle()
+
+        queued = conf.queue_event.await_args.args[0]
+        assert (queued.status, queued.phone_number) == (CallStatus.CONNECTED, "+911111111111")
+        caller_state.update_state.assert_awaited_once_with(
+            conference_id=CONF_ID,
+            participant_id="+911111111111",
+            new_state={"call_status": CallStatus.CONNECTED.value, "onHold": False},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ("started", CallStatus.CONNECTING),
+            ("ringing", CallStatus.CONNECTING),
+            ("answered", CallStatus.CONNECTED),
+            ("completed", CallStatus.DISCONNECTED),
+            ("notconnected", CallStatus.DISCONNECTED),
+        ],
+    )
+    async def test_every_vonage_status_maps_to_a_conference_status(
+        self, manager, conf, caller_state, status, expected
+    ) -> None:
+        await dispatch_conference_event(
+            {"status": status, "to": "+911111111111"}, CONF_ID, manager, caller_state
+        )
+        await _settle()
+        assert conf.queue_event.await_args.args[0].status == expected
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_conference_is_dropped_without_queueing(
+        self, manager, conf, caller_state
+    ) -> None:
+        manager.get_conference.return_value = None
+        await dispatch_conference_event(
+            {"status": "answered", "to": "+911111111111"}, CONF_ID, manager, caller_state
+        )
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_payload_that_is_not_a_status_change_is_tried_as_a_transfer(
+        self, manager, conf, caller_state
+    ) -> None:
+        await dispatch_conference_event(
+            {
+                "conversation_uuid_from": "cf",
+                "type": "transfer",
+                "uuid": "leg1",
+                "conversation_uuid_to": "ct",
+                "timestamp": "2026-08-25T00:00:00Z",
+            },
+            CONF_ID,
+            manager,
+            caller_state,
+        )
+        queued = conf.queue_event.await_args.args[0]
+        assert (queued.uuid, queued.conversation_uuid_to) == ("leg1", "ct")
+
+    @pytest.mark.asyncio
+    async def test_a_payload_matching_neither_type_is_ignored(
+        self, manager, conf, caller_state
+    ) -> None:
+        await dispatch_conference_event({"unrelated": True}, CONF_ID, manager, caller_state)
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_queue_does_not_propagate(self, manager, conf, caller_state) -> None:
+        conf.queue_event.side_effect = RuntimeError("queue is gone")
+        await dispatch_conference_event(
+            {"status": "answered", "to": "+911111111111"}, CONF_ID, manager, caller_state
+        )
+        await _settle()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_transfer_queue_does_not_propagate(
+        self, manager, conf, caller_state
+    ) -> None:
+        conf.queue_event.side_effect = RuntimeError("queue is gone")
+        await dispatch_conference_event(
+            {
+                "conversation_uuid_from": "cf",
+                "type": "transfer",
+                "uuid": "leg1",
+                "conversation_uuid_to": "ct",
+                "timestamp": "2026-08-25T00:00:00Z",
+            },
+            CONF_ID,
+            manager,
+            caller_state,
+        )
+
+
+class TestConversationEvent:
+    @pytest.mark.asyncio
+    async def test_a_dtmf_press_is_routed_by_the_callers_phone_number(
+        self, manager, conf
+    ) -> None:
+        await dispatch_conversation_event(_dtmf_payload(digit="7"), manager)
+
+        manager.get_conference_from_phone_number.assert_called_once_with("+911111111111")
+        queued = conf.queue_event.await_args.args[0]
+        assert (queued.digit, queued.phone_number) == ("7", "+911111111111")
+
+    @pytest.mark.asyncio
+    async def test_a_non_dtmf_rtc_event_is_ignored(self, manager, conf) -> None:
+        await dispatch_conversation_event(_dtmf_payload(type_="ringing"), manager)
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_dtmf_press_from_an_unknown_caller_is_dropped(self, manager, conf) -> None:
+        manager.get_conference_from_phone_number.return_value = None
+        await dispatch_conversation_event(_dtmf_payload(), manager)
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_payload_does_not_propagate(self, manager, conf) -> None:
+        await dispatch_conversation_event({"type": "audio:dtmf"}, manager)
+        conf.queue_event.assert_not_awaited()

--- a/platform/tests/unit/test_confevents_participants_playback.py
+++ b/platform/tests/unit/test_confevents_participants_playback.py
@@ -1,0 +1,402 @@
+"""Conference events: participant roster changes, content playback, and conference teardown."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.action_history import ActionType
+from app.models.conference_state import ConferenceCallState
+from app.models.participant import CallStatus, Participant, Role
+from app.models.playback_state import ContentStatus
+from app.models.system_audio_messages import SystemAudioMessages
+from app.models.ws_service_message import MessageType
+from app.services.confevents.add_participant_event import AddParticipantEvent
+from app.services.confevents.mute_all_event import MuteAllEvent
+from app.services.confevents.mute_participant_event import MuteParticipantEvent
+from app.services.confevents.pause_content_event import PauseContentEvent
+from app.services.confevents.play_content_event import PlayContentEvent
+from app.services.confevents.playback_state_update_event import PlaybackStateUpdateEvent
+from app.services.confevents.remove_participant_event import RemoveParticipantEvent
+from app.services.confevents.resume_content_event import ResumeContentEvent
+from app.services.confevents.seek_content_event import SeekContentEvent
+from app.services.confevents.set_playback_speed_event import SetPlaybackSpeedEvent
+from app.services.confevents.sink_conf_event import SinkConferenceEvent
+from app.services.confevents.unmute_participant_event import UnmuteParticipantEvent
+
+TEACHER = "+911111111111"
+STUDENT = "+912222222222"
+CONF_ID = "conf-1"
+AUDIO_URL = "https://blob.test/output-container/c1/1.0.mp3"
+
+
+def _participant(phone, role=Role.STUDENT, **overrides):
+    return Participant(
+        name="Teacher" if role == Role.TEACHER else "Student",
+        phone_number=phone,
+        role=role,
+        **overrides,
+    )
+
+
+@pytest.fixture
+def conf():
+    conf = MagicMock()
+    conf.conf_id = CONF_ID
+    conf.state = ConferenceCallState(
+        conference_id=CONF_ID,
+        teacher_phone_number=TEACHER,
+        is_running=True,
+        participants={
+            TEACHER: _participant(TEACHER, Role.TEACHER, call_status=CallStatus.CONNECTED),
+            STUDENT: _participant(STUDENT, call_status=CallStatus.CONNECTED),
+        },
+    )
+    conf.update_state = AsyncMock()
+    conf.stream_system_message = AsyncMock()
+    conf.communication_api = MagicMock()
+    for method in (
+        "add_participant", "remove_participant", "mute_participant", "unmute_participant",
+        "play_announcement_to_conference",
+    ):
+        setattr(conf.communication_api, method, AsyncMock())
+    return conf
+
+
+@pytest.fixture
+def ws():
+    client = MagicMock()
+    client.send_message = AsyncMock()
+    with patch("app.providers.websocket_client.WebsocketClientProvider", return_value=client):
+        yield client
+
+
+def _last_action(conf):
+    return conf.state.action_history[-1]
+
+
+class TestAddParticipant:
+    @pytest.mark.asyncio
+    async def test_a_new_number_is_dialled_and_added_muted(self, conf) -> None:
+        await AddParticipantEvent("+913333333333", name="Asha", conf_call=conf).execute_event()
+
+        conf.communication_api.add_participant.assert_awaited_once_with(
+            "+913333333333", announce_text="Asha"
+        )
+        added = conf.state.participants["+913333333333"]
+        assert (added.name, added.role, added.is_muted, added.added_after_start) == (
+            "Asha", Role.STUDENT, True, True,
+        )
+        assert added.call_status == CallStatus.DISCONNECTED
+        conf.update_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_nameless_participant_gets_a_default_name(self, conf) -> None:
+        await AddParticipantEvent("+913333333333", conf_call=conf).execute_event()
+        assert conf.state.participants["+913333333333"].name == "Student"
+
+    @pytest.mark.asyncio
+    async def test_a_disconnected_participant_is_redialled_not_duplicated(self, conf) -> None:
+        conf.state.participants[STUDENT].call_status = CallStatus.DISCONNECTED
+
+        await AddParticipantEvent(STUDENT, name="Ravi", conf_call=conf).execute_event()
+
+        conf.communication_api.add_participant.assert_awaited_once()
+        assert conf.state.participants[STUDENT].call_status == CallStatus.CONNECTING
+        assert conf.state.participants[STUDENT].name == "Ravi"
+
+    @pytest.mark.asyncio
+    async def test_an_already_connected_participant_is_not_redialled(self, conf) -> None:
+        await AddParticipantEvent(STUDENT, conf_call=conf).execute_event()
+
+        conf.communication_api.add_participant.assert_not_awaited()
+        assert _last_action(conf).action_type == ActionType.TEACHER_ADD_STUDENT
+
+
+class TestRemoveParticipant:
+    @pytest.mark.asyncio
+    async def test_removing_drops_the_participant_and_records_the_action(self, conf) -> None:
+        await RemoveParticipantEvent(STUDENT, conf).execute_event()
+
+        conf.communication_api.remove_participant.assert_awaited_once_with(STUDENT)
+        assert STUDENT not in conf.state.participants
+        assert _last_action(conf).action_type == ActionType.TEACHER_REMOVE_STUDENT
+        conf.update_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_the_remaining_participants_hear_who_left(self, conf) -> None:
+        await RemoveParticipantEvent(STUDENT, conf).execute_event()
+
+        conf.communication_api.play_announcement_to_conference.assert_awaited_once_with(
+            "Student has left", [TEACHER]
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_departing_teacher_is_announced_as_the_teacher(self, conf) -> None:
+        await RemoveParticipantEvent(TEACHER, conf).execute_event()
+
+        conf.communication_api.play_announcement_to_conference.assert_awaited_once_with(
+            "Teacher has left", [STUDENT]
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_announcement_when_nobody_is_left_connected(self, conf) -> None:
+        conf.state.participants[TEACHER].call_status = CallStatus.DISCONNECTED
+
+        await RemoveParticipantEvent(STUDENT, conf).execute_event()
+
+        conf.communication_api.play_announcement_to_conference.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_removing_someone_who_is_not_here_does_nothing(self, conf) -> None:
+        await RemoveParticipantEvent("+919999999999", conf).execute_event()
+
+        conf.communication_api.remove_participant.assert_not_awaited()
+        conf.update_state.assert_not_awaited()
+
+
+class TestMuteUnmute:
+    @pytest.mark.asyncio
+    async def test_muting_a_student_tells_the_teacher(self, conf) -> None:
+        await MuteParticipantEvent(STUDENT, conf).execute_event()
+
+        conf.communication_api.mute_participant.assert_awaited_once_with(STUDENT)
+        assert conf.state.participants[STUDENT].is_muted is True
+        conf.stream_system_message.assert_awaited_once_with(SystemAudioMessages.STUDENT_IS_MUTED)
+        assert _last_action(conf).metadata == {"phone_number": STUDENT, "is_muted": True}
+
+    @pytest.mark.asyncio
+    async def test_the_teacher_muting_themselves_is_not_announced(self, conf) -> None:
+        await MuteParticipantEvent(TEACHER, conf).execute_event()
+
+        assert conf.state.participants[TEACHER].is_muted is True
+        conf.stream_system_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_system_message_can_be_suppressed(self, conf) -> None:
+        await MuteParticipantEvent(STUDENT, conf, stream_system_message=False).execute_event()
+        conf.stream_system_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_muting_an_unknown_number_does_nothing(self, conf) -> None:
+        await MuteParticipantEvent("+919999999999", conf).execute_event()
+
+        conf.communication_api.mute_participant.assert_not_awaited()
+        conf.update_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unmuting_also_lowers_a_raised_hand(self, conf) -> None:
+        conf.state.participants[STUDENT].is_muted = True
+        conf.state.participants[STUDENT].is_raised = True
+        conf.state.participants[STUDENT].raised_at = 1000
+
+        await UnmuteParticipantEvent(STUDENT, conf).execute_event()
+
+        student = conf.state.participants[STUDENT]
+        assert (student.is_muted, student.is_raised, student.raised_at) == (False, False, -1)
+        conf.stream_system_message.assert_awaited_once_with(SystemAudioMessages.STUDENT_IS_UNMUTED)
+
+    @pytest.mark.asyncio
+    async def test_unmuting_an_unknown_number_does_nothing(self, conf) -> None:
+        await UnmuteParticipantEvent("+919999999999", conf).execute_event()
+        conf.communication_api.unmute_participant.assert_not_awaited()
+
+
+class TestMuteAll:
+    @pytest.mark.asyncio
+    async def test_only_the_unmuted_students_are_muted(self, conf) -> None:
+        conf.state.participants["+913333333333"] = _participant("+913333333333", is_muted=True)
+
+        await MuteAllEvent(conf).execute_event()
+
+        conf.communication_api.mute_participant.assert_awaited_once_with(STUDENT)
+        assert _last_action(conf).metadata == {
+            "muted_count": 1, "total_students": 2, "failed_phones": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_the_teacher_is_never_muted_by_mute_all(self, conf) -> None:
+        await MuteAllEvent(conf).execute_event()
+        assert conf.state.participants[TEACHER].is_muted is False
+
+    @pytest.mark.asyncio
+    async def test_a_student_that_fails_to_mute_is_named_in_the_history(self, conf) -> None:
+        conf.communication_api.mute_participant.side_effect = RuntimeError("vonage down")
+
+        await MuteAllEvent(conf).execute_event()
+
+        assert _last_action(conf).metadata["failed_phones"] == [STUDENT]
+        assert _last_action(conf).metadata["muted_count"] == 0
+        conf.stream_system_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_mute_still_records_the_action(self, conf) -> None:
+        conf.state.participants[STUDENT].is_muted = True
+
+        await MuteAllEvent(conf).execute_event()
+
+        conf.stream_system_message.assert_not_awaited()
+        assert _last_action(conf).metadata["muted_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_conference_without_a_teacher_is_left_alone(self, conf) -> None:
+        conf.state.teacher_phone_number = None
+
+        await MuteAllEvent(conf).execute_event()
+
+        conf.communication_api.mute_participant.assert_not_awaited()
+        conf.update_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_dtmf_triggered_mute_all_is_attributed_to_the_leader(self, conf) -> None:
+        await MuteAllEvent(conf, initiator_phone=STUDENT).execute_event()
+
+        assert _last_action(conf).action_type == ActionType.LEADER_MUTE_ALL_VIA_DTMF
+        assert _last_action(conf).owner == STUDENT
+
+
+class TestContentPlayback:
+    @pytest.mark.asyncio
+    async def test_play_sends_the_url_and_marks_the_content_starting(self, conf, ws) -> None:
+        await PlayContentEvent(conf, AUDIO_URL).execute_event()
+
+        message = ws.send_message.await_args.args[0]
+        assert (message.websocket_id, message.type, message.message) == (
+            CONF_ID, MessageType.PLAY_AUDIO, AUDIO_URL,
+        )
+        assert conf.state.audio_content_state.current_url == AUDIO_URL
+        assert conf.state.audio_content_state.status == ContentStatus.STARTING
+
+    @pytest.mark.asyncio
+    async def test_pause_sends_a_pause_message(self, conf, ws) -> None:
+        await PauseContentEvent(conf).execute_event()
+
+        assert ws.send_message.await_args.args[0].type == MessageType.PAUSE_AUDIO
+        assert _last_action(conf).owner == TEACHER
+
+    @pytest.mark.asyncio
+    async def test_resume_sends_a_resume_message_and_restarts_the_content(self, conf, ws) -> None:
+        await ResumeContentEvent(conf).execute_event()
+
+        assert ws.send_message.await_args.args[0].type == MessageType.RESUME_AUDIO
+        assert conf.state.audio_content_state.status == ContentStatus.STARTING
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("event_type", [PauseContentEvent, ResumeContentEvent])
+    async def test_a_dtmf_toggle_is_attributed_to_the_leader(self, conf, ws, event_type) -> None:
+        await event_type(conf, initiator_phone=STUDENT).execute_event()
+
+        assert _last_action(conf).action_type == ActionType.LEADER_TOGGLE_CONTENT_VIA_DTMF
+        assert _last_action(conf).owner == STUDENT
+
+
+class TestSeekContent:
+    @pytest.mark.asyncio
+    async def test_an_absolute_seek_sends_a_position(self, conf, ws) -> None:
+        await SeekContentEvent(conf, position_seconds=42.5).execute_event()
+
+        message = ws.send_message.await_args.args[0]
+        assert message.type == MessageType.SEEK_AUDIO
+        assert message.message == '{"positionSeconds": 42.5}'
+        assert _last_action(conf).metadata == {"seek_position_seconds": 42.5}
+
+    @pytest.mark.asyncio
+    async def test_a_relative_seek_sends_a_delta(self, conf, ws) -> None:
+        await SeekContentEvent(conf, delta_seconds=-15).execute_event()
+
+        assert ws.send_message.await_args.args[0].message == '{"deltaSeconds": -15}'
+        assert _last_action(conf).metadata == {"seek_delta_seconds": -15}
+
+    @pytest.mark.asyncio
+    async def test_a_dtmf_seek_is_attributed_to_the_leader(self, conf, ws) -> None:
+        await SeekContentEvent(conf, delta_seconds=10, initiator_phone=STUDENT).execute_event()
+
+        assert _last_action(conf).action_type == ActionType.LEADER_SEEK_CONTENT_VIA_DTMF
+        assert _last_action(conf).owner == STUDENT
+
+    def test_a_seek_with_no_target_is_rejected_at_construction(self, conf) -> None:
+        with pytest.raises(ValueError, match="Exactly one of delta_seconds or position_seconds"):
+            SeekContentEvent(conf)
+
+
+class TestSetPlaybackSpeed:
+    @pytest.mark.asyncio
+    async def test_setting_the_speed_sends_it_and_stores_it(self, conf, ws) -> None:
+        await SetPlaybackSpeedEvent(conf, 1.5).execute_event()
+
+        message = ws.send_message.await_args.args[0]
+        assert (message.type, message.message) == (MessageType.SET_SPEED, "1.5")
+        assert conf.state.audio_content_state.speed == 1.5
+        assert _last_action(conf).metadata == {"playback_speed": 1.5}
+
+    @pytest.mark.asyncio
+    async def test_a_dtmf_speed_change_is_attributed_to_the_leader(self, conf, ws) -> None:
+        await SetPlaybackSpeedEvent(conf, 0.75, initiator_phone=STUDENT).execute_event()
+
+        assert _last_action(conf).action_type == ActionType.LEADER_SET_SPEED_VIA_DTMF
+
+    @pytest.mark.parametrize("speed", [0.4, 2.1])
+    def test_a_speed_outside_the_supported_range_is_rejected(self, conf, speed) -> None:
+        with pytest.raises(ValueError, match="speed must be 0.5-2.0"):
+            SetPlaybackSpeedEvent(conf, speed)
+
+
+class TestPlaybackStateUpdate:
+    @pytest.mark.asyncio
+    async def test_a_full_update_lands_on_the_content_state(self, conf) -> None:
+        await PlaybackStateUpdateEvent(
+            conf, ContentStatus.PLAYING, position_seconds=12.0, duration_seconds=300.0, speed=1.25
+        ).execute_event()
+
+        state = conf.state.audio_content_state
+        assert (state.status, state.position_seconds, state.duration_seconds, state.speed) == (
+            ContentStatus.PLAYING, 12.0, 300.0, 1.25,
+        )
+        conf.update_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_omitted_fields_keep_their_previous_values(self, conf) -> None:
+        conf.state.audio_content_state.position_seconds = 99.0
+        conf.state.audio_content_state.speed = 1.5
+
+        await PlaybackStateUpdateEvent(conf, ContentStatus.PAUSED).execute_event()
+
+        state = conf.state.audio_content_state
+        assert (state.status, state.position_seconds, state.speed) == (
+            ContentStatus.PAUSED, 99.0, 1.5,
+        )
+
+
+class TestSinkConference:
+    @pytest.mark.asyncio
+    async def test_sinking_stops_the_conference_and_releases_everything(self, conf) -> None:
+        conf.connection_manager = MagicMock()
+        conf.connection_manager.disconnect = AsyncMock()
+        callback = MagicMock()
+
+        await SinkConferenceEvent(conf, callback).execute_event()
+
+        assert conf.state.is_running is False
+        conf.stop_remote_audio_relay.assert_called_once()
+        conf.schedule_capture_finalize.assert_called_once()
+        conf.end_processing_conf_events_from_queue.assert_called_once()
+        conf.connection_manager.disconnect.assert_awaited_once_with(conf.state.get_teacher())
+        callback.assert_called_once()
+        assert _last_action(conf).action_type == ActionType.CONFERENCE_SINK
+        assert _last_action(conf).owner == TEACHER
+
+    @pytest.mark.asyncio
+    async def test_sinking_without_a_smartphone_connection_still_works(self, conf) -> None:
+        conf.connection_manager = None
+
+        await SinkConferenceEvent(conf, MagicMock()).execute_event()
+
+        assert conf.state.is_running is False
+        conf.update_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sinking_without_a_callback_still_works(self, conf) -> None:
+        conf.connection_manager = None
+        await SinkConferenceEvent(conf, None).execute_event()
+        assert conf.state.is_running is False

--- a/platform/tests/unit/test_confevents_participants_playback.py
+++ b/platform/tests/unit/test_confevents_participants_playback.py
@@ -388,15 +388,25 @@ class TestSinkConference:
 
     @pytest.mark.asyncio
     async def test_sinking_without_a_smartphone_connection_still_works(self, conf) -> None:
+        """Skipping the teacher's SSE disconnect must not skip the rest of the teardown."""
         conf.connection_manager = None
+        callback = MagicMock()
 
-        await SinkConferenceEvent(conf, MagicMock()).execute_event()
+        await SinkConferenceEvent(conf, callback).execute_event()
 
         assert conf.state.is_running is False
+        conf.stop_remote_audio_relay.assert_called_once()
+        conf.schedule_capture_finalize.assert_called_once()
+        conf.end_processing_conf_events_from_queue.assert_called_once()
+        callback.assert_called_once()
         conf.update_state.assert_awaited_once()
+        assert _last_action(conf).action_type == ActionType.CONFERENCE_SINK
 
     @pytest.mark.asyncio
     async def test_sinking_without_a_callback_still_works(self, conf) -> None:
         conf.connection_manager = None
+
         await SinkConferenceEvent(conf, None).execute_event()
+
         assert conf.state.is_running is False
+        conf.end_processing_conf_events_from_queue.assert_called_once()

--- a/platform/tests/unit/test_ivr_service_deep.py
+++ b/platform/tests/unit/test_ivr_service_deep.py
@@ -363,6 +363,7 @@ class TestProcessDtmfDuringStreaming:
 
         ncco = await service.process_dtmf(CALL_ID, "#")
 
+        websocket.set_playback_speed.assert_awaited_once_with(CALL_ID, 2.0)
         assert [a["action"] for a in ncco] == ["input"]
         doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
         assert doc["experience_data"]["playback_speed"] == 1.5
@@ -652,15 +653,16 @@ class TestEnsureFsmLoaded:
             {"_id": "stale-fsm", "created_at": 1, "states": [], "transitions": [],
              "init_state_id": "state-1"}
         )
-        monkeypatch.setattr(
-            ivr_service, "instantitate_from_doc", MagicMock(side_effect=RuntimeError("bad shape"))
-        )
+        deserialise = MagicMock(side_effect=RuntimeError("bad shape"))
+        monkeypatch.setattr(ivr_service, "instantitate_from_doc", deserialise)
         rebuilt = FakeFSM()
         monkeypatch.setattr(
             ivr_service, "instantiate_from_latest_content", AsyncMock(return_value=rebuilt)
         )
 
         await service._ensure_fsm_loaded()
+
+        deserialise.assert_called_once()
         assert fsm_cache[FSM_ID] is rebuilt
 
     @pytest.mark.asyncio

--- a/platform/tests/unit/test_ivr_service_deep.py
+++ b/platform/tests/unit/test_ivr_service_deep.py
@@ -410,13 +410,14 @@ class TestProcessDtmfDuringStreaming:
         self, service, db, streaming_fsm, websocket
     ) -> None:
         websocket.pause_audio.side_effect = RuntimeError("ws gone")
-        await _seed_ongoing(db)
+        await _seed_ongoing(db, experience_data={"playback_speed": 1.5})
 
         ncco = await service.process_dtmf(CALL_ID, "0")
 
         assert [a["action"] for a in ncco] == ["input"]
         doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
-        assert doc["experience_data"] == {}
+        assert "is_paused" not in doc["experience_data"]
+        assert doc["experience_data"]["playback_speed"] == 1.5
 
     @pytest.mark.asyncio
     async def test_speed_keys_outside_streaming_fall_through_to_the_fsm(

--- a/platform/tests/unit/test_ivr_service_deep.py
+++ b/platform/tests/unit/test_ivr_service_deep.py
@@ -222,7 +222,7 @@ class TestStartCallFlow:
 
     @pytest.mark.asyncio
     async def test_a_vonage_failure_is_reported_not_swallowed(
-        self, service, cached_fsm, monkeypatch
+        self, service, db, cached_fsm, monkeypatch
     ) -> None:
         monkeypatch.setattr(
             ivr_service, "_make_vonage_call", AsyncMock(side_effect=RuntimeError("vonage down"))
@@ -231,6 +231,7 @@ class TestStartCallFlow:
 
         assert result["status_code"] == 500
         assert "vonage down" in result["message"]
+        assert await db["ongoingIVRState"].find_one({"phone_number": PHONE}) is None
 
     @pytest.mark.asyncio
     async def test_an_empty_vonage_response_is_a_500(
@@ -489,6 +490,8 @@ class TestProcessCallEvent:
 
         doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
         assert doc["call_status_updates"] == {}
+        assert doc["current_state_id"] == "state-1"
+        assert doc["stopped_at"] is None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status", [s.value for s in IVRCallStatus.end_statuses()])

--- a/platform/tests/unit/test_ivr_service_deep.py
+++ b/platform/tests/unit/test_ivr_service_deep.py
@@ -351,6 +351,8 @@ class TestProcessDtmfDuringStreaming:
         await service.process_dtmf(CALL_ID, "*")
 
         websocket.set_playback_speed.assert_awaited_once_with(CALL_ID, 1.25)
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["experience_data"]["playback_speed"] == 1.25
 
     @pytest.mark.asyncio
     async def test_a_websocket_failure_leaves_the_speed_unchanged(

--- a/platform/tests/unit/test_ivr_service_deep.py
+++ b/platform/tests/unit/test_ivr_service_deep.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -20,6 +21,11 @@ CALL_ID = "conv-uuid-1"
 PHONE = "+911111111111"
 TENANT = "tenant-1"
 FSM_ID = "fsm-1"
+_real_sleep = asyncio.sleep
+
+
+async def _no_backoff(*_args) -> None:
+    await _real_sleep(0)
 
 
 class FakeFSM:
@@ -84,8 +90,13 @@ def fsm_cache(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def no_retry_backoff(monkeypatch):
-    """The retry loops sleep for whole seconds; nothing under test needs real time to pass."""
-    monkeypatch.setattr(ivr_service.asyncio, "sleep", AsyncMock())
+    """The retry loops sleep for whole seconds; nothing under test needs real time to pass.
+
+    `ivr_service.asyncio` is the asyncio module itself, so this replaces sleep everywhere
+    for the duration of the test — yield instead of returning immediately, or anything else
+    sharing the loop stops being scheduled.
+    """
+    monkeypatch.setattr(ivr_service.asyncio, "sleep", _no_backoff)
 
 
 @pytest.fixture
@@ -203,10 +214,7 @@ class TestStartCallFlow:
 
     @pytest.mark.asyncio
     async def test_no_usable_fsm_is_a_500(self, service, monkeypatch, vonage_call) -> None:
-        monkeypatch.setattr(ivr_service, "_ensure_fsm_loaded", AsyncMock(), raising=False)
-        monkeypatch.setattr(
-            IVRService, "_ensure_fsm_loaded", AsyncMock(return_value=None)
-        )
+        monkeypatch.setattr(IVRService, "_ensure_fsm_loaded", AsyncMock(return_value=None))
         result = await service.start_call_flow(PHONE, TENANT)
 
         assert result == {"status_code": 500, "message": "FSM not available"}

--- a/platform/tests/unit/test_ivr_service_deep.py
+++ b/platform/tests/unit/test_ivr_service_deep.py
@@ -1,0 +1,689 @@
+"""IVR orchestration — call start, DTMF handling, lifecycle events, and FSM caching."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.ivr_state import IVRCallStateMongoDoc, IVRCallStatus, IVRfsmDoc
+from app.providers.vonage_actions.connect_action import VonageConnectAction
+from app.providers.vonage_actions.input_action import InputAction
+from app.providers.vonage_actions.talk_action import TalkAction
+from app.services import ivr_service
+from app.services.ivr_service import IVRService
+from tests.support.mongomock_async import AsyncMongoMockClient
+
+CALL_ID = "conv-uuid-1"
+PHONE = "+911111111111"
+TENANT = "tenant-1"
+FSM_ID = "fsm-1"
+
+
+class FakeFSM:
+    """Minimal stand-in for the FSM engine: a fixed transition and serialisable shape."""
+
+    def __init__(self, next_actions=None, next_state_id="state-2"):
+        self.fsm_id = FSM_ID
+        self.init_state_id = "state-1"
+        self.states = {}
+        self._next_actions = next_actions if next_actions is not None else []
+        self._next_state_id = next_state_id
+        self.transitions_seen: list[str] = []
+
+    def get_start_fsm_actions(self):
+        return [TalkAction(text="welcome")]
+
+    async def get_next_actions(self, digit, ivr_state):
+        self.transitions_seen.append(digit)
+        return self._next_actions, self._next_state_id
+
+    def serialize(self):
+        return IVRfsmDoc(
+            _id=self.fsm_id, created_at=1, states=[{"id": "state-1"}], transitions=[],
+            init_state_id=self.init_state_id,
+        )
+
+
+def _streaming_state():
+    return SimpleNamespace(actions=[VonageConnectAction(websocket_uri="wss://ws.test/s")], menu=None)
+
+
+def _settings(**overrides):
+    base = {
+        "ivr_daily_listening_limit_seconds": 0,
+        "default_welcome_language": "en",
+        "base_url": "https://api.test",
+        "vonage_ivr_application_id": "app-1",
+        "vonage_ivr_application_private_key64": "",
+        "vonage_number": "+910000000000",
+    }
+    return SimpleNamespace(**{**base, **overrides})
+
+
+@pytest.fixture
+def db():
+    return AsyncMongoMockClient()["test_ivr_deep"]
+
+
+@pytest.fixture
+def service(db):
+    return IVRService(db)
+
+
+@pytest.fixture(autouse=True)
+def fsm_cache(monkeypatch):
+    """The FSM cache is module-level state — give every test its own."""
+    monkeypatch.setattr(ivr_service, "_fsm_cache", {})
+    monkeypatch.setattr(ivr_service, "_latest_fsm_id", None)
+    monkeypatch.setattr(ivr_service, "get_settings", _settings)
+    return ivr_service._fsm_cache
+
+
+@pytest.fixture(autouse=True)
+def no_retry_backoff(monkeypatch):
+    """The retry loops sleep for whole seconds; nothing under test needs real time to pass."""
+    monkeypatch.setattr(ivr_service.asyncio, "sleep", AsyncMock())
+
+
+@pytest.fixture
+def cached_fsm(monkeypatch, fsm_cache):
+    fsm = FakeFSM()
+    fsm_cache[FSM_ID] = fsm
+    monkeypatch.setattr(ivr_service, "_latest_fsm_id", FSM_ID)
+    return fsm
+
+
+@pytest.fixture
+def vonage_call(monkeypatch):
+    call = AsyncMock(return_value={"conversation_uuid": CALL_ID})
+    monkeypatch.setattr(ivr_service, "_make_vonage_call", call)
+    return call
+
+
+@pytest.fixture
+def websocket(monkeypatch):
+    ws = MagicMock()
+    ws.set_playback_speed = AsyncMock()
+    ws.pause_audio = AsyncMock()
+    ws.resume_audio = AsyncMock()
+    monkeypatch.setattr(ivr_service, "get_websocket_service", AsyncMock(return_value=ws))
+    return ws
+
+
+async def _seed_ongoing(db, **overrides):
+    state = IVRCallStateMongoDoc(
+        _id=CALL_ID, phone_number=PHONE, fsm_id=FSM_ID, current_state_id="state-1",
+        tenant_id=TENANT, **{"created_at": datetime.now(), **overrides},
+    )
+    await db["ongoingIVRState"].insert_one(state.model_dump(by_alias=True))
+    return state
+
+
+class TestStartCallFlow:
+    @pytest.mark.asyncio
+    async def test_a_successful_start_persists_the_call_state(
+        self, service, db, cached_fsm, vonage_call
+    ) -> None:
+        result = await service.start_call_flow(PHONE, TENANT)
+
+        assert result == {"status_code": 200, "message": f"IVR started for {PHONE}"}
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["phone_number"] == PHONE
+        assert doc["fsm_id"] == FSM_ID
+        assert doc["current_state_id"] == cached_fsm.init_state_id
+        assert doc["tenant_id"] == TENANT
+
+    @pytest.mark.asyncio
+    async def test_the_start_ncco_comes_from_the_fsm(
+        self, service, cached_fsm, vonage_call
+    ) -> None:
+        await service.start_call_flow(PHONE, TENANT)
+        ncco = vonage_call.await_args.args[1]
+        assert [a["action"] for a in ncco] == ["talk"]
+        assert ncco[0]["text"] == "welcome"
+
+    @pytest.mark.asyncio
+    async def test_a_recent_call_in_progress_is_rejected(
+        self, service, db, cached_fsm, vonage_call
+    ) -> None:
+        await _seed_ongoing(db)
+        result = await service.start_call_flow(PHONE, TENANT)
+
+        assert result["status_code"] == 400
+        assert PHONE in result["message"]
+        vonage_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_stale_call_in_progress_is_cleared_and_the_new_call_starts(
+        self, service, db, cached_fsm, vonage_call, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("STALE_WAIT_IN_MINUTES", "30")
+        await _seed_ongoing(db, created_at=datetime.now() - timedelta(hours=2))
+
+        result = await service.start_call_flow(PHONE, TENANT)
+
+        assert result["status_code"] == 200
+        vonage_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_caller_over_the_daily_limit_only_hears_the_limit_announcement(
+        self, service, db, cached_fsm, vonage_call, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            ivr_service, "get_settings", lambda: _settings(ivr_daily_listening_limit_seconds=600)
+        )
+        monkeypatch.setattr(ivr_service, "get_ist_date_string", lambda: "2026-08-25")
+        await db["dailyListeningUsage"].insert_one(
+            {"phone_number": PHONE, "date": "2026-08-25", "total_seconds": 900}
+        )
+
+        result = await service.start_call_flow(PHONE, TENANT)
+
+        assert result["status_code"] == 200
+        assert "Daily limit reached" in result["message"]
+        assert vonage_call.await_args.args[1][-1] == {"action": "hangup"}
+        assert await db["ongoingIVRState"].find_one({"_id": CALL_ID}) is None
+
+    @pytest.mark.asyncio
+    async def test_a_caller_under_the_daily_limit_starts_normally(
+        self, service, db, cached_fsm, vonage_call, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            ivr_service, "get_settings", lambda: _settings(ivr_daily_listening_limit_seconds=600)
+        )
+        monkeypatch.setattr(ivr_service, "get_ist_date_string", lambda: "2026-08-25")
+        await db["dailyListeningUsage"].insert_one(
+            {"phone_number": PHONE, "date": "2026-08-25", "total_seconds": 60}
+        )
+
+        assert (await service.start_call_flow(PHONE, TENANT))["status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_no_usable_fsm_is_a_500(self, service, monkeypatch, vonage_call) -> None:
+        monkeypatch.setattr(ivr_service, "_ensure_fsm_loaded", AsyncMock(), raising=False)
+        monkeypatch.setattr(
+            IVRService, "_ensure_fsm_loaded", AsyncMock(return_value=None)
+        )
+        result = await service.start_call_flow(PHONE, TENANT)
+
+        assert result == {"status_code": 500, "message": "FSM not available"}
+        vonage_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_vonage_failure_is_reported_not_swallowed(
+        self, service, cached_fsm, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            ivr_service, "_make_vonage_call", AsyncMock(side_effect=RuntimeError("vonage down"))
+        )
+        result = await service.start_call_flow(PHONE, TENANT)
+
+        assert result["status_code"] == 500
+        assert "vonage down" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_an_empty_vonage_response_is_a_500(
+        self, service, cached_fsm, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(ivr_service, "_make_vonage_call", AsyncMock(return_value=None))
+        assert await service.start_call_flow(PHONE, TENANT) == {
+            "status_code": 500, "message": "No Vonage response",
+        }
+
+
+class TestProcessDtmf:
+    @pytest.mark.asyncio
+    async def test_an_unknown_call_gets_an_apology_and_a_hangup(self, service) -> None:
+        ncco = await service.process_dtmf(CALL_ID, "1")
+
+        assert ncco[0]["action"] == "talk"
+        assert "Server error" in ncco[0]["text"]
+        assert ncco[-1] == {"action": "hangup"}
+
+    @pytest.mark.asyncio
+    async def test_a_call_whose_fsm_left_the_cache_gets_no_ncco(self, service, db) -> None:
+        await _seed_ongoing(db)
+        assert await service.process_dtmf(CALL_ID, "1") == []
+
+    @pytest.mark.asyncio
+    async def test_a_keypress_walks_the_fsm_and_records_the_transition(
+        self, service, db, cached_fsm
+    ) -> None:
+        await _seed_ongoing(db)
+        await service.process_dtmf(CALL_ID, "3")
+
+        assert cached_fsm.transitions_seen == ["3"]
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["current_state_id"] == "state-2"
+        assert [a["key_pressed"] for a in doc["user_actions"]] == ["3"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_digits_are_walked_one_transition_at_a_time(
+        self, service, db, cached_fsm
+    ) -> None:
+        await _seed_ongoing(db)
+        await service.process_dtmf(CALL_ID, "12")
+
+        assert cached_fsm.transitions_seen == ["1", "2"]
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert [a["key_pressed"] for a in doc["user_actions"]] == ["1", "2"]
+
+    @pytest.mark.asyncio
+    async def test_no_keypress_is_recorded_as_an_empty_action(
+        self, service, db, cached_fsm
+    ) -> None:
+        await _seed_ongoing(db)
+        await service.process_dtmf(CALL_ID, "")
+
+        assert cached_fsm.transitions_seen == [""]
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert [a["key_pressed"] for a in doc["user_actions"]] == ["empty"]
+
+    @pytest.mark.asyncio
+    async def test_a_state_still_expecting_input_does_not_hang_up(
+        self, service, db, fsm_cache, monkeypatch
+    ) -> None:
+        fsm_cache[FSM_ID] = FakeFSM(
+            next_actions=[TalkAction(text="menu"), InputAction(type_=["dtmf"], eventApi="/input")]
+        )
+        await _seed_ongoing(db)
+
+        ncco = await service.process_dtmf(CALL_ID, "1")
+        assert [a["action"] for a in ncco] == ["talk", "input"]
+
+    @pytest.mark.asyncio
+    async def test_a_terminal_state_hangs_up(self, service, db, fsm_cache) -> None:
+        fsm_cache[FSM_ID] = FakeFSM(next_actions=[TalkAction(text="goodbye")])
+        await _seed_ongoing(db)
+
+        ncco = await service.process_dtmf(CALL_ID, "1")
+        assert [a["action"] for a in ncco] == ["talk", "hangup"]
+
+
+class TestProcessDtmfDuringStreaming:
+    @pytest.fixture
+    def streaming_fsm(self, fsm_cache):
+        fsm = FakeFSM()
+        fsm.states = {"state-1": _streaming_state()}
+        fsm_cache[FSM_ID] = fsm
+        return fsm
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_keeps_the_dtmf_listener_alive(
+        self, service, db, streaming_fsm
+    ) -> None:
+        await _seed_ongoing(db)
+        ncco = await service.process_dtmf(CALL_ID, "", timed_out=True)
+
+        assert [a["action"] for a in ncco] == ["input"]
+        assert ncco[0]["eventUrl"] == ["https://api.test/input"]
+        assert streaming_fsm.transitions_seen == []
+
+    @pytest.mark.asyncio
+    async def test_hash_speeds_playback_up_and_remembers_it(
+        self, service, db, streaming_fsm, websocket
+    ) -> None:
+        await _seed_ongoing(db)
+        ncco = await service.process_dtmf(CALL_ID, "#")
+
+        websocket.set_playback_speed.assert_awaited_once_with(CALL_ID, 1.25)
+        assert [a["action"] for a in ncco] == ["input"]
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["experience_data"]["playback_speed"] == 1.25
+
+    @pytest.mark.asyncio
+    async def test_star_slows_playback_down_from_the_remembered_speed(
+        self, service, db, streaming_fsm, websocket
+    ) -> None:
+        await _seed_ongoing(db, experience_data={"playback_speed": 1.5})
+        await service.process_dtmf(CALL_ID, "*")
+
+        websocket.set_playback_speed.assert_awaited_once_with(CALL_ID, 1.25)
+
+    @pytest.mark.asyncio
+    async def test_a_websocket_failure_leaves_the_speed_unchanged(
+        self, service, db, streaming_fsm, websocket
+    ) -> None:
+        websocket.set_playback_speed.side_effect = RuntimeError("ws gone")
+        await _seed_ongoing(db, experience_data={"playback_speed": 1.5})
+
+        ncco = await service.process_dtmf(CALL_ID, "#")
+
+        assert [a["action"] for a in ncco] == ["input"]
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["experience_data"]["playback_speed"] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_zero_pauses_playback_and_announces_it(
+        self, service, db, streaming_fsm, websocket
+    ) -> None:
+        await _seed_ongoing(db)
+        ncco = await service.process_dtmf(CALL_ID, "0")
+
+        websocket.pause_audio.assert_awaited_once_with(CALL_ID)
+        assert [a["action"] for a in ncco] == ["talk", "input"]
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["experience_data"]["is_paused"] is True
+
+    @pytest.mark.asyncio
+    async def test_zero_again_resumes_playback(
+        self, service, db, streaming_fsm, websocket
+    ) -> None:
+        await _seed_ongoing(db, experience_data={"is_paused": True})
+        ncco = await service.process_dtmf(CALL_ID, "0")
+
+        websocket.resume_audio.assert_awaited_once_with(CALL_ID)
+        assert ncco[0]["action"] == "talk"
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["experience_data"]["is_paused"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_pause_announcement_follows_the_menu_language(
+        self, service, db, streaming_fsm, websocket
+    ) -> None:
+        streaming_fsm.states["state-1"] = SimpleNamespace(
+            actions=[VonageConnectAction(websocket_uri="wss://ws.test/s")],
+            menu=SimpleNamespace(language="hi"),
+        )
+        await _seed_ongoing(db)
+
+        ncco = await service.process_dtmf(CALL_ID, "0")
+        assert ncco[0]["language"] == "hi-IN"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_pause_is_not_recorded_as_paused(
+        self, service, db, streaming_fsm, websocket
+    ) -> None:
+        websocket.pause_audio.side_effect = RuntimeError("ws gone")
+        await _seed_ongoing(db)
+
+        ncco = await service.process_dtmf(CALL_ID, "0")
+
+        assert [a["action"] for a in ncco] == ["input"]
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["experience_data"] == {}
+
+    @pytest.mark.asyncio
+    async def test_speed_keys_outside_streaming_fall_through_to_the_fsm(
+        self, service, db, cached_fsm, websocket
+    ) -> None:
+        await _seed_ongoing(db)
+        await service.process_dtmf(CALL_ID, "#")
+
+        websocket.set_playback_speed.assert_not_awaited()
+        assert cached_fsm.transitions_seen == ["#"]
+
+
+class TestProcessCallEvent:
+    @pytest.mark.asyncio
+    async def test_an_unknown_call_is_ignored(self, service, db) -> None:
+        assert await service.process_call_event(CALL_ID, {"status": "completed"}) is None
+
+    @pytest.mark.asyncio
+    async def test_an_end_status_archives_the_call_and_clears_the_live_state(
+        self, service, db, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(ivr_service, "WebsocketClientProvider", MagicMock())
+        await _seed_ongoing(db)
+
+        await service.process_call_event(
+            CALL_ID, {"status": "completed", "duration": "42", "timestamp": "2026-08-25T10:00:00Z"}
+        )
+
+        assert await db["ongoingIVRState"].find_one({"_id": CALL_ID}) is None
+        archived = await db["ivrv2logs"].find_one({"_id": CALL_ID})
+        assert archived["duration"] == "42"
+        assert archived["stopped_at"] is not None
+        assert "2026-08-25T10:00:00+00:00" in archived["call_status_updates"]
+
+    @pytest.mark.asyncio
+    async def test_a_websocket_close_failure_does_not_block_archiving(
+        self, service, db, monkeypatch
+    ) -> None:
+        provider = MagicMock()
+        provider.return_value.close = AsyncMock(side_effect=RuntimeError("ws gone"))
+        monkeypatch.setattr(ivr_service, "WebsocketClientProvider", provider)
+        await _seed_ongoing(db)
+
+        await service.process_call_event(CALL_ID, {"status": "completed"})
+
+        assert await db["ivrv2logs"].find_one({"_id": CALL_ID}) is not None
+
+    @pytest.mark.asyncio
+    async def test_a_mid_call_status_updates_without_archiving(self, service, db) -> None:
+        await _seed_ongoing(db)
+
+        await service.process_call_event(
+            CALL_ID, {"status": "answered", "timestamp": "2026-08-25T10:00:00Z"}
+        )
+
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["current_state_id"] == "state-1"
+        assert await db["ivrv2logs"].find_one({"_id": CALL_ID}) is None
+
+    @pytest.mark.asyncio
+    async def test_an_unrecognised_status_leaves_the_call_alone(self, service, db) -> None:
+        await _seed_ongoing(db)
+        await service.process_call_event(CALL_ID, {"status": "sideways"})
+
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["stopped_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_an_unparseable_timestamp_is_dropped_not_fatal(self, service, db) -> None:
+        await _seed_ongoing(db)
+        await service.process_call_event(
+            CALL_ID, {"status": "answered", "timestamp": "not-a-timestamp"}
+        )
+
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["call_status_updates"] == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [s.value for s in IVRCallStatus.end_statuses()])
+    async def test_every_end_status_archives(self, service, db, monkeypatch, status) -> None:
+        monkeypatch.setattr(ivr_service, "WebsocketClientProvider", MagicMock())
+        await _seed_ongoing(db)
+
+        await service.process_call_event(CALL_ID, {"status": status})
+        assert await db["ongoingIVRState"].find_one({"_id": CALL_ID}) is None
+
+
+class TestProcessRtcEvent:
+    @pytest.mark.asyncio
+    async def test_an_audio_play_event_records_the_stream(self, service, db) -> None:
+        await _seed_ongoing(db)
+        await service.process_rtc_event({
+            "type": "audio:play",
+            "conversation_id": CALL_ID,
+            "timestamp": "2026-08-25T10:00:00Z",
+            "body": {"play_id": "p1", "stream_url": ["https://cdn/a.mp3"]},
+        })
+
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["stream_playback"] == [
+            {"play_id": "p1", "stream_url": "https://cdn/a.mp3",
+             "started_at": "2026-08-25T10:00:00Z"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_bare_stream_url_is_stored_as_is(self, service, db) -> None:
+        await _seed_ongoing(db)
+        await service.process_rtc_event({
+            "type": "audio:play",
+            "conversation_id": CALL_ID,
+            "timestamp": "2026-08-25T10:00:00Z",
+            "body": {"play_id": "p1", "stream_url": "https://cdn/a.mp3"},
+        })
+
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["stream_playback"][0]["stream_url"] == "https://cdn/a.mp3"
+
+    @pytest.mark.asyncio
+    async def test_an_audio_play_event_for_an_unknown_call_is_dropped(self, service, db) -> None:
+        await service.process_rtc_event({
+            "type": "audio:play",
+            "conversation_id": "no-such-call",
+            "body": {"play_id": "p1", "stream_url": "https://cdn/a.mp3"},
+        })
+        assert await db["ongoingIVRState"].find_one({"_id": "no-such-call"}) is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("event_type", "field"),
+        [("audio:play:stop", "stopped_at"), ("audio:play:done", "done_at")],
+    )
+    async def test_a_stop_or_done_event_closes_out_the_stream(
+        self, service, db, event_type, field
+    ) -> None:
+        await _seed_ongoing(db, stream_playback=[{
+            "play_id": "p1", "stream_url": "https://cdn/a.mp3", "started_at": datetime.now(),
+        }])
+
+        await service.process_rtc_event({
+            "type": event_type,
+            "conversation_id": CALL_ID,
+            "timestamp": "2026-08-25T10:05:00Z",
+            "body": {"play_id": "p1"},
+        })
+
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["stream_playback"][0][field] == "2026-08-25T10:05:00Z"
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_rtc_event_changes_nothing(self, service, db) -> None:
+        await _seed_ongoing(db)
+        await service.process_rtc_event({"type": "member:joined", "body": {}})
+
+        doc = await db["ongoingIVRState"].find_one({"_id": CALL_ID})
+        assert doc["stream_playback"] == []
+
+
+class TestFsmStructure:
+    @pytest.mark.asyncio
+    async def test_the_structure_is_the_cached_fsm_serialised(self, service, cached_fsm) -> None:
+        assert await service.get_ivr_structure(TENANT) == {
+            "fsm_id": FSM_ID,
+            "init_state_id": "state-1",
+            "states": [{"id": "state-1"}],
+            "transitions": [],
+            "created_at": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_fsm_anywhere_is_reported_as_an_error(
+        self, service, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            ivr_service, "instantiate_from_latest_content",
+            AsyncMock(side_effect=RuntimeError("no content")),
+        )
+        assert await service.get_ivr_structure(TENANT) == {
+            "error": "No FSM available", "states": [], "transitions": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_an_update_is_refused_while_calls_are_live(
+        self, service, db, cached_fsm
+    ) -> None:
+        await _seed_ongoing(db)
+        result = await service.update_ivr_structure(TENANT, {})
+
+        assert result["status_code"] == 409
+        assert "1 active call" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_an_update_rebuilds_persists_and_caches_the_fsm(
+        self, service, db, fsm_cache, monkeypatch
+    ) -> None:
+        rebuilt = FakeFSM()
+        monkeypatch.setattr(
+            ivr_service, "instantiate_from_latest_content", AsyncMock(return_value=rebuilt)
+        )
+
+        result = await service.update_ivr_structure(TENANT, {})
+
+        assert result == {
+            "status_code": 200, "message": "FSM updated successfully", "fsm_id": FSM_ID,
+        }
+        assert fsm_cache[FSM_ID] is rebuilt
+        assert ivr_service._latest_fsm_id == FSM_ID
+        assert await db["ivrfsms"].find_one({"_id": FSM_ID}) is not None
+
+
+class TestEnsureFsmLoaded:
+    @pytest.mark.asyncio
+    async def test_a_persisted_fsm_is_deserialised_into_the_cache(
+        self, service, db, fsm_cache, monkeypatch
+    ) -> None:
+        await db["ivrfsms"].insert_one(
+            {"_id": FSM_ID, "created_at": 1, "states": [], "transitions": [],
+             "init_state_id": "state-1"}
+        )
+        loaded = FakeFSM()
+        monkeypatch.setattr(ivr_service, "instantitate_from_doc", MagicMock(return_value=loaded))
+
+        await service._ensure_fsm_loaded()
+
+        assert fsm_cache[FSM_ID] is loaded
+        assert ivr_service._latest_fsm_id == FSM_ID
+
+    @pytest.mark.asyncio
+    async def test_an_undeserialisable_persisted_fsm_falls_back_to_a_rebuild(
+        self, service, db, fsm_cache, monkeypatch
+    ) -> None:
+        await db["ivrfsms"].insert_one(
+            {"_id": "stale-fsm", "created_at": 1, "states": [], "transitions": [],
+             "init_state_id": "state-1"}
+        )
+        monkeypatch.setattr(
+            ivr_service, "instantitate_from_doc", MagicMock(side_effect=RuntimeError("bad shape"))
+        )
+        rebuilt = FakeFSM()
+        monkeypatch.setattr(
+            ivr_service, "instantiate_from_latest_content", AsyncMock(return_value=rebuilt)
+        )
+
+        await service._ensure_fsm_loaded()
+        assert fsm_cache[FSM_ID] is rebuilt
+
+    @pytest.mark.asyncio
+    async def test_a_failed_rebuild_leaves_the_cache_empty(
+        self, service, fsm_cache, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            ivr_service, "instantiate_from_latest_content",
+            AsyncMock(side_effect=RuntimeError("no content")),
+        )
+
+        await service._ensure_fsm_loaded()
+
+        assert fsm_cache == {}
+        assert ivr_service._latest_fsm_id is None
+
+    @pytest.mark.asyncio
+    async def test_an_already_cached_fsm_is_not_reloaded(
+        self, service, cached_fsm, monkeypatch
+    ) -> None:
+        rebuild = AsyncMock()
+        monkeypatch.setattr(ivr_service, "instantiate_from_latest_content", rebuild)
+
+        await service._ensure_fsm_loaded()
+        rebuild.assert_not_awaited()
+
+
+class TestFsmLookup:
+    @pytest.mark.asyncio
+    async def test_an_fsm_is_found_in_the_radio_collection_too(self, service, db) -> None:
+        await db["radioFSMs"].insert_one(
+            {"_id": "radio-1", "created_at": 1, "states": [], "transitions": [],
+             "init_state_id": "s1"}
+        )
+        assert (await service.get_ivr_fsm_by_id("radio-1")).init_state_id == "s1"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_fsm_id_is_none(self, service) -> None:
+        assert await service.get_ivr_fsm_by_id("nope") is None

--- a/platform/tests/unit/test_smartphone_connection.py
+++ b/platform/tests/unit/test_smartphone_connection.py
@@ -1,0 +1,99 @@
+"""SSE connection manager for the teacher smartphone app."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from app.providers import smartphone_connection
+from app.providers.smartphone_connection import (
+    SmartphoneConnectionManager,
+    SmartphoneConnectionManagerFactory,
+)
+
+CLIENT = object()
+
+
+async def _drain(response, count: int) -> list[str]:
+    stream = response.body_iterator
+    return [await asyncio.wait_for(anext(stream), timeout=2) for _ in range(count)]
+
+
+@pytest.fixture
+def manager():
+    return SmartphoneConnectionManager("conf-1")
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_an_unbuffered_sse_response(manager) -> None:
+    response = await manager.connect(CLIENT)
+    assert response.media_type == "text/event-stream"
+    assert response.headers["cache-control"] == "no-cache"
+    assert response.headers["x-accel-buffering"] == "no"
+
+
+@pytest.mark.asyncio
+async def test_queued_messages_are_streamed_as_sse_data_frames(manager) -> None:
+    response = await manager.connect(CLIENT)
+    await manager.send_message_to_client(CLIENT, {"event": "play"})
+    await manager.send_message_to_client(CLIENT, {"event": "pause"})
+
+    frames = await _drain(response, 2)
+    assert frames == ['data: {"event": "play"}\n\n', 'data: {"event": "pause"}\n\n']
+    assert json.loads(frames[0].removeprefix("data: ").strip()) == {"event": "play"}
+
+
+@pytest.mark.asyncio
+async def test_an_idle_stream_emits_a_keepalive_comment(manager, monkeypatch) -> None:
+    monkeypatch.setattr(smartphone_connection, "_KEEPALIVE_INTERVAL", 0.01)
+    response = await manager.connect(CLIENT)
+    assert await _drain(response, 1) == [": keepalive\n\n"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_ends_the_stream(manager) -> None:
+    response = await manager.connect(CLIENT)
+    assert await manager.disconnect(CLIENT) == {}
+
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(response.body_iterator), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_messages_queued_before_the_sentinel_still_get_delivered(manager) -> None:
+    response = await manager.connect(CLIENT)
+    await manager.send_message_to_client(CLIENT, {"event": "play"})
+    await manager.disconnect(CLIENT)
+
+    assert await _drain(response, 1) == ['data: {"event": "play"}\n\n']
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(response.body_iterator), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_stream_shuts_down_quietly(manager) -> None:
+    response = await manager.connect(CLIENT)
+    await manager.send_message_to_client(CLIENT, {"event": "play"})
+    await _drain(response, 1)
+
+    with pytest.raises(StopAsyncIteration):
+        await response.body_iterator.athrow(asyncio.CancelledError)
+
+
+@pytest.mark.asyncio
+async def test_a_full_queue_drops_the_message_instead_of_raising(manager, caplog) -> None:
+    manager._queue = asyncio.Queue(maxsize=1)
+    await manager.send_message_to_client(CLIENT, {"event": "first"})
+    await manager.send_message_to_client(CLIENT, {"event": "dropped"})
+
+    assert manager._queue.qsize() == 1
+    assert "queue full for conf_id=conf-1" in caplog.text
+
+
+def test_the_factory_makes_one_manager_per_conference() -> None:
+    factory = SmartphoneConnectionManagerFactory()
+    first, second = factory.create("conf-1"), factory.create("conf-2")
+    assert (first.conf_id, second.conf_id) == ("conf-1", "conf-2")
+    assert first is not second

--- a/platform/tests/unit/test_smartphone_connection.py
+++ b/platform/tests/unit/test_smartphone_connection.py
@@ -95,6 +95,22 @@ async def test_a_full_queue_drops_the_message_instead_of_raising(manager, caplog
     assert "conf-1" in warnings[0].getMessage()
 
 
+@pytest.mark.asyncio
+async def test_a_drop_does_not_corrupt_the_stream(manager) -> None:
+    """The dropped message must be the only casualty — the stream stays usable and ordered."""
+    manager._queue = asyncio.Queue(maxsize=1)
+    response = await manager.connect(CLIENT)
+
+    await manager.send_message_to_client(CLIENT, {"event": "first"})
+    await manager.send_message_to_client(CLIENT, {"event": "dropped"})
+    assert await _drain(response, 1) == ['data: {"event": "first"}\n\n']
+
+    await manager.send_message_to_client(CLIENT, {"event": "second"})
+    await manager.send_message_to_client(CLIENT, {"event": "third"})
+
+    assert await _drain(response, 1) == ['data: {"event": "second"}\n\n']
+
+
 def test_the_factory_makes_one_manager_per_conference() -> None:
     factory = SmartphoneConnectionManagerFactory()
     first, second = factory.create("conf-1"), factory.create("conf-2")

--- a/platform/tests/unit/test_smartphone_connection.py
+++ b/platform/tests/unit/test_smartphone_connection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 import pytest
 
@@ -89,7 +90,9 @@ async def test_a_full_queue_drops_the_message_instead_of_raising(manager, caplog
     await manager.send_message_to_client(CLIENT, {"event": "dropped"})
 
     assert manager._queue.qsize() == 1
-    assert "queue full for conf_id=conf-1" in caplog.text
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, "a silently dropped message is worse than a noisy one"
+    assert "conf-1" in warnings[0].getMessage()
 
 
 def test_the_factory_makes_one_manager_per_conference() -> None:

--- a/platform/tests/unit/test_speed_control.py
+++ b/platform/tests/unit/test_speed_control.py
@@ -1,0 +1,67 @@
+"""Playback speed stepping and the localised speed-control announcement."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.fsm.instantiation.speed_control import (
+    MAX_SPEED,
+    MIN_SPEED,
+    SUPPORTED_SPEEDS,
+    decrease_speed,
+    get_speed_instruction,
+    increase_speed,
+)
+
+
+@pytest.mark.parametrize(
+    ("current", "expected"),
+    [(0.75, (1.0, False)), (1.0, (1.25, False)), (1.25, (1.5, False)), (1.5, (2.0, True))],
+)
+def test_increase_walks_up_the_supported_ladder(current, expected) -> None:
+    assert increase_speed(current) == expected
+
+
+@pytest.mark.parametrize(
+    ("current", "expected"),
+    [(2.0, (1.5, False)), (1.5, (1.25, False)), (1.25, (1.0, False)), (1.0, (0.75, True))],
+)
+def test_decrease_walks_down_the_supported_ladder(current, expected) -> None:
+    assert decrease_speed(current) == expected
+
+
+def test_increase_at_max_stays_and_reports_at_max() -> None:
+    assert increase_speed(MAX_SPEED) == (MAX_SPEED, True)
+
+
+def test_decrease_at_min_stays_and_reports_at_min() -> None:
+    assert decrease_speed(MIN_SPEED) == (MIN_SPEED, True)
+
+
+@pytest.mark.parametrize("bad", [0.1, 3.0, -1.0])
+def test_out_of_range_speed_is_treated_as_normal_speed(bad) -> None:
+    assert increase_speed(bad) == (1.25, False)
+    assert decrease_speed(bad) == (0.75, True)
+
+
+def test_an_unsupported_in_range_speed_snaps_to_the_next_rung() -> None:
+    assert increase_speed(1.1) == (1.25, False)
+    assert decrease_speed(1.1) == (1.0, False)
+
+
+def test_stepping_up_then_down_returns_to_the_start() -> None:
+    for speed in SUPPORTED_SPEEDS[1:-1]:
+        assert decrease_speed(increase_speed(speed)[0])[0] == speed
+
+
+@pytest.mark.parametrize("language", ["kn", "en", "hi", "bn", "ta", "mr"])
+def test_every_supported_language_has_its_own_instruction(language) -> None:
+    assert get_speed_instruction(language) != "" 
+
+
+def test_instruction_lookup_is_case_insensitive() -> None:
+    assert get_speed_instruction("KN") == get_speed_instruction("kn")
+
+
+def test_unknown_language_falls_back_to_english() -> None:
+    assert get_speed_instruction("xx") == get_speed_instruction("en")

--- a/platform/tests/unit/test_speed_control.py
+++ b/platform/tests/unit/test_speed_control.py
@@ -54,9 +54,15 @@ def test_stepping_up_then_down_returns_to_the_start() -> None:
         assert decrease_speed(increase_speed(speed)[0])[0] == speed
 
 
-@pytest.mark.parametrize("language", ["kn", "en", "hi", "bn", "ta", "mr"])
-def test_every_supported_language_has_its_own_instruction(language) -> None:
-    assert get_speed_instruction(language) != "" 
+SUPPORTED_LANGUAGES = ["kn", "en", "hi", "bn", "ta", "mr"]
+
+
+def test_every_supported_language_has_its_own_instruction() -> None:
+    """Non-empty is not enough — a broken lookup would hand every caller English."""
+    instructions = [get_speed_instruction(lang) for lang in SUPPORTED_LANGUAGES]
+
+    assert len(set(instructions)) == len(SUPPORTED_LANGUAGES)
+    assert get_speed_instruction("en") == "Press star to slow down, press hash to speed up"
 
 
 def test_instruction_lookup_is_case_insensitive() -> None:

--- a/platform/tests/unit/test_subodha_client.py
+++ b/platform/tests/unit/test_subodha_client.py
@@ -1,0 +1,417 @@
+"""Subodha LMS client — session auth, paging, xblock enrichment, and retry policy."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from app.providers import subodha_client as module
+from app.providers.subodha_client import SubodhaClient, close_subodha_client, get_subodha_client
+
+BASE_URL = "https://lms.test"
+COOKIE = "sessionid=abc"
+_real_sleep = asyncio.sleep
+
+
+async def _no_backoff(*_args) -> None:
+    await _real_sleep(0)
+
+
+@pytest.fixture(autouse=True)
+def settings(monkeypatch):
+    values = SimpleNamespace(
+        subodha_base_url=BASE_URL,
+        subodha_username="lms@a4i.org",
+        subodha_password="pw",
+        subodha_page_size=2,
+        subodha_page_delay_ms=0,
+        subodha_xblock_concurrency=2,
+        subodha_xblock_delay_ms=0,
+    )
+    monkeypatch.setattr(module, "get_settings", lambda: values)
+    monkeypatch.setattr(module.asyncio, "sleep", _no_backoff)
+    return values
+
+
+@pytest.fixture
+def routed(monkeypatch):
+    """Build a client whose HTTP calls are served by a handler the test provides."""
+
+    def _build(handler):
+        client = SubodhaClient()
+        client._http = httpx.AsyncClient(transport=httpx.MockTransport(handler), timeout=1.0)
+        return client
+
+    return _build
+
+
+def _xblock_page(body: str) -> str:
+    return (
+        "<html><body>"
+        '<script class="xblock-json-init-args">{"noise": 1}</script>'
+        f'<div class="xblock">{body}</div>'
+        '<div class="staff-modal">staff only</div>'
+        "</body></html>"
+    )
+
+
+class TestGetSession:
+    @pytest.mark.asyncio
+    async def test_a_successful_login_builds_a_cookie_from_both_responses(self, routed) -> None:
+        def handler(request):
+            if request.url.path == "/":
+                return httpx.Response(200, headers={"set-cookie": "csrftoken=tok; Path=/"})
+            assert request.headers["X-CSRFToken"] == "tok"
+            assert request.headers["Referer"] == f"{BASE_URL}/login"
+            return httpx.Response(
+                200, json={"success": True}, headers={"set-cookie": "sessionid=abc; Path=/"}
+            )
+
+        client = routed(handler)
+        cookie = await client.get_session()
+
+        assert "csrftoken=tok" in cookie
+        assert "sessionid=abc" in cookie
+
+    @pytest.mark.asyncio
+    async def test_the_credentials_are_posted_as_a_form(self, routed, settings) -> None:
+        posted = {}
+
+        def handler(request):
+            if request.url.path == "/":
+                return httpx.Response(200)
+            posted["body"] = request.content.decode()
+            return httpx.Response(200, json={"success": True})
+
+        await routed(handler).get_session()
+
+        assert "email=lms%40a4i.org" in posted["body"]
+        assert "password=pw" in posted["body"]
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_login_raises(self, routed) -> None:
+        def handler(request):
+            if request.url.path == "/":
+                return httpx.Response(200)
+            return httpx.Response(200, json={"success": False, "value": "bad credentials"})
+
+        with pytest.raises(RuntimeError, match="Subodha login failed"):
+            await routed(handler).get_session()
+
+    @pytest.mark.asyncio
+    async def test_a_non_json_login_response_is_treated_as_a_failure(self, routed) -> None:
+        def handler(request):
+            if request.url.path == "/":
+                return httpx.Response(200)
+            return httpx.Response(200, text="<html>maintenance</html>")
+
+        with pytest.raises(RuntimeError, match="Subodha login failed"):
+            await routed(handler).get_session()
+
+    @pytest.mark.asyncio
+    async def test_a_live_session_is_reused_without_logging_in_again(self, routed) -> None:
+        calls = []
+
+        def handler(request):
+            calls.append(request.url.path)
+            return httpx.Response(
+                200, json={"success": True}, headers={"set-cookie": "sessionid=abc; Path=/"}
+            )
+
+        client = routed(handler)
+        first = await client.get_session()
+        calls.clear()
+
+        assert await client.get_session() == first
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_clearing_the_cache_forces_a_fresh_login(self, routed) -> None:
+        calls = []
+
+        def handler(request):
+            calls.append(request.url.path)
+            return httpx.Response(
+                200, json={"success": True}, headers={"set-cookie": "sessionid=abc; Path=/"}
+            )
+
+        client = routed(handler)
+        await client.get_session()
+        client.clear_session_cache()
+        calls.clear()
+
+        await client.get_session()
+        assert calls == ["/", "/api/user/v1/account/login_session/"]
+
+
+class TestListAllCourses:
+    @pytest.mark.asyncio
+    async def test_every_page_is_followed_and_the_results_concatenated(self, routed) -> None:
+        pages = {
+            "1": {"results": [{"id": "c1"}, {"id": "c2"}],
+                  "pagination": {"next": f"{BASE_URL}/api/courses/v1/courses/?page=2"}},
+            "2": {"results": [{"id": "c3"}], "pagination": {"next": None}},
+        }
+
+        def handler(request):
+            return httpx.Response(200, json=pages[request.url.params.get("page", "1")])
+
+        courses = await routed(handler).list_all_courses()
+        assert [c["id"] for c in courses] == ["c1", "c2", "c3"]
+
+    @pytest.mark.asyncio
+    async def test_the_first_request_carries_the_configured_page_size(self, routed) -> None:
+        seen = {}
+
+        def handler(request):
+            seen["page_size"] = request.url.params.get("page_size")
+            return httpx.Response(200, json={"results": [], "pagination": {}})
+
+        await routed(handler).list_all_courses()
+        assert seen["page_size"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_a_response_without_pagination_ends_the_walk(self, routed) -> None:
+        def handler(request):
+            return httpx.Response(200, json={"results": [{"id": "c1"}]})
+
+        assert len(await routed(handler).list_all_courses()) == 1
+
+
+class TestFetchBlocks:
+    @pytest.mark.asyncio
+    async def test_the_course_tree_is_requested_in_full_with_the_session_cookie(
+        self, routed
+    ) -> None:
+        seen = {}
+
+        def handler(request):
+            seen["params"] = dict(request.url.params)
+            seen["cookie"] = request.headers["Cookie"]
+            return httpx.Response(200, json={"blocks": {}})
+
+        await routed(handler).fetch_blocks("course-v1:A4I+S1+2026", COOKIE)
+
+        assert seen["cookie"] == COOKIE
+        assert seen["params"]["course_id"] == "course-v1:A4I+S1+2026"
+        assert (seen["params"]["depth"], seen["params"]["all_blocks"]) == ("all", "true")
+
+    @pytest.mark.asyncio
+    async def test_a_404_is_not_retried_and_surfaces(self, routed) -> None:
+        calls = []
+
+        def handler(request):
+            calls.append(request.url.path)
+            return httpx.Response(404)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await routed(handler).fetch_blocks("course-1", COOKIE)
+        assert len(calls) == 1
+
+
+class TestEnrichBlocks:
+    @pytest.mark.asyncio
+    async def test_html_blocks_get_their_xblock_body_stripped_of_staff_panels(
+        self, routed
+    ) -> None:
+        def handler(request):
+            return httpx.Response(200, text=_xblock_page("<p>Lesson one</p>"))
+
+        blocks = {"blocks": {"b1": {
+            "id": "b1", "type": "html", "student_view_url": f"{BASE_URL}/xblock/b1"
+        }}}
+
+        result = await routed(handler).enrich_blocks_with_content(blocks, COOKIE)
+
+        block = result["blocks"]["b1"]
+        assert block["student_view_html"] == "<p>Lesson one</p>"
+        assert "staff only" not in block["student_view_html"]
+        assert block["student_view_data"] is None
+
+    @pytest.mark.asyncio
+    async def test_mathtype_annotations_are_removed(self, routed) -> None:
+        def handler(request):
+            return httpx.Response(
+                200, text=_xblock_page("<p>a MathType@MTEF@junk@1A2b@ b</p>")
+            )
+
+        blocks = {"blocks": {"b1": {
+            "id": "b1", "type": "html", "student_view_url": f"{BASE_URL}/xblock/b1"
+        }}}
+
+        result = await routed(handler).enrich_blocks_with_content(blocks, COOKIE)
+        assert result["blocks"]["b1"]["student_view_html"] == "<p>a  b</p>"
+
+    @pytest.mark.asyncio
+    async def test_video_blocks_get_their_metadata_instead_of_html(self, routed) -> None:
+        metadata = {
+            "sources": ["https://cdn/v.mp4"],
+            "streams": "1.00:abc",
+            "poster": "https://cdn/p.jpg",
+            "transcriptLanguages": {"en": "English"},
+        }
+
+        attribute = json.dumps(metadata).replace('"', "&quot;")
+
+        def handler(request):
+            return httpx.Response(200, text=f'<div data-metadata="{attribute}"></div>')
+
+        blocks = {"blocks": {"v1": {
+            "id": "v1", "type": "video", "student_view_url": f"{BASE_URL}/xblock/v1"
+        }}}
+
+        result = await routed(handler).enrich_blocks_with_content(blocks, COOKIE)
+
+        block = result["blocks"]["v1"]
+        assert block["student_view_data"] == metadata
+        assert block["student_view_html"] == ""
+
+    @pytest.mark.asyncio
+    async def test_a_video_without_metadata_is_recorded_as_none(self, routed) -> None:
+        def handler(request):
+            return httpx.Response(200, text="<div>no metadata here</div>")
+
+        blocks = {"blocks": {"v1": {
+            "id": "v1", "type": "video", "student_view_url": f"{BASE_URL}/xblock/v1"
+        }}}
+
+        result = await routed(handler).enrich_blocks_with_content(blocks, COOKIE)
+        assert result["blocks"]["v1"]["student_view_data"] is None
+
+    @pytest.mark.asyncio
+    async def test_blocks_that_are_not_content_are_left_untouched(self, routed) -> None:
+        def handler(request):
+            raise AssertionError("no xblock should be fetched")
+
+        blocks = {"blocks": {
+            "chapter": {"id": "chapter", "type": "chapter",
+                        "student_view_url": f"{BASE_URL}/xblock/chapter"},
+            "no_url": {"id": "no_url", "type": "html"},
+        }}
+
+        assert await routed(handler).enrich_blocks_with_content(blocks, COOKIE) == blocks
+
+    @pytest.mark.asyncio
+    async def test_a_failing_xblock_is_reported_loudly_not_skipped(self, routed) -> None:
+        def handler(request):
+            return httpx.Response(500)
+
+        blocks = {"blocks": {"b1": {
+            "id": "b1", "type": "html", "student_view_url": f"{BASE_URL}/xblock/b1"
+        }}}
+
+        with pytest.raises(RuntimeError, match="1/1 xblocks failed to enrich"):
+            await routed(handler).enrich_blocks_with_content(blocks, COOKIE)
+
+
+class TestFetchAsset:
+    @pytest.mark.asyncio
+    async def test_a_relative_url_is_resolved_against_the_lms_base(self, routed) -> None:
+        seen = {}
+
+        def handler(request):
+            seen["url"] = str(request.url)
+            return httpx.Response(200, content=b"\x89PNG")
+
+        assert await routed(handler).fetch_asset("/asset-v1:img.png", COOKIE) == b"\x89PNG"
+        assert seen["url"] == f"{BASE_URL}/asset-v1:img.png"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_asset_raises(self, routed) -> None:
+        def handler(request):
+            return httpx.Response(404)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await routed(handler).fetch_asset("/asset-v1:gone.png", COOKIE)
+
+
+class TestRetryPolicy:
+    @pytest.mark.asyncio
+    async def test_a_429_is_retried_until_it_succeeds(self) -> None:
+        attempts = []
+
+        async def flaky():
+            attempts.append(1)
+            if len(attempts) < 3:
+                raise httpx.HTTPStatusError(
+                    "rate limited", request=httpx.Request("GET", BASE_URL),
+                    response=httpx.Response(429),
+                )
+            return "ok"
+
+        assert await module._with_retry(flaky, label="t", base_delay=0) == "ok"
+        assert len(attempts) == 3
+
+    @pytest.mark.asyncio
+    async def test_a_503_is_retried_too(self) -> None:
+        attempts = []
+
+        async def flaky():
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise httpx.HTTPStatusError(
+                    "unavailable", request=httpx.Request("GET", BASE_URL),
+                    response=httpx.Response(503, headers={"retry-after": "1"}),
+                )
+            return "ok"
+
+        assert await module._with_retry(flaky, label="t", base_delay=0) == "ok"
+
+    @pytest.mark.asyncio
+    async def test_a_network_error_is_retried(self) -> None:
+        attempts = []
+
+        async def flaky():
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise httpx.ConnectError("dns failure")
+            return "ok"
+
+        assert await module._with_retry(flaky, label="t", base_delay=0) == "ok"
+
+    @pytest.mark.asyncio
+    async def test_a_non_retryable_status_is_raised_straight_away(self) -> None:
+        attempts = []
+
+        async def failing():
+            attempts.append(1)
+            raise httpx.HTTPStatusError(
+                "forbidden", request=httpx.Request("GET", BASE_URL),
+                response=httpx.Response(403),
+            )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await module._with_retry(failing, label="t", base_delay=0)
+        assert len(attempts) == 1
+
+    @pytest.mark.asyncio
+    async def test_exhausting_the_retries_fails_with_the_label(self) -> None:
+        async def always_429():
+            raise httpx.HTTPStatusError(
+                "rate limited", request=httpx.Request("GET", BASE_URL),
+                response=httpx.Response(429),
+            )
+
+        with pytest.raises(RuntimeError, match="blocks c1 failed after 2 retries"):
+            await module._with_retry(always_429, label="blocks c1", retries=2, base_delay=0)
+
+
+class TestSingleton:
+    @pytest.mark.asyncio
+    async def test_the_client_is_reused_and_closed_once(self, monkeypatch) -> None:
+        monkeypatch.setattr(module, "_client", None)
+
+        client = get_subodha_client()
+        assert get_subodha_client() is client
+
+        await close_subodha_client()
+        assert module._client is None
+
+    @pytest.mark.asyncio
+    async def test_closing_without_a_client_is_a_no_op(self, monkeypatch) -> None:
+        monkeypatch.setattr(module, "_client", None)
+        await close_subodha_client()

--- a/platform/tests/unit/test_subodha_client.py
+++ b/platform/tests/unit/test_subodha_client.py
@@ -144,10 +144,12 @@ class TestGetSession:
         client = routed(handler)
         await client.get_session()
         client._session_expires_at = datetime.now(UTC) + timedelta(minutes=29)
+        stale_expiry = client._session_expires_at
         calls.clear()
 
         assert "sessionid=fresh" in await client.get_session()
         assert calls == ["/", "/api/user/v1/account/login_session/"]
+        assert client._session_expires_at > stale_expiry, "a re-login that keeps the old expiry re-logs in on every call"
 
     @pytest.mark.asyncio
     async def test_an_expired_session_is_replaced(self, routed) -> None:

--- a/platform/tests/unit/test_subodha_client.py
+++ b/platform/tests/unit/test_subodha_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import httpx
@@ -128,6 +129,43 @@ class TestGetSession:
 
         assert await client.get_session() == first
         assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_a_session_inside_the_renewal_window_is_replaced(self, routed) -> None:
+        """The cache is given up 30 minutes early so a call never runs on a dying session."""
+        calls = []
+
+        def handler(request):
+            calls.append(request.url.path)
+            return httpx.Response(
+                200, json={"success": True}, headers={"set-cookie": "sessionid=fresh; Path=/"}
+            )
+
+        client = routed(handler)
+        await client.get_session()
+        client._session_expires_at = datetime.now(UTC) + timedelta(minutes=29)
+        calls.clear()
+
+        assert "sessionid=fresh" in await client.get_session()
+        assert calls == ["/", "/api/user/v1/account/login_session/"]
+
+    @pytest.mark.asyncio
+    async def test_an_expired_session_is_replaced(self, routed) -> None:
+        calls = []
+
+        def handler(request):
+            calls.append(request.url.path)
+            return httpx.Response(
+                200, json={"success": True}, headers={"set-cookie": "sessionid=fresh; Path=/"}
+            )
+
+        client = routed(handler)
+        await client.get_session()
+        client._session_expires_at = datetime.now(UTC) - timedelta(days=1)
+        calls.clear()
+
+        await client.get_session()
+        assert calls == ["/", "/api/user/v1/account/login_session/"]
 
     @pytest.mark.asyncio
     async def test_clearing_the_cache_forces_a_fresh_login(self, routed) -> None:

--- a/platform/tests/unit/test_telemetry_auth.py
+++ b/platform/tests/unit/test_telemetry_auth.py
@@ -10,8 +10,10 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from jose import jwt as jose_jwt
+from opentelemetry import metrics
 from opentelemetry._logs import get_logger_provider
 from opentelemetry.sdk._logs import LoggerProvider as SDKLoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider as SDKMeterProvider
 
 import app.platform.telemetry as tel_mod
 from app.platform.auth.dependencies import require_teacher, require_tenant
@@ -46,6 +48,18 @@ _FAKE_CONNECTION_STRING = (
 
 
 class TestTelemetry:
+    @pytest.fixture(autouse=True)
+    def shutdown_exporters(self):
+        """Azure Monitor's exporter threads outlive the test and keep calling the network."""
+        yield
+        for provider in (get_logger_provider(), metrics.get_meter_provider()):
+            if isinstance(provider, SDKLoggerProvider | SDKMeterProvider):
+                provider.shutdown()
+        logging.getLogger("app").handlers.clear()
+        tel_mod._telemetry_configured = False
+        tel_mod._metrics = {}
+        configure_telemetry(Settings(applicationinsights_connection_string=""))
+
     def test_disabled_without_connection_string(self) -> None:
         """configure_telemetry with no connection string must not raise, counters stay no-op."""
         tel_mod._telemetry_configured = False

--- a/platform/tests/unit/test_vonage_actions.py
+++ b/platform/tests/unit/test_vonage_actions.py
@@ -1,0 +1,184 @@
+"""Vonage NCCO action tests — factory dispatch, accumulator, and each action's get()."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.providers.vonage_actions import (
+    InputAction,
+    StreamAction,
+    TalkAction,
+    VonageActionAccumulator,
+    VonageActionFactory,
+    VonageConnectAction,
+)
+from app.providers.vonage_actions.base.action import Action
+from app.providers.vonage_actions.vonage_input_action import VonageInputAction
+from app.providers.vonage_actions.vonage_stream_action import VonageStreamAction
+from app.providers.vonage_actions.vonage_talk_action import VonageTalkAction
+
+
+class PassThroughSas:
+    def get_url_with_sas(self, url: str) -> str:
+        return url + "?sig=stub"
+
+
+@pytest.fixture
+def factory():
+    return VonageActionFactory()
+
+
+class TestActionFactory:
+    def test_stream_action_uses_extra_args(self, factory) -> None:
+        impl = factory.get_action_implementation(
+            StreamAction(url="https://cdn/a.mp3", volume=0.5, bargeIn=False, loop=3)
+        )
+        assert isinstance(impl, VonageStreamAction)
+        assert (impl.streamUrl, impl.level, impl.bargeIn, impl.loop) == (
+            "https://cdn/a.mp3", 0.5, False, 3,
+        )
+
+    def test_stream_action_falls_back_to_class_defaults(self, factory) -> None:
+        impl = factory.get_action_implementation(StreamAction(url="https://cdn/a.mp3"))
+        assert (impl.level, impl.bargeIn, impl.loop) == (
+            VonageStreamAction.default_level,
+            VonageStreamAction.default_bargeIn,
+            VonageStreamAction.default_loop,
+        )
+
+    def test_talk_action_carries_language(self, factory) -> None:
+        impl = factory.get_action_implementation(TalkAction(text="hello", language="kn-IN"))
+        assert isinstance(impl, VonageTalkAction)
+        assert impl.language == "kn-IN"
+
+    def test_talk_action_defaults_to_en_us(self, factory) -> None:
+        impl = factory.get_action_implementation(TalkAction(text="hello"))
+        assert impl.language == VonageTalkAction.default_language
+
+    def test_input_action_prefixes_event_api_with_base_url(self, factory, monkeypatch) -> None:
+        monkeypatch.setenv("BASE_URL", "https://api.test")
+        impl = factory.get_action_implementation(
+            InputAction(type_=["dtmf"], eventApi="/input", maxDigits=4, timeOut=7, submitOnHash=True)
+        )
+        assert isinstance(impl, VonageInputAction)
+        assert impl.eventUrl == "https://api.test/input"
+        assert (impl.maxDigits, impl.timeOut, impl.submitOnHash) == (4, 7, True)
+
+    def test_input_action_defaults(self, factory, monkeypatch) -> None:
+        monkeypatch.delenv("BASE_URL", raising=False)
+        impl = factory.get_action_implementation(InputAction(type_=["dtmf"], eventApi="/input"))
+        assert (impl.eventUrl, impl.maxDigits, impl.timeOut, impl.submitOnHash) == (
+            "/input", 1, 10, False,
+        )
+
+    def test_connect_action_passes_through_unchanged(self, factory) -> None:
+        action = VonageConnectAction(websocket_uri="wss://ws.test/socket")
+        assert factory.get_action_implementation(action) is action
+
+    def test_unknown_action_type_raises(self, factory) -> None:
+        class Mystery(Action):
+            def get(self, sas_gen_obj):
+                return {}
+
+        with pytest.raises(NotImplementedError):
+            factory.get_action_implementation(Mystery())
+
+    def test_deprecated_alias_is_the_same_callable(self, factory) -> None:
+        assert VonageActionFactory.get_action_implmentation is (
+            VonageActionFactory.get_action_implementation
+        )
+
+
+class TestActionNcco:
+    def test_stream_ncco_runs_the_url_through_the_sas_generator(self) -> None:
+        action = VonageStreamAction(streamUrl="https://cdn/a.mp3", level=1, bargeIn=True, loop=2)
+        assert action.get(PassThroughSas()) == {
+            "action": "stream",
+            "streamUrl": ["https://cdn/a.mp3?sig=stub"],
+            "loop": 2,
+            "bargeIn": True,
+            "level": 1,
+        }
+
+    def test_talk_ncco(self) -> None:
+        action = VonageTalkAction(text="hi", level=1, bargeIn=False, loop=1, language="hi-IN")
+        assert action.get(PassThroughSas()) == {
+            "action": "talk",
+            "text": "hi",
+            "loop": 1,
+            "bargeIn": False,
+            "level": 1,
+            "language": "hi-IN",
+        }
+
+    def test_input_ncco_includes_dtmf_block_for_dtmf_type(self) -> None:
+        action = VonageInputAction(
+            type_=["dtmf"], maxDigits=2, eventUrl="https://api.test/input", timeOut=5,
+            submitOnHash=True,
+        )
+        ncco = action.get(PassThroughSas())
+        assert ncco["eventUrl"] == ["https://api.test/input"]
+        assert ncco["dtmf"] == {"maxDigits": 2, "submitOnHash": True, "timeOut": 5}
+
+    def test_input_ncco_omits_dtmf_block_for_speech_type(self) -> None:
+        action = VonageInputAction(
+            type_=["speech"], maxDigits=1, eventUrl="https://api.test/input", timeOut=5,
+            submitOnHash=False,
+        )
+        assert "dtmf" not in action.get(PassThroughSas())
+
+    def test_connect_ncco_omits_headers_when_empty(self) -> None:
+        ncco = VonageConnectAction(websocket_uri="wss://ws.test/s").get(PassThroughSas())
+        assert ncco["endpoint"] == [
+            {"type": "websocket", "uri": "wss://ws.test/s", "content-type": "audio/l16;rate=8000"}
+        ]
+
+    def test_connect_ncco_includes_headers_when_given(self) -> None:
+        ncco = VonageConnectAction(
+            websocket_uri="wss://ws.test/s", content_type="audio/l16;rate=16000",
+            headers={"call_id": "c1"},
+        ).get(PassThroughSas())
+        assert ncco["endpoint"][0]["headers"] == {"call_id": "c1"}
+        assert ncco["endpoint"][0]["content-type"] == "audio/l16;rate=16000"
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            StreamAction(url="https://cdn/a.mp3"),
+            TalkAction(text="hi"),
+            InputAction(type_=["dtmf"], eventApi="/input"),
+        ],
+    )
+    def test_base_actions_have_no_ncco_of_their_own(self, action) -> None:
+        with pytest.raises(NotImplementedError):
+            action.get(PassThroughSas())
+
+
+class TestActionSerialization:
+    def test_round_trip_restores_attributes(self) -> None:
+        original = VonageConnectAction(websocket_uri="wss://ws.test/s", headers={"call_id": "c1"})
+        restored = Action.from_json(original.to_json())
+        assert isinstance(restored, VonageConnectAction)
+        assert restored.websocket_uri == "wss://ws.test/s"
+        assert restored.headers == {"call_id": "c1"}
+
+    def test_repr_uses_the_str_form(self) -> None:
+        action = TalkAction(text="hi")
+        assert repr(action) == str(action) == "TalkAction: hi {}"
+
+
+class TestAccumulator:
+    def test_combine_maps_every_action_to_its_ncco_dict(self, monkeypatch) -> None:
+        accumulator = VonageActionAccumulator()
+        monkeypatch.setattr(accumulator, "_sas_gen", PassThroughSas())
+        ncco = accumulator.combine([
+            VonageTalkAction(text="hi", level=1, bargeIn=True, loop=1, language="en-US"),
+            VonageStreamAction(streamUrl="https://cdn/a.mp3", level=1, bargeIn=True, loop=1),
+        ])
+        assert [a["action"] for a in ncco] == ["talk", "stream"]
+
+    def test_combine_of_nothing_is_empty(self) -> None:
+        assert VonageActionAccumulator().combine([]) == []
+
+    def test_factory_hands_out_an_accumulator(self, factory) -> None:
+        assert isinstance(factory.get_action_accumulator_implmentation(), VonageActionAccumulator)

--- a/platform/tests/unit/test_websocket_client.py
+++ b/platform/tests/unit/test_websocket_client.py
@@ -1,0 +1,402 @@
+"""Control channel to websocket-service — envelope, connect/reconnect, dispatch, and send."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import websockets
+
+from app.models.playback_state import ContentStatus
+from app.models.ws_service_message import MessageType
+from app.providers import websocket_client
+from app.providers.websocket_client import (
+    WebsocketClientProvider,
+    WebsocketServiceMessage,
+    get_websocket_service,
+)
+from app.services.confevents.playback_state_update_event import PlaybackStateUpdateEvent
+from app.services.confevents.reconnect_comm_api_websocket_event import (
+    ReconnectCommApiWebsocketEvent,
+)
+
+CONF_ID = "conf-1"
+_real_sleep = asyncio.sleep
+
+
+async def _no_backoff(*_args) -> None:
+    await _real_sleep(0)
+
+
+async def _let_workers_run(times: int = 4) -> None:
+    for _ in range(times):
+        await _real_sleep(0)
+
+
+@pytest.fixture(autouse=True)
+def fresh_singleton(monkeypatch):
+    """WebsocketClientProvider is a process-wide singleton — do not leak it between tests."""
+    monkeypatch.setattr(WebsocketClientProvider, "_instance", None)
+    monkeypatch.setattr(websocket_client.asyncio, "sleep", _no_backoff)
+    yield
+    WebsocketClientProvider._instance = None
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    values = SimpleNamespace(websocket_service_url="wss://ws.test/socket", ws_control_secret="")
+    monkeypatch.setattr(websocket_client, "get_settings", lambda: values)
+    return values
+
+
+@pytest.fixture
+def socket():
+    ws = MagicMock()
+    ws.send = AsyncMock()
+    ws.close = AsyncMock()
+    ws.__aiter__ = lambda self: iter([])
+    return ws
+
+
+@pytest.fixture
+def connect(monkeypatch, socket):
+    connect = AsyncMock(return_value=socket)
+    monkeypatch.setattr(websocket_client.websockets, "connect", connect)
+    return connect
+
+
+@pytest.fixture
+def conf():
+    conf = MagicMock()
+    conf.queue_event = AsyncMock()
+    conf._remote_audio_queue = None
+    return conf
+
+
+@pytest.fixture
+def manager(conf):
+    manager = MagicMock()
+    manager.get_conference.return_value = conf
+    return manager
+
+
+@pytest.fixture
+async def provider(settings, connect, manager):
+    provider = WebsocketClientProvider()
+    await provider.initialize(manager)
+    await provider.close()
+    provider.is_connected = True
+    return provider
+
+
+class TestMessageEnvelope:
+    def test_optional_fields_are_left_out_when_unset(self) -> None:
+        message = WebsocketServiceMessage(websocket_id=CONF_ID, type="play", message="url")
+        assert message.model_dump() == {
+            "websocket_id": CONF_ID, "type": "play", "message": "url"
+        }
+
+    def test_optional_fields_are_included_when_set(self) -> None:
+        message = WebsocketServiceMessage(
+            websocket_id=CONF_ID, type="playback-state-update", position_seconds=1.0,
+            duration_seconds=2.0, speed=1.5,
+        )
+        assert message.model_dump() == {
+            "websocket_id": CONF_ID, "type": "playback-state-update", "message": "",
+            "position_seconds": 1.0, "duration_seconds": 2.0, "speed": 1.5,
+        }
+
+    def test_the_json_form_round_trips(self) -> None:
+        message = WebsocketServiceMessage(websocket_id=CONF_ID, type="pause")
+        assert json.loads(message.model_dump_json()) == message.model_dump()
+
+
+class TestSingleton:
+    def test_every_construction_returns_the_same_client(self) -> None:
+        assert WebsocketClientProvider() is WebsocketClientProvider()
+
+    @pytest.mark.asyncio
+    async def test_the_service_getter_returns_that_same_client(self) -> None:
+        assert await get_websocket_service() is WebsocketClientProvider()
+
+
+class TestConnect:
+    @pytest.mark.asyncio
+    async def test_initialize_connects_to_the_configured_url_and_starts_workers(
+        self, settings, connect, manager
+    ) -> None:
+        provider = WebsocketClientProvider()
+        await provider.initialize(manager)
+
+        assert connect.await_args.args[0] == "wss://ws.test/socket?id=confv2server"
+        assert provider.is_connected is True
+        assert len(provider._bg_tasks) == 2
+        await provider.close()
+
+    @pytest.mark.asyncio
+    async def test_the_control_secret_is_sent_as_a_handshake_header(
+        self, settings, connect, manager
+    ) -> None:
+        settings.ws_control_secret = "s3cret"
+        provider = WebsocketClientProvider()
+        await provider.initialize(manager)
+
+        assert connect.await_args.kwargs["additional_headers"] == {"WS-Control-Secret": "s3cret"}
+        await provider.close()
+
+    @pytest.mark.asyncio
+    async def test_no_secret_means_no_header(self, settings, connect, manager) -> None:
+        provider = WebsocketClientProvider()
+        await provider.initialize(manager)
+
+        assert connect.await_args.kwargs["additional_headers"] == {}
+        await provider.close()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_connect_is_retried_until_it_succeeds(
+        self, settings, connect, manager, socket
+    ) -> None:
+        connect.side_effect = [OSError("refused"), OSError("refused"), socket]
+        provider = WebsocketClientProvider()
+
+        await provider.initialize(manager)
+
+        assert connect.await_count == 3
+        assert provider.reconnect_attempts == 0
+        await provider.close()
+
+    @pytest.mark.asyncio
+    async def test_an_established_connection_is_not_reopened(self, provider, connect) -> None:
+        connect.reset_mock()
+        await provider._connect()
+        connect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_close_cancels_the_workers_and_shuts_the_socket(
+        self, settings, connect, manager, socket
+    ) -> None:
+        provider = WebsocketClientProvider()
+        await provider.initialize(manager)
+        tasks = list(provider._bg_tasks)
+
+        await provider.close()
+
+        assert provider._bg_tasks == []
+        assert all(task.cancelled() or task.cancelling() for task in tasks)
+        socket.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_socket_that_refuses_to_close_does_not_raise(
+        self, settings, connect, manager, socket
+    ) -> None:
+        socket.close.side_effect = RuntimeError("already gone")
+        provider = WebsocketClientProvider()
+        await provider.initialize(manager)
+
+        await provider.close()
+
+
+class TestSendMessage:
+    @pytest.mark.asyncio
+    async def test_a_message_is_serialised_onto_the_socket(self, provider, socket) -> None:
+        await provider.send_message(
+            WebsocketServiceMessage(websocket_id=CONF_ID, type="play", message="url")
+        )
+        assert json.loads(socket.send.await_args.args[0]) == {
+            "websocket_id": CONF_ID, "type": "play", "message": "url"
+        }
+
+    @pytest.mark.asyncio
+    async def test_sending_while_disconnected_is_an_error(self, provider) -> None:
+        provider.is_connected = False
+        with pytest.raises(ConnectionError, match="not connected"):
+            await provider.send_message(WebsocketServiceMessage(websocket_id=CONF_ID, type="play"))
+
+    @pytest.mark.asyncio
+    async def test_a_send_failure_marks_the_client_disconnected_and_re_raises(
+        self, provider, socket, connect
+    ) -> None:
+        socket.send.side_effect = RuntimeError("broken pipe")
+
+        with pytest.raises(RuntimeError, match="broken pipe"):
+            await provider.send_message(WebsocketServiceMessage(websocket_id=CONF_ID, type="play"))
+
+        assert connect.await_count > 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("call", "expected_type"),
+        [
+            (lambda p: p.pause_audio(CONF_ID), MessageType.PAUSE_AUDIO),
+            (lambda p: p.resume_audio(CONF_ID), MessageType.RESUME_AUDIO),
+            (lambda p: p.disconnect(CONF_ID), MessageType.DISCONNECT),
+        ],
+    )
+    async def test_the_playback_helpers_send_their_message_type(
+        self, provider, socket, call, expected_type
+    ) -> None:
+        await call(provider)
+        sent = json.loads(socket.send.await_args.args[0])
+        assert (sent["websocket_id"], sent["type"]) == (CONF_ID, expected_type)
+
+    @pytest.mark.asyncio
+    async def test_setting_the_speed_sends_it_both_ways(self, provider, socket) -> None:
+        await provider.set_playback_speed(CONF_ID, 1.5)
+        sent = json.loads(socket.send.await_args.args[0])
+        assert (sent["type"], sent["message"], sent["speed"]) == (
+            MessageType.SET_SPEED, "1.5", 1.5,
+        )
+
+
+class TestDispatchMessage:
+    @pytest.mark.asyncio
+    async def test_a_playback_state_update_is_queued_on_the_conference(
+        self, provider, conf
+    ) -> None:
+        await provider._dispatch_message(json.dumps({
+            "websocket_id": CONF_ID,
+            "type": MessageType.PLAYBACK_STATE_UPDATES,
+            "message": ContentStatus.PLAYING.value,
+            "position_seconds": 12.0,
+            "duration_seconds": 300.0,
+            "speed": 1.25,
+        }))
+
+        queued = conf.queue_event.await_args.args[0]
+        assert isinstance(queued, PlaybackStateUpdateEvent)
+        assert (queued.content_state, queued.position_seconds, queued.speed) == (
+            ContentStatus.PLAYING, 12.0, 1.25,
+        )
+
+    @pytest.mark.asyncio
+    async def test_audio_data_is_decoded_onto_the_relay_queue(self, provider, conf) -> None:
+        conf._remote_audio_queue = asyncio.Queue()
+        await provider._dispatch_message(json.dumps({
+            "websocket_id": CONF_ID,
+            "type": MessageType.AUDIO_DATA,
+            "message": base64.b64encode(b"pcm-bytes").decode(),
+        }))
+
+        assert conf._remote_audio_queue.get_nowait() == b"pcm-bytes"
+
+    @pytest.mark.asyncio
+    async def test_audio_data_without_a_relay_queue_is_dropped(self, provider, conf) -> None:
+        await provider._dispatch_message(json.dumps({
+            "websocket_id": CONF_ID,
+            "type": MessageType.AUDIO_DATA,
+            "message": base64.b64encode(b"pcm-bytes").decode(),
+        }))
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_full_relay_queue_drops_the_chunk_instead_of_raising(
+        self, provider, conf, caplog
+    ) -> None:
+        conf._remote_audio_queue = asyncio.Queue(maxsize=1)
+        conf._remote_audio_queue.put_nowait(b"already-here")
+
+        await provider._dispatch_message(json.dumps({
+            "websocket_id": CONF_ID,
+            "type": MessageType.AUDIO_DATA,
+            "message": base64.b64encode(b"pcm-bytes").decode(),
+        }))
+
+        assert conf._remote_audio_queue.qsize() == 1
+        assert "audio relay queue full" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_reconnect_request_is_queued_on_the_conference(self, provider, conf) -> None:
+        await provider._dispatch_message(
+            json.dumps({"websocket_id": CONF_ID, "type": MessageType.RECONNECT})
+        )
+        assert isinstance(conf.queue_event.await_args.args[0], ReconnectCommApiWebsocketEvent)
+
+    @pytest.mark.asyncio
+    async def test_a_message_for_an_unknown_conference_is_dropped(
+        self, provider, manager, conf
+    ) -> None:
+        manager.get_conference.return_value = None
+        await provider._dispatch_message(
+            json.dumps({"websocket_id": "nope", "type": MessageType.RECONNECT})
+        )
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_message_arriving_before_initialisation_is_dropped(
+        self, provider, conf
+    ) -> None:
+        provider._conference_manager = None
+        await provider._dispatch_message(
+            json.dumps({"websocket_id": CONF_ID, "type": MessageType.RECONNECT})
+        )
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_non_json_message_is_ignored(self, provider, conf) -> None:
+        await provider._dispatch_message("not json at all")
+        conf.queue_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_unrecognised_message_type_is_ignored(self, provider, conf) -> None:
+        await provider._dispatch_message(
+            json.dumps({"websocket_id": CONF_ID, "type": "something-else"})
+        )
+        conf.queue_event.assert_not_awaited()
+
+
+class TestBackgroundWorkers:
+    @pytest.mark.asyncio
+    async def test_the_heartbeat_pings_while_connected(self, provider, socket) -> None:
+        task = asyncio.create_task(provider._send_heartbeat())
+        await _let_workers_run()
+        task.cancel()
+
+        assert json.loads(socket.send.await_args.args[0])["type"] == "heartbeat"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_heartbeat_triggers_a_reconnect(
+        self, provider, socket, connect
+    ) -> None:
+        socket.send.side_effect = RuntimeError("broken pipe")
+        connect.reset_mock()
+
+        task = asyncio.create_task(provider._send_heartbeat())
+        await _let_workers_run()
+        task.cancel()
+
+        assert connect.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_a_closed_connection_is_reconnected_by_the_listener(
+        self, provider, socket, connect
+    ) -> None:
+        def _raise_closed(self):
+            raise websockets.exceptions.ConnectionClosedOK(None, None)
+
+        socket.__aiter__ = _raise_closed
+        connect.reset_mock()
+
+        task = asyncio.create_task(provider._listen_messages())
+        await _let_workers_run()
+        task.cancel()
+
+        assert connect.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_inbound_frames_reach_the_dispatcher(self, provider, socket, conf) -> None:
+        frame = json.dumps({"websocket_id": CONF_ID, "type": MessageType.RECONNECT})
+
+        async def _frames(self):
+            yield frame
+
+        socket.__aiter__ = _frames
+
+        task = asyncio.create_task(provider._listen_messages())
+        await _let_workers_run()
+        task.cancel()
+
+        conf.queue_event.assert_awaited()

--- a/platform/tests/unit/test_websocket_client.py
+++ b/platform/tests/unit/test_websocket_client.py
@@ -53,12 +53,18 @@ def settings(monkeypatch):
     return values
 
 
+async def _no_frames(_self):
+    """An open socket that has delivered nothing yet — async iteration, not a list."""
+    return
+    yield
+
+
 @pytest.fixture
 def socket():
     ws = MagicMock()
     ws.send = AsyncMock()
     ws.close = AsyncMock()
-    ws.__aiter__ = lambda self: iter([])
+    ws.__aiter__ = _no_frames
     return ws
 
 
@@ -374,7 +380,7 @@ class TestBackgroundWorkers:
     async def test_a_closed_connection_is_reconnected_by_the_listener(
         self, provider, socket, connect
     ) -> None:
-        async def _closes_mid_stream(self):
+        async def _closes_mid_stream(_self):
             """A closed socket yields what it had, then raises on the next frame."""
             yield json.dumps({"websocket_id": CONF_ID, "type": "ignored"})
             raise websockets.exceptions.ConnectionClosedOK(None, None)
@@ -400,7 +406,7 @@ class TestBackgroundWorkers:
     async def test_inbound_frames_reach_the_dispatcher(self, provider, socket, conf) -> None:
         frame = json.dumps({"websocket_id": CONF_ID, "type": MessageType.RECONNECT})
 
-        async def _frames(self):
+        async def _frames(_self):
             yield frame
 
         socket.__aiter__ = _frames

--- a/platform/tests/unit/test_websocket_client.py
+++ b/platform/tests/unit/test_websocket_client.py
@@ -217,7 +217,7 @@ class TestSendMessage:
             await provider.send_message(WebsocketServiceMessage(websocket_id=CONF_ID, type="play"))
 
     @pytest.mark.asyncio
-    async def test_a_send_failure_marks_the_client_disconnected_and_re_raises(
+    async def test_a_send_failure_reconnects_and_re_raises(
         self, provider, socket, connect
     ) -> None:
         socket.send.side_effect = RuntimeError("broken pipe")
@@ -374,17 +374,26 @@ class TestBackgroundWorkers:
     async def test_a_closed_connection_is_reconnected_by_the_listener(
         self, provider, socket, connect
     ) -> None:
-        def _raise_closed(self):
+        async def _closes_mid_stream(self):
+            """A closed socket yields what it had, then raises on the next frame."""
+            yield json.dumps({"websocket_id": CONF_ID, "type": "ignored"})
             raise websockets.exceptions.ConnectionClosedOK(None, None)
 
-        socket.__aiter__ = _raise_closed
+        socket.__aiter__ = _closes_mid_stream
+        dispatched = []
+        provider._dispatch_message = AsyncMock(side_effect=dispatched.append)
+        connected_when_reconnecting = []
         connect.reset_mock()
+        connect.side_effect = lambda *_a, **_kw: (
+            connected_when_reconnecting.append(provider.is_connected) or socket
+        )
 
         task = asyncio.create_task(provider._listen_messages())
         await _let_workers_run()
         task.cancel()
 
-        assert connect.await_count >= 1
+        assert dispatched, "the frames the socket did deliver must still be dispatched"
+        assert connected_when_reconnecting[0] is False, "the close must be recorded before retrying"
 
     @pytest.mark.asyncio
     async def test_inbound_frames_reach_the_dispatcher(self, provider, socket, conf) -> None:

--- a/platform/tests/unit/test_websocket_client.py
+++ b/platform/tests/unit/test_websocket_client.py
@@ -403,6 +403,53 @@ class TestBackgroundWorkers:
         assert connected_when_reconnecting[0] is False, "the close must be recorded before retrying"
 
     @pytest.mark.asyncio
+    async def test_the_reconnect_backoff_doubles_and_then_caps(
+        self, provider, monkeypatch
+    ) -> None:
+        """Without the cap an unreachable service backs off for hours."""
+        delays = []
+
+        async def _record(seconds):
+            delays.append(seconds)
+
+        monkeypatch.setattr(websocket_client.asyncio, "sleep", _record)
+        monkeypatch.setattr(websocket_client.random, "uniform", lambda _a, _b: 0.0)
+
+        for already_failed in range(6):
+            provider.reconnect_attempts = already_failed
+            await provider._attempt_reconnect()
+
+        assert delays == [2.0, 4.0, 8.0, 16.0, 30.0, 30.0]
+
+    @pytest.mark.asyncio
+    async def test_a_successful_reconnect_resets_the_backoff(
+        self, provider, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(websocket_client.asyncio, "sleep", _no_backoff)
+        provider.reconnect_attempts = 5
+        provider.is_connected = False
+
+        await provider._attempt_reconnect()
+
+        assert provider.reconnect_attempts == 0
+
+    @pytest.mark.asyncio
+    async def test_the_backoff_is_jittered(self, provider, monkeypatch) -> None:
+        """Every server-side restart reconnects every client; without jitter they stampede."""
+        delays = []
+
+        async def _record(seconds):
+            delays.append(seconds)
+
+        monkeypatch.setattr(websocket_client.asyncio, "sleep", _record)
+        monkeypatch.setattr(websocket_client.random, "uniform", lambda _a, _b: 0.7)
+
+        provider.is_connected = False
+        await provider._attempt_reconnect()
+
+        assert delays == [2.7]
+
+    @pytest.mark.asyncio
     async def test_inbound_frames_reach_the_dispatcher(self, provider, socket, conf) -> None:
         frame = json.dumps({"websocket_id": CONF_ID, "type": MessageType.RECONNECT})
 

--- a/platform/tests/unit/test_websocket_client.py
+++ b/platform/tests/unit/test_websocket_client.py
@@ -393,6 +393,7 @@ class TestBackgroundWorkers:
         task.cancel()
 
         assert dispatched, "the frames the socket did deliver must still be dispatched"
+        assert connect.await_count >= 1, "the listener must reopen the socket after a close"
         assert connected_when_reconnecting[0] is False, "the close must be recorded before retrying"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes A4i-tech/.github#501 (platform service).

## What

Adds unit and integration coverage for the platform modules that had the least, and removes a real source of noise/flakiness in the test run itself.

`pytest --ignore=tests/e2e --cov=app` on `a4i/staging`: **73%, 1165 tests**.
Same command on this branch: **80%, 1421 tests**. 647 fewer uncovered lines.

## Coverage added

| Module | Before | After |
|---|---|---|
| `services/ivr_service.py` | 43% | 98% |
| `providers/subodha_client.py` | 31% | 99% |
| `providers/websocket_client.py` | 42% | 95% |
| `providers/smartphone_connection.py` | 0% | 97% |
| `services/confevents/sink_conf_event.py` | 0% | 100% |
| `services/audio/protocols.py` | 0% | 100% |
| `controllers/playback_controller.py` | 38% | 96% |
| `services/conference_event_dispatcher.py` | 48% | 98% |
| `services/blob_service.py` | 52% | 100% |
| `services/fsm/instantiation/speed_control.py` | 48% | 100% |
| `providers/vonage_actions/*` | 36–73% | 89–100% |
| `confevents` participant + playback events | 50–68% | 100% |

The critical flows now covered end to end: starting an IVR call (daily-limit
check, stale-session cleanup, Vonage failure paths), DTMF handling including
speed control and pause/resume over the WebSocket, call lifecycle archiving,
Vonage webhook dispatch, conference roster and playback events, LMS session
auth and paged course sync, and the playback endpoints' ownership checks.

## Test reliability

**Telemetry was live during tests.** `conftest.py` set a fake
`APPLICATIONINSIGHTS_CONNECTION_STRING`, and `app/main.py` calls
`configure_telemetry(settings)` at import — so every run that imported the app
configured Azure Monitor for real. Its exporter threads resolved
`fake.example.com` on each collection interval, retried for 30s on failure, and
wrote to pytest's already-closed streams at shutdown, producing pages of
`ServiceRequestError` / `ValueError: I/O operation on closed file` tracebacks
after a green run. Telemetry now stays off by default, and the four tests that
do exercise the configured path shut their providers down afterwards.

**Weak tests replaced.** The existing `playback_controller` tests posted JSON
bodies to query-parameter endpoints and asserted
`status_code in (200, 404, 422)` — they never reached a handler, which is why
the controller sat at 38%. Replaced with tests that seed conference ownership
and assert on the event actually queued, plus the 401/403/404 and validation
paths.

## Scope

Platform (Python) only. The Node services in `ContentWebApp/`,
`teacher-webapp/`, and `websocket-service/` are untouched and would be a
follow-up under the same issue.

## Verification

- `poetry run pytest --ignore=tests/e2e --cov=app` — 1421 passed, 0 failed
- `poetry run ruff check .` — clean
- No production code changed; only `platform/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
