### PR TITLE
fix: make Login form labels visible on white card background

### DIFF
--- a/ContentWebApp/src/components/Login.js
+++ b/ContentWebApp/src/components/Login.js
@@ -66,7 +66,7 @@ const tabButtonStyle = (active) => ({
 const labelStyle = {
   fontSize: "14px",
   fontWeight: 600,
-  color: "#fff",
+  color: "#0f172a",
   marginBottom: "6px",
 };
 


### PR DESCRIPTION
Label color was #fff (white on white), making fields invisible and triggering Google Safe Browsing deceptive-page classifier. Matches Register.js which already uses #0f172a.