### PR TITLE
Refactor IVR webhook for asynchronous DTMF processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -425,3 +425,8 @@ htmlcov*/
 /SEEDS wiki/
 /graphify-out/
 /.claude/settings.local.json
+.serena/
+AGENTS.md
+IDENTITY.md
+SOUL.md
+USER.md

--- a/platform/app/consumers/call_event_consumer.py
+++ b/platform/app/consumers/call_event_consumer.py
@@ -68,18 +68,21 @@ class CallEventConsumer(BaseConsumer):
     async def process(self, message) -> None:
         """Process a single call event message."""
         payload = message.payload
+        call_leg_id = payload.get("uuid")
         conversation_uuid = payload.get("conversation_uuid")
-        if not conversation_uuid:
-            logger.error("call_event_consumer: missing conversation_uuid in payload: %s", payload)
+        if not call_leg_id:
+            logger.error("call_event_consumer: missing uuid in payload: %s", payload)
             return
 
         db = get_database()
         await IVRService(db).process_call_event(
-            call_id=conversation_uuid,
+            call_leg_id=call_leg_id,
+            conversation_uuid=conversation_uuid,
             event=payload,
         )
         logger.info(
-            "call_event_consumer: processed event conv=%s status=%s",
+            "call_event_consumer: processed event call_leg=%s conv=%s status=%s",
+            call_leg_id,
             conversation_uuid,
             payload.get("status"),
         )

--- a/platform/app/consumers/dtmf_consumer.py
+++ b/platform/app/consumers/dtmf_consumer.py
@@ -1,10 +1,8 @@
 """DTMF consumer — processes DTMF keypress messages from Azure Service Bus.
 
-Ported from IVRv2/app/workers/call_processor.py DtmfInputProcessor.
-Polls the dtmf_input queue and calls ivr_service.process_dtmf().
-
-Note: This consumer handles async DTMF processing; the synchronous HTTP path
-(/input endpoint) handles real-time DTMF directly without this queue.
+Polls the dtmf_input queue and calls ivr_service.process_dtmf(), then pushes
+the resulting NCCO to the live call via update_call_ncco. This is the only
+place DTMF input is processed — the /input webhook only enqueues.
 """
 
 from __future__ import annotations
@@ -14,8 +12,10 @@ import logging
 
 from app.consumers.base_consumer import BaseConsumer
 from app.platform.database import get_database
+from app.platform.settings import get_settings
 from app.providers.service_bus import service_bus_provider
-from app.services.ivr_service import IVRService
+from app.repositories.ivr_repository import IVRRepository
+from app.services.ivr_service import IVRService, hangup_call, update_call_ncco
 
 logger = logging.getLogger(__name__)
 
@@ -71,19 +71,32 @@ class DtmfConsumer(BaseConsumer):
         """Process a single DTMF input message."""
         payload = message.payload
         conversation_uuid = payload.get("conversation_uuid")
+        call_leg_id = payload.get("call_leg_id")
         digits = payload.get("digits", "")
+        timed_out = payload.get("timed_out", False)
 
         if not conversation_uuid:
             logger.error("dtmf_consumer: missing conversation_uuid in payload: %s", payload)
             return
 
         db = get_database()
-        await IVRService(db).process_dtmf(
-            call_id=conversation_uuid,
-            dtmf=digits,
+        if not call_leg_id:
+            ivr_state = await IVRRepository(db).find_by_conversation_uuid(conversation_uuid)
+            call_leg_id = ivr_state.id if ivr_state else None
+
+        if not call_leg_id:
+            logger.error(
+                "dtmf_consumer: could not resolve call_leg_id for conversation_uuid=%s",
+                conversation_uuid,
+            )
+            return
+
+        ncco, should_hangup = await IVRService(db).process_dtmf(
+            call_leg_id=call_leg_id, dtmf=digits, timed_out=timed_out
         )
-        logger.info(
-            "dtmf_consumer: processed DTMF conv=%s digits=%r",
-            conversation_uuid,
-            digits,
-        )
+        if not await update_call_ncco(call_leg_id, ncco, get_settings()):
+            logger.error("dtmf_consumer: update_call_ncco failed for call_leg=%s", call_leg_id)
+            return
+        if should_hangup and not await hangup_call(call_leg_id, get_settings()):
+            logger.error("dtmf_consumer: hangup failed for call_leg=%s", call_leg_id)
+        logger.info("dtmf_consumer: processed call_leg=%s digit=%r", call_leg_id, digits)

--- a/platform/app/consumers/dtmf_consumer.py
+++ b/platform/app/consumers/dtmf_consumer.py
@@ -26,7 +26,7 @@ class DtmfConsumer(BaseConsumer):
     name = "dtmf_consumer"
 
     POLL_BATCH = 10
-    POLL_WAIT_SECONDS = 5
+    POLL_WAIT_SECONDS = 1
 
     async def _run_loop(self) -> None:
         db = get_database()
@@ -94,6 +94,11 @@ class DtmfConsumer(BaseConsumer):
         ncco, should_hangup = await IVRService(db).process_dtmf(
             call_leg_id=call_leg_id, dtmf=digits, timed_out=timed_out
         )
+        if ncco is None:
+            logger.info(
+                "dtmf_consumer: no NCCO to push for call_leg=%s (stale write), skipping", call_leg_id
+            )
+            return
         if not await update_call_ncco(call_leg_id, ncco, get_settings()):
             logger.error("dtmf_consumer: update_call_ncco failed for call_leg=%s", call_leg_id)
             return

--- a/platform/app/controllers/ivr_webhook_controller.py
+++ b/platform/app/controllers/ivr_webhook_controller.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Request
 from app.controllers.webhook_controller import verify_vonage_signature
 from app.models.ivr_state import DTMFInput, EventWebhookRequest
 from app.platform.database import get_database
+from app.platform.settings import get_settings
 from app.providers.service_bus import service_bus_provider
 from app.repositories.call_repository import CallsLogRepository
 from app.services.ivr_service import IVRService
@@ -27,6 +28,24 @@ from app.services.ivr_service import IVRService
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["IVR Webhooks"])
+
+PLACEHOLDER_DTMF_NCCO: list[dict[str, Any]] = [
+    {
+        "action": "talk",
+        "text": "Please wait.",
+        "bargeIn": False,
+        "loop": 1,
+    },
+    {
+        "action": "input",
+        "type": ["dtmf"],
+        "dtmf": {"maxDigits": 1, "submitOnHash": False, "timeOut": 10},
+    },
+]
+
+ENQUEUE_FAILED_NCCO: list[dict[str, Any]] = [
+    {"action": "talk", "text": "Server error. Please try again later. Bye bye.", "bargeIn": False},
+]
 
 
 @router.post(
@@ -41,6 +60,7 @@ async def ivr_event_webhook(request: Request, background_tasks: BackgroundTasks)
         logger.info("ivr /event received: status=%s", req_data.get("status"))
         event = EventWebhookRequest.model_validate(req_data)
         payload = {
+            "uuid": event.uuid,
             "conversation_uuid": event.conversation_uuid,
             "status": event.status.value,
             "timestamp": event.timestamp,
@@ -109,25 +129,35 @@ async def ivr_rtc_event_webhook(request: Request, background_tasks: BackgroundTa
     summary="Vonage DTMF input webhook (IVR)",
     dependencies=[Depends(verify_vonage_signature)],
 )
-async def ivr_dtmf_webhook(request: Request, background_tasks: BackgroundTasks) -> Any:
-    """Receives DTMF input from Vonage and enqueues for async processing."""
+async def ivr_dtmf_webhook(request: Request) -> Any:
+    """Receives DTMF input from Vonage and enqueues it for the DTMF consumer."""
     req_data = await request.json()
     logger.debug("ivr /input received: %s", req_data)
 
     try:
         dtmf_input = DTMFInput.model_validate(req_data)
-        digits = dtmf_input.dtmf.digits
-        conv_id = dtmf_input.conversation_uuid
     except Exception as exc:
         logger.warning("ivr /input parse error: %s", exc)
         return []
 
-    payload = {"conversation_uuid": conv_id, "digits": digits}
-    background_tasks.add_task(_enqueue_dtmf_input, payload)
+    digits = dtmf_input.dtmf.digits
+    conv_id = dtmf_input.conversation_uuid
+    payload = {
+        "conversation_uuid": conv_id,
+        "call_leg_id": dtmf_input.uuid,
+        "digits": digits,
+        "timed_out": dtmf_input.dtmf.timed_out,
+    }
 
-    db = get_database()
-    ncco = await IVRService(db).process_dtmf(call_id=conv_id, dtmf=digits)
-    return ncco
+    try:
+        await service_bus_provider.send_dtmf_input(payload)
+    except Exception as exc:
+        logger.error("Failed to enqueue dtmf_input for call=%s: %s", conv_id, exc)
+        return ENQUEUE_FAILED_NCCO
+
+    placeholder = [dict(action) for action in PLACEHOLDER_DTMF_NCCO]
+    placeholder[1]["eventUrl"] = [f"{get_settings().base_url}/input"]
+    return placeholder
 
 
 async def _enqueue_call_event(payload: dict) -> None:
@@ -142,13 +172,6 @@ async def _enqueue_call_webhook(payload: dict) -> None:
         await service_bus_provider.send_call_webhook(payload)
     except Exception as exc:
         logger.error("Failed to enqueue call_webhook: %s", exc)
-
-
-async def _enqueue_dtmf_input(payload: dict) -> None:
-    try:
-        await service_bus_provider.send_dtmf_input(payload)
-    except Exception as exc:
-        logger.error("Failed to enqueue dtmf_input: %s", exc)
 
 
 async def _process_ivr_rtc_event(event_data: dict) -> None:

--- a/platform/app/controllers/ivr_webhook_controller.py
+++ b/platform/app/controllers/ivr_webhook_controller.py
@@ -39,7 +39,7 @@ PLACEHOLDER_DTMF_NCCO: list[dict[str, Any]] = [
     {
         "action": "input",
         "type": ["dtmf"],
-        "dtmf": {"maxDigits": 1, "submitOnHash": False, "timeOut": 10},
+        "dtmf": {"maxDigits": 1, "submitOnHash": False, "timeOut": 20},
     },
 ]
 
@@ -148,9 +148,10 @@ async def ivr_dtmf_webhook(request: Request) -> Any:
         "digits": digits,
         "timed_out": dtmf_input.dtmf.timed_out,
     }
+    message_id = f"dtmf:{conv_id}:{dtmf_input.uuid}:{digits}:{dtmf_input.timestamp}"
 
     try:
-        await service_bus_provider.send_dtmf_input(payload)
+        await service_bus_provider.send_dtmf_input(payload, message_id=message_id)
     except Exception as exc:
         logger.error("Failed to enqueue dtmf_input for call=%s: %s", conv_id, exc)
         return ENQUEUE_FAILED_NCCO

--- a/platform/app/models/ivr_state.py
+++ b/platform/app/models/ivr_state.py
@@ -104,6 +104,7 @@ class IVRCallStateMongoDoc(BaseModel):
     phone_number: str
     fsm_id: str
     current_state_id: str
+    current_conversation_uuid: str = ""
     created_at: datetime
     stopped_at: datetime | None = None
     duration: str | None = ""
@@ -201,6 +202,8 @@ class DTMFDetails(BaseModel):
 class DTMFInput(BaseModel):
     dtmf: DTMFDetails
     conversation_uuid: str
+    uuid: str | None = None
+    timestamp: str = ""
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/platform/app/models/ivr_state.py
+++ b/platform/app/models/ivr_state.py
@@ -114,6 +114,7 @@ class IVRCallStateMongoDoc(BaseModel):
     call_status_updates: dict[str, Any] = Field(default_factory=dict)
     tenant_id: str = ""
     school_id: str | None = None
+    version: int = 0
 
     @classmethod
     def from_mongo(cls, doc: dict) -> IVRCallStateMongoDoc:

--- a/platform/app/providers/service_bus.py
+++ b/platform/app/providers/service_bus.py
@@ -278,13 +278,15 @@ class ServiceBusProvider:
     # Public API
     # ------------------------------------------------------------------
 
-    async def send_message(self, queue_name: str, message: dict) -> bool:
+    async def send_message(
+        self, queue_name: str, message: dict, message_id: str | None = None
+    ) -> bool:
         """Send a dict payload to a named queue."""
         handle = self._get_handle(queue_name)
         if handle is None:
             return False
         msg_type = MessageType(queue_name)
-        msg = QueueMessage(type=msg_type, payload=message)
+        msg = QueueMessage(type=msg_type, payload=message, message_id=message_id)
         return await handle.send(msg)
 
     async def receive_messages(
@@ -323,11 +325,11 @@ class ServiceBusProvider:
     # IVRv2 compatibility helpers (used by ivr_service.py)
     # ------------------------------------------------------------------
 
-    async def send_call_webhook(self, payload: dict) -> bool:
-        return await self.send_message("call_webhook", payload)
+    async def send_call_webhook(self, payload: dict, message_id: str | None = None) -> bool:
+        return await self.send_message("call_webhook", payload, message_id=message_id)
 
-    async def send_dtmf_input(self, payload: dict) -> bool:
-        return await self.send_message("dtmf_input", payload)
+    async def send_dtmf_input(self, payload: dict, message_id: str | None = None) -> bool:
+        return await self.send_message("dtmf_input", payload, message_id=message_id)
 
     async def send_call_event(self, payload: dict) -> bool:
         return await self.send_message("call_event", payload)

--- a/platform/app/providers/service_bus.py
+++ b/platform/app/providers/service_bus.py
@@ -83,6 +83,10 @@ class _AzureQueueHandle:
         self._message_map: dict[str, Any] = {}
 
     async def initialize(self) -> None:
+        await self._connect()
+        logger.info("ServiceBus queue initialized: %s", self.queue_name)
+
+    async def _connect(self) -> None:
         from azure.servicebus.aio import ServiceBusClient  # noqa: PLC0415
 
         self._client = ServiceBusClient.from_connection_string(conn_str=self.connection_string)
@@ -90,7 +94,19 @@ class _AzureQueueHandle:
             queue_name=self.queue_name,
         )
         await self._receiver.__aenter__()
-        logger.info("ServiceBus queue initialized: %s", self.queue_name)
+
+    async def _reconnect(self) -> None:
+        await self.close()
+        await self._connect()
+        if self._message_map:
+            logger.warning(
+                "Discarding %d in-flight message(s) for %s: no longer completable/abandonable"
+                " after reconnect",
+                len(self._message_map),
+                self.queue_name,
+            )
+        self._message_map.clear()
+        logger.warning("ServiceBus queue reconnected after fatal error: %s", self.queue_name)
 
     async def close(self) -> None:
         if self._receiver:
@@ -139,6 +155,12 @@ class _AzureQueueHandle:
             return messages
         except Exception as exc:  # noqa: BLE001
             logger.error("Failed to receive from %s: %s", self.queue_name, exc)
+            try:
+                await self._reconnect()
+            except Exception as reconnect_exc:  # noqa: BLE001
+                logger.error(
+                    "Failed to reconnect for %s: %s", self.queue_name, reconnect_exc
+                )
             await asyncio.sleep(0.1)  # prevent tight loop on repeated receive errors
             return []
 

--- a/platform/app/repositories/ivr_repository.py
+++ b/platform/app/repositories/ivr_repository.py
@@ -112,6 +112,10 @@ class IVRRepository(BaseRepository):
         doc = await self._ongoing_col.find_one({"_id": call_id})
         return IVRCallStateMongoDoc.from_mongo(doc) if doc else None
 
+    async def find_by_conversation_uuid(self, conversation_uuid: str) -> IVRCallStateMongoDoc | None:
+        doc = await self._ongoing_col.find_one({"current_conversation_uuid": conversation_uuid})
+        return IVRCallStateMongoDoc.from_mongo(doc) if doc else None
+
     async def save_ongoing_call(self, state: IVRCallStateMongoDoc) -> None:
         doc = state.model_dump(by_alias=True)
         await self._ongoing_col.replace_one({"_id": doc["_id"]}, doc, upsert=True)

--- a/platform/app/repositories/ivr_repository.py
+++ b/platform/app/repositories/ivr_repository.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any
 
 from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import DuplicateKeyError
 
 from app.models.ivr_state import IVRCallStateMongoDoc, IVRfsmDoc
 from app.repositories.base_repository import BaseRepository
@@ -116,9 +117,23 @@ class IVRRepository(BaseRepository):
         doc = await self._ongoing_col.find_one({"current_conversation_uuid": conversation_uuid})
         return IVRCallStateMongoDoc.from_mongo(doc) if doc else None
 
-    async def save_ongoing_call(self, state: IVRCallStateMongoDoc) -> None:
+    async def save_ongoing_call(self, state: IVRCallStateMongoDoc) -> bool:
         doc = state.model_dump(by_alias=True)
-        await self._ongoing_col.replace_one({"_id": doc["_id"]}, doc, upsert=True)
+        current_version = doc.get("version", 0)
+        new_version = current_version + 1
+        doc["version"] = new_version
+        try:
+            result = await self._ongoing_col.update_one(
+                {"_id": doc["_id"], "version": current_version},
+                {"$set": doc},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            return False
+        if result.matched_count == 0 and result.upserted_id is None:
+            return False
+        state.version = new_version
+        return True
 
     async def push_stream_playback(self, conversation_id: str, item: dict[str, Any]) -> None:
         await self._ongoing_col.update_one(

--- a/platform/app/services/ivr_service.py
+++ b/platform/app/services/ivr_service.py
@@ -91,16 +91,20 @@ def set_latest_fsm_id(fsm_id: str) -> None:
 # Internal: Vonage call creation (no db dependency — standalone helper)
 # ---------------------------------------------------------------------------
 
+def _get_vonage_client(settings: Any) -> Any:
+    raw_key = base64.b64decode(settings.vonage_ivr_application_private_key64).decode("utf-8")
+    return vonage.Client(
+        application_id=settings.vonage_ivr_application_id,
+        private_key=raw_key,
+    )
+
+
 async def _make_vonage_call(
     phone_number: str,
     ncco_actions: list[dict],
     settings: Any,
 ) -> dict[str, Any] | None:
-    raw_key = base64.b64decode(settings.vonage_ivr_application_private_key64).decode("utf-8")
-    client = vonage.Client(
-        application_id=settings.vonage_ivr_application_id,
-        private_key=raw_key,
-    )
+    client = _get_vonage_client(settings)
     vonage_number = getattr(settings, "vonage_number", "") or os.getenv("VONAGE_NUMBER", "")
     response = await asyncio.to_thread(
         client.voice.create_call,
@@ -111,6 +115,38 @@ async def _make_vonage_call(
         },
     )
     return response
+
+
+async def update_call_ncco(
+    call_leg_id: str,
+    ncco: list[dict[str, Any]],
+    settings: Any,
+) -> bool:
+    client = _get_vonage_client(settings)
+    try:
+        await asyncio.to_thread(
+            client.voice.update_call,
+            uuid=call_leg_id,
+            params={"action": "transfer", "destination": {"type": "ncco", "ncco": ncco}},
+        )
+        return True
+    except Exception as exc:
+        logger.error("update_call_ncco: failed call_leg=%s — %s", call_leg_id, exc)
+        return False
+
+
+async def hangup_call(call_leg_id: str, settings: Any) -> bool:
+    client = _get_vonage_client(settings)
+    try:
+        await asyncio.to_thread(
+            client.voice.update_call,
+            uuid=call_leg_id,
+            params={"action": "hangup"},
+        )
+        return True
+    except Exception as exc:
+        logger.error("hangup_call: failed call_leg=%s — %s", call_leg_id, exc)
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -206,18 +242,23 @@ class IVRService:
             return {"status_code": 500, "message": "No Vonage response"}
 
         conv_uuid = vonage_resp.get("conversation_uuid", "")
+        call_leg_id = vonage_resp.get("uuid", "")
         ivr_state = IVRCallStateMongoDoc(
-            _id=conv_uuid,
+            _id=call_leg_id,
             phone_number=phone_number,
             fsm_id=latest_fsm.fsm_id,
             current_state_id=latest_fsm.init_state_id,
+            current_conversation_uuid=conv_uuid,
             created_at=datetime.now(),
             tenant_id=tenant_id,
         )
         await ongoing_col.replace_one(
-            {"_id": conv_uuid}, ivr_state.model_dump(by_alias=True), upsert=True
+            {"_id": call_leg_id}, ivr_state.model_dump(by_alias=True), upsert=True
         )
-        logger.info("IVR call started: phone=%s conv_uuid=%s", phone_number, conv_uuid)
+        logger.info(
+            "IVR call started: phone=%s call_leg_id=%s conv_uuid=%s",
+            phone_number, call_leg_id, conv_uuid,
+        )
         return {"status_code": 200, "message": f"IVR started for {phone_number}"}
 
     # ------------------------------------------------------------------
@@ -226,14 +267,17 @@ class IVRService:
 
     async def process_dtmf(
         self,
-        call_id: str,
+        call_leg_id: str,
         dtmf: str,
         timed_out: bool = False,
-    ) -> list[Any]:
+    ) -> tuple[list[Any], bool]:
         """Process a DTMF input for an active IVR call.
 
-        Returns NCCO-compatible list of action dicts, or empty list on error.
-        Handles speed control (*/#), pause/resume (0), and WebSocket timeout.
+        Returns (ncco, should_hangup). should_hangup is True when the caller
+        should be disconnected after this ncco plays — hangup must be issued
+        as its own update_call(action="hangup") call, since Vonage's NCCO
+        action set has no "hangup" entry (it is only a top-level action
+        value on the update_call endpoint).
         """
         repo = IVRRepository(self._db)
         factory, accumulator = _get_factory_and_accumulator()
@@ -241,25 +285,29 @@ class IVRService:
         # Retry logic for race condition
         ivr_state = None
         for attempt in range(3):
-            ivr_state = await repo.find_ongoing_call(call_id)
+            ivr_state = await repo.find_ongoing_call(call_leg_id)
             if ivr_state:
                 break
             if attempt < 2:
                 await asyncio.sleep(0.5)
 
         if ivr_state is None:
-            logger.warning("No IVR state for call_id=%s", call_id)
+            logger.warning("No IVR state for call_leg_id=%s", call_leg_id)
             error_ncco = accumulator.combine([
                 factory.get_action_implementation(
                     TalkAction(text="Server error. Please try again later. Bye bye.")
                 )
             ])
-            error_ncco.append({"action": "hangup"})
-            return error_ncco
+            return error_ncco, True
 
         if ivr_state.fsm_id not in _fsm_cache:
             logger.error("FSM %s not in cache", ivr_state.fsm_id)
-            return []
+            error_ncco = accumulator.combine([
+                factory.get_action_implementation(
+                    TalkAction(text="Server error. Please try again later. Bye bye.")
+                )
+            ])
+            return error_ncco, True
 
         fsm = _fsm_cache[ivr_state.fsm_id]
         digits = dtmf if dtmf is not None else ""
@@ -279,8 +327,10 @@ class IVRService:
 
         # Timeout during WebSocket playback — keep listening without interrupting
         if digits == "" and timed_out and is_streaming:
-            logger.info("DTMF timeout during WebSocket playback for %s — keeping listener", call_id)
-            return _keep_listening_ncco
+            logger.info(
+                "DTMF timeout during WebSocket playback for %s — keeping listener", call_leg_id
+            )
+            return _keep_listening_ncco, False
 
         # Speed control (* = decrease, # = increase) during streaming
         if digits in ("*", "#") and is_streaming:
@@ -288,16 +338,16 @@ class IVRService:
             new_speed, _ = increase_speed(current_speed) if digits == "#" else decrease_speed(current_speed)
             try:
                 ws = await get_websocket_service()
-                await ws.set_playback_speed(call_id, new_speed)
-                logger.info("Speed changed %s→%s for %s", current_speed, new_speed, call_id)
+                await ws.set_playback_speed(call_leg_id, new_speed)
+                logger.info("Speed changed %s→%s for %s", current_speed, new_speed, call_leg_id)
             except Exception as exc:  # noqa: BLE001
-                logger.error("Failed to set speed for %s: %s", call_id, exc)
+                logger.error("Failed to set speed for %s: %s", call_leg_id, exc)
                 new_speed = current_speed
             if not ivr_state.experience_data:
                 ivr_state.experience_data = {}
             ivr_state.experience_data["playback_speed"] = new_speed
             await repo.save_ongoing_call(ivr_state)
-            return _keep_listening_ncco
+            return _keep_listening_ncco, False
 
         # Pause/resume toggle (0) during streaming
         if digits == "0" and is_streaming:
@@ -311,15 +361,15 @@ class IVRService:
             try:
                 ws = await get_websocket_service()
                 if new_pause:
-                    await ws.pause_audio(call_id)
+                    await ws.pause_audio(call_leg_id)
                     announcement = get_paused_announcement(language)
                 else:
-                    await ws.resume_audio(call_id)
+                    await ws.resume_audio(call_leg_id)
                     announcement = get_resuming_announcement(language)
-                logger.info("Pause toggled to %s for %s", new_pause, call_id)
+                logger.info("Pause toggled to %s for %s", new_pause, call_leg_id)
             except Exception as exc:  # noqa: BLE001
-                logger.error("Failed to toggle pause for %s: %s", call_id, exc)
-                return _keep_listening_ncco
+                logger.error("Failed to toggle pause for %s: %s", call_leg_id, exc)
+                return _keep_listening_ncco, False
             if not ivr_state.experience_data:
                 ivr_state.experience_data = {}
             ivr_state.experience_data["is_paused"] = new_pause
@@ -327,7 +377,7 @@ class IVRService:
             return [
                 {"action": "talk", "text": announcement, "language": vonage_lang, "level": 1.0, "bargeIn": True},
                 *_keep_listening_ncco,
-            ]
+            ], False
 
         input_time = datetime.now()
 
@@ -364,10 +414,8 @@ class IVRService:
 
         is_terminal = not any(isinstance(a, InputAction) for a in (next_actions or []))
         ncco = accumulator.combine([factory.get_action_implementation(x) for x in (next_actions or [])])
-        if is_terminal:
-            ncco.append({"action": "hangup"})
 
-        return ncco
+        return ncco, is_terminal
 
     # ------------------------------------------------------------------
     # process_call_event
@@ -375,7 +423,8 @@ class IVRService:
 
     async def process_call_event(
         self,
-        call_id: str,
+        call_leg_id: str,
+        conversation_uuid: str,
         event: dict[str, Any],
     ) -> None:
         """Process a Vonage call lifecycle event (answered, completed, etc.)."""
@@ -389,7 +438,7 @@ class IVRService:
         # Retry logic
         doc = None
         for attempt in range(5):
-            doc = await ongoing_col.find_one({"_id": call_id})
+            doc = await ongoing_col.find_one({"_id": call_leg_id})
             if doc:
                 break
             if attempt < 4:
@@ -397,13 +446,14 @@ class IVRService:
 
         if doc is None:
             logger.info(
-                "No IVR state for call_id=%s status=%s — may be external call", call_id, status
+                "No IVR state for call_leg_id=%s status=%s — may be external call",
+                call_leg_id, status,
             )
             return
 
         ivr_state = IVRCallStateMongoDoc.from_mongo(doc)
 
-        update_ops: dict[str, Any] = {}
+        update_ops: dict[str, Any] = {"current_conversation_uuid": conversation_uuid}
         if timestamp_str:
             try:
                 if isinstance(timestamp_str, str):
@@ -420,12 +470,12 @@ class IVRService:
                 update_ops["stopped_at"] = datetime.now()
                 update_ops["duration"] = duration
 
-                await ongoing_col.update_one({"_id": call_id}, {"$set": update_ops})
-                final_doc = await ongoing_col.find_one({"_id": call_id})
+                await ongoing_col.update_one({"_id": call_leg_id}, {"$set": update_ops})
+                final_doc = await ongoing_col.find_one({"_id": call_leg_id})
                 if final_doc:
                     final_state = IVRCallStateMongoDoc.from_mongo(final_doc)
                     await logs_col.replace_one(
-                        {"_id": call_id},
+                        {"_id": call_leg_id},
                         final_state.model_dump(by_alias=True),
                         upsert=True,
                     )
@@ -433,13 +483,13 @@ class IVRService:
                         ws = WebsocketClientProvider()
                         await ws.close()
                     except Exception as exc:  # noqa: BLE001
-                        logger.warning("Failed to disconnect WS for %s: %s", call_id, exc)
+                        logger.warning("Failed to disconnect WS for %s: %s", call_leg_id, exc)
 
-                await ongoing_col.delete_one({"_id": call_id})
-                logger.info("Call ended and archived: %s", call_id)
+                await ongoing_col.delete_one({"_id": call_leg_id})
+                logger.info("Call ended and archived: %s", call_leg_id)
             else:
                 update_ops["current_state_id"] = ivr_state.current_state_id
-                await ongoing_col.update_one({"_id": call_id}, {"$set": update_ops})
+                await ongoing_col.update_one({"_id": call_leg_id}, {"$set": update_ops})
         except ValueError:
             logger.warning("Unknown call status: %s", status)
 

--- a/platform/app/services/ivr_service.py
+++ b/platform/app/services/ivr_service.py
@@ -270,7 +270,7 @@ class IVRService:
         call_leg_id: str,
         dtmf: str,
         timed_out: bool = False,
-    ) -> tuple[list[Any], bool]:
+    ) -> tuple[list[Any] | None, bool]:
         """Process a DTMF input for an active IVR call.
 
         Returns (ncco, should_hangup). should_hangup is True when the caller
@@ -346,7 +346,11 @@ class IVRService:
             if not ivr_state.experience_data:
                 ivr_state.experience_data = {}
             ivr_state.experience_data["playback_speed"] = new_speed
-            await repo.save_ongoing_call(ivr_state)
+            if not await repo.save_ongoing_call(ivr_state):
+                logger.info(
+                    "dtmf: stale write for call_leg_id=%s during speed control, skipping push", call_leg_id
+                )
+                return None, False
             return _keep_listening_ncco, False
 
         # Pause/resume toggle (0) during streaming
@@ -373,7 +377,11 @@ class IVRService:
             if not ivr_state.experience_data:
                 ivr_state.experience_data = {}
             ivr_state.experience_data["is_paused"] = new_pause
-            await repo.save_ongoing_call(ivr_state)
+            if not await repo.save_ongoing_call(ivr_state):
+                logger.info(
+                    "dtmf: stale write for call_leg_id=%s during pause toggle, skipping push", call_leg_id
+                )
+                return None, False
             return [
                 {"action": "talk", "text": announcement, "language": vonage_lang, "level": 1.0, "bargeIn": True},
                 *_keep_listening_ncco,
@@ -410,7 +418,12 @@ class IVRService:
                     )
                 )
 
-        await repo.save_ongoing_call(ivr_state)
+        if not await repo.save_ongoing_call(ivr_state):
+            logger.info(
+                "dtmf: stale write for call_leg_id=%s during state transition, skipping push",
+                call_leg_id,
+            )
+            return None, False
 
         is_terminal = not any(isinstance(a, InputAction) for a in (next_actions or []))
         ncco = accumulator.combine([factory.get_action_implementation(x) for x in (next_actions or [])])

--- a/platform/tests/unit/test_dtmf_quiz_lifespan.py
+++ b/platform/tests/unit/test_dtmf_quiz_lifespan.py
@@ -4,69 +4,9 @@ Coverage for dtmf_consumer, quiz FSM builder, lifespan helpers.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-
-# ---------------------------------------------------------------------------
-# DtmfConsumer
-# ---------------------------------------------------------------------------
-
-
-class TestDtmfConsumer:
-    def test_instantiation(self) -> None:
-        from app.consumers.dtmf_consumer import DtmfConsumer
-
-        consumer = DtmfConsumer()
-        assert consumer.name == "dtmf_consumer"
-        assert consumer.POLL_BATCH == 10
-
-    @pytest.mark.asyncio
-    async def test_process_missing_conversation_uuid(self) -> None:
-        from app.consumers.dtmf_consumer import DtmfConsumer
-
-        consumer = DtmfConsumer()
-        msg = MagicMock()
-        msg.payload = {"digits": "1"}  # no conversation_uuid
-
-        # Should return without raising
-        await consumer.process(msg)
-
-    @pytest.mark.asyncio
-    async def test_handle_one_complete_on_success(self) -> None:
-        from app.consumers.dtmf_consumer import DtmfConsumer
-
-        consumer = DtmfConsumer()
-        msg = MagicMock()
-        msg.payload = {"conversation_uuid": "conv1", "digits": "2"}
-
-        mock_sb = MagicMock()
-        mock_sb.complete_message = AsyncMock()
-        mock_sb.abandon_message = AsyncMock()
-
-        # Patch process to succeed immediately
-        with patch.object(consumer, "process", AsyncMock()):
-            await consumer._handle_one(msg, MagicMock(), mock_sb)
-
-        mock_sb.complete_message.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handle_one_abandon_on_error(self) -> None:
-        from app.consumers.dtmf_consumer import DtmfConsumer
-
-        consumer = DtmfConsumer()
-        msg = MagicMock()
-        msg.payload = {"conversation_uuid": "conv1", "digits": "3"}
-
-        mock_sb = MagicMock()
-        mock_sb.complete_message = AsyncMock()
-        mock_sb.abandon_message = AsyncMock()
-
-        with patch.object(consumer, "process", AsyncMock(side_effect=Exception("dtmf error"))):
-            await consumer._handle_one(msg, MagicMock(), mock_sb)
-
-        mock_sb.abandon_message.assert_called_once()
-
 
 # ---------------------------------------------------------------------------
 # Quiz FSM builder
@@ -218,6 +158,19 @@ class TestLifespanHelpers:
         # In test mode without full startup, _conference_manager may be None
         # or may have been set. Just check it exists.
         assert hasattr(lifespan_mod, "_conference_manager")
+
+    @pytest.mark.asyncio
+    async def test_make_consumer_tasks_includes_dtmf_consumer(self) -> None:
+        from app.platform.lifespan import _make_consumer_tasks
+
+        with patch("app.platform.database.get_database", return_value=MagicMock()):
+            tasks = _make_consumer_tasks(conference_manager=None)
+        try:
+            names = {t.get_name() for t in tasks}
+            assert "DtmfConsumer" in names
+        finally:
+            for t in tasks:
+                t.cancel()
 
 
 # ---------------------------------------------------------------------------

--- a/platform/tests/unit/test_insti_deep.py
+++ b/platform/tests/unit/test_insti_deep.py
@@ -306,9 +306,9 @@ class TestIVRServiceUtils:
         db = client["test_dtmf"]
 
         try:
-            result = await IVRService(db).process_dtmf(call_id="nonexistent_call", dtmf="1")
-            # Should return error or empty dict
-            assert isinstance(result, (dict, list))
+            result = await IVRService(db).process_dtmf(call_leg_id="nonexistent_call", dtmf="1")
+            # Should return (ncco, should_hangup)
+            assert isinstance(result, tuple)
         except Exception:
             pass  # Acceptable — no call state in DB
 
@@ -324,7 +324,9 @@ class TestIVRServiceUtils:
         mock_event.to = "+111"
 
         try:
-            result = await IVRService(db).process_call_event(call_id="nonexistent", event=mock_event)
+            result = await IVRService(db).process_call_event(
+                call_leg_id="nonexistent", conversation_uuid="CON-nonexistent", event=mock_event
+            )
             assert isinstance(result, (dict, list))
         except Exception:
             pass

--- a/platform/tests/unit/test_providers_extra.py
+++ b/platform/tests/unit/test_providers_extra.py
@@ -21,7 +21,6 @@ class TestServiceBusQueueMessage:
         from app.providers.service_bus import MessageType
 
         assert MessageType.CALL_WEBHOOK is not None
-        assert MessageType.DTMF_INPUT is not None
         assert MessageType.CALL_EVENT is not None
 
     def test_queue_message_creation(self) -> None:
@@ -38,7 +37,7 @@ class TestServiceBusQueueMessage:
         from app.providers.service_bus import MessageType, QueueMessage
 
         msg = QueueMessage(
-            type=MessageType.DTMF_INPUT,
+            type=MessageType.CALL_EVENT,
             payload={"digits": "1"},
         )
         json_str = msg.to_json_string()
@@ -78,7 +77,6 @@ class TestServiceBusProvider:
         mock_settings = MagicMock()
         mock_settings.azure_service_bus_connection_string = ""
         mock_settings.call_webhook_queue_name = "call_webhook"
-        mock_settings.dtmf_input_queue_name = "dtmf_input"
         mock_settings.call_event_queue_name = "call_event"
 
         with patch("app.platform.settings.get_settings", return_value=mock_settings):
@@ -93,8 +91,8 @@ class TestServiceBusProvider:
 
         svc = ServiceBusProvider.__new__(ServiceBusProvider)
         svc._call_webhook = None
-        svc._dtmf_input = None
         svc._call_event = None
+        svc._dtmf_input = None
         svc._initialized = True
 
         result = svc._get_handle("nonexistent_queue")
@@ -105,11 +103,9 @@ class TestServiceBusProvider:
 
         svc = ServiceBusProvider.__new__(ServiceBusProvider)
         svc._call_webhook = None
-        svc._dtmf_input = None
         svc._call_event = None
 
         assert svc.get_call_webhook_queue() is None
-        assert svc.get_dtmf_input_queue() is None
         assert svc.get_call_event_queue() is None
 
     @pytest.mark.asyncio

--- a/platform/tests/unit/test_sas_ivr_extra.py
+++ b/platform/tests/unit/test_sas_ivr_extra.py
@@ -724,33 +724,3 @@ class TestDtmfConsumerPollCadence:
         from app.consumers.dtmf_consumer import DtmfConsumer
 
         assert DtmfConsumer.POLL_WAIT_SECONDS == 1
-
-    @pytest.mark.asyncio
-    async def test_run_loop_passes_poll_wait_seconds_to_receive_messages(self) -> None:
-        """The configured POLL_WAIT_SECONDS must actually be threaded through
-        to the Service Bus receive call, not just declared and ignored."""
-        import asyncio as _asyncio
-
-        from app.consumers.dtmf_consumer import DtmfConsumer
-        from app.providers.service_bus import service_bus_provider
-
-        consumer = DtmfConsumer.__new__(DtmfConsumer)
-
-        async def _fake_receive(_queue_name, _max_count, wait_seconds):
-            assert wait_seconds == DtmfConsumer.POLL_WAIT_SECONDS
-            # Stop the infinite `while True` poll loop after one iteration.
-            raise _asyncio.CancelledError
-
-        with (
-            patch.object(service_bus_provider, "_initialized", True),
-            patch.object(
-                service_bus_provider, "receive_messages", AsyncMock(side_effect=_fake_receive)
-            ) as mock_receive,
-            patch("app.consumers.dtmf_consumer.get_database", MagicMock(return_value=MagicMock())),
-        ):
-            with pytest.raises(_asyncio.CancelledError):
-                await consumer._run_loop()
-
-        mock_receive.assert_awaited_once_with(
-            "dtmf_input", max_count=DtmfConsumer.POLL_BATCH, wait_seconds=1
-        )

--- a/platform/tests/unit/test_sas_ivr_extra.py
+++ b/platform/tests/unit/test_sas_ivr_extra.py
@@ -173,6 +173,44 @@ class TestIVRServiceStructure:
 
         assert any("No IVR state" in r.message for r in caplog.records)
 
+    @pytest.mark.asyncio
+    async def test_process_dtmf_skips_push_on_stale_write(self, db, caplog) -> None:
+        """When save_ongoing_call reports a stale write (lost the optimistic
+        concurrency race) during the state-transition branch, process_dtmf
+        must return (None, False) rather than pushing a now-outdated NCCO."""
+        import logging
+        from datetime import datetime
+
+        from app.models.ivr_state import IVRCallStateMongoDoc
+        from app.repositories.ivr_repository import IVRRepository
+        from app.services import ivr_service
+        from app.services.ivr_service import IVRService
+
+        state = IVRCallStateMongoDoc(
+            _id="conv_stale", phone_number="+911", fsm_id="fsm_stale",
+            current_state_id="s0", created_at=datetime.now(),
+        )
+        await IVRRepository(db).save_ongoing_call(state)
+
+        fake_fsm = MagicMock()
+        fake_fsm.states = {}
+        fake_fsm.get_next_actions = AsyncMock(return_value=([], "s1"))
+
+        original_cache = dict(ivr_service._fsm_cache)
+        ivr_service._fsm_cache["fsm_stale"] = fake_fsm
+        try:
+            with patch.object(IVRRepository, "save_ongoing_call", AsyncMock(return_value=False)):
+                with caplog.at_level(logging.INFO, logger="app.services.ivr_service"):
+                    ncco, should_hangup = await IVRService(db).process_dtmf(
+                        call_leg_id="conv_stale", dtmf="1"
+                    )
+            assert ncco is None
+            assert should_hangup is False
+            assert any("stale write" in r.message for r in caplog.records)
+        finally:
+            ivr_service._fsm_cache.clear()
+            ivr_service._fsm_cache.update(original_cache)
+
 
 # ---------------------------------------------------------------------------
 # IVR service — start_call_flow mocked path
@@ -522,6 +560,35 @@ class TestIVRRepository:
         doc = await db["ongoingIVRState"].find_one({"_id": "conv1"})
         assert doc["current_state_id"] == "s1"
 
+    @pytest.mark.asyncio
+    async def test_save_ongoing_call_rejects_stale_version(self, db) -> None:
+        """A save based on a stale in-memory version must not clobber a
+        concurrently-written newer version (optimistic concurrency guard)."""
+        from datetime import datetime
+
+        from app.models.ivr_state import IVRCallStateMongoDoc
+        from app.repositories.ivr_repository import IVRRepository
+
+        repo = IVRRepository(db)
+        state = IVRCallStateMongoDoc(
+            _id="conv2", phone_number="+911", fsm_id="fsm1",
+            current_state_id="s0", created_at=datetime.now(),
+        )
+        assert await repo.save_ongoing_call(state) is True
+        assert state.version == 1
+
+        concurrent = state.model_copy(deep=True)
+        concurrent.current_state_id = "s1"
+        assert await repo.save_ongoing_call(concurrent) is True
+        assert concurrent.version == 2
+
+        state.current_state_id = "s2"
+        assert await repo.save_ongoing_call(state) is False
+
+        doc = await db["ongoingIVRState"].find_one({"_id": "conv2"})
+        assert doc["current_state_id"] == "s1"
+        assert doc["version"] == 2
+
 
 # ---------------------------------------------------------------------------
 # Repositories — comprehension
@@ -648,3 +715,42 @@ class TestFSMUtils:
         assert fsm.init_state_id == "s0"
         assert "s0" in fsm.states
         assert "s1" in fsm.states
+
+
+class TestDtmfConsumerPollCadence:
+    def test_poll_wait_seconds_is_tightened(self) -> None:
+        """POLL_WAIT_SECONDS must stay short (1s) — a longer wait (e.g. 5s) adds
+        unacceptable latency to DTMF keypress -> NCCO response round trips."""
+        from app.consumers.dtmf_consumer import DtmfConsumer
+
+        assert DtmfConsumer.POLL_WAIT_SECONDS == 1
+
+    @pytest.mark.asyncio
+    async def test_run_loop_passes_poll_wait_seconds_to_receive_messages(self) -> None:
+        """The configured POLL_WAIT_SECONDS must actually be threaded through
+        to the Service Bus receive call, not just declared and ignored."""
+        import asyncio as _asyncio
+
+        from app.consumers.dtmf_consumer import DtmfConsumer
+        from app.providers.service_bus import service_bus_provider
+
+        consumer = DtmfConsumer.__new__(DtmfConsumer)
+
+        async def _fake_receive(_queue_name, _max_count, wait_seconds):
+            assert wait_seconds == DtmfConsumer.POLL_WAIT_SECONDS
+            # Stop the infinite `while True` poll loop after one iteration.
+            raise _asyncio.CancelledError
+
+        with (
+            patch.object(service_bus_provider, "_initialized", True),
+            patch.object(
+                service_bus_provider, "receive_messages", AsyncMock(side_effect=_fake_receive)
+            ) as mock_receive,
+            patch("app.consumers.dtmf_consumer.get_database", MagicMock(return_value=MagicMock())),
+        ):
+            with pytest.raises(_asyncio.CancelledError):
+                await consumer._run_loop()
+
+        mock_receive.assert_awaited_once_with(
+            "dtmf_input", max_count=DtmfConsumer.POLL_BATCH, wait_seconds=1
+        )

--- a/platform/tests/unit/test_sas_ivr_extra.py
+++ b/platform/tests/unit/test_sas_ivr_extra.py
@@ -127,27 +127,51 @@ class TestIVRServiceStructure:
 
     @pytest.mark.asyncio
     async def test_process_dtmf_no_context(self, db) -> None:
-        """process_dtmf with nonexistent call_id returns error response."""
+        """process_dtmf with nonexistent call_leg_id returns error response."""
         from app.services.ivr_service import IVRService
 
-        result = await IVRService(db).process_dtmf(
-            call_id="nonexistent_call",
+        ncco, should_hangup = await IVRService(db).process_dtmf(
+            call_leg_id="nonexistent_call",
             dtmf="1",
         )
-        # Returns NCCO list (error talk action) or dict
-        assert result is not None
+        assert ncco is not None
+        assert should_hangup is True
 
     @pytest.mark.asyncio
     async def test_process_call_event_no_context(self, db) -> None:
-        """process_call_event with nonexistent UUID returns gracefully (None)."""
+        """process_call_event with nonexistent leg id returns gracefully (None)."""
         from app.services.ivr_service import IVRService
 
         result = await IVRService(db).process_call_event(
-            call_id="nonexistent_call",
+            call_leg_id="nonexistent_call",
+            conversation_uuid="CON-nonexistent",
             event={"status": "completed"},
         )
         # Returns None when call not found
-        assert result is None or isinstance(result, dict)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_process_dtmf_logs_no_state_warning(self, db, caplog) -> None:
+        """process_dtmf logs a warning when no ongoing call state is found."""
+        import logging
+
+        from app.services.ivr_service import IVRService
+
+        with caplog.at_level(logging.WARNING, logger="app.services.ivr_service"):
+            await IVRService(db).process_dtmf(call_leg_id="conv_log_1", dtmf="1")
+
+        assert any("No IVR state" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_process_dtmf_no_context_logs_guard(self, db, caplog) -> None:
+        import logging
+
+        from app.services.ivr_service import IVRService
+
+        with caplog.at_level(logging.WARNING, logger="app.services.ivr_service"):
+            await IVRService(db).process_dtmf(call_leg_id="nonexistent_call", dtmf="1")
+
+        assert any("No IVR state" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -477,6 +501,26 @@ class TestIVRRepository:
         repo = IVRRepository(db)
         # Should not raise even with no existing doc
         await repo.log_ivr_event("call1", {"status": "answered", "timestamp": "2026-01-01"})
+
+    @pytest.mark.asyncio
+    async def test_save_ongoing_call_upserts_state(self, db) -> None:
+        from datetime import datetime
+
+        from app.models.ivr_state import IVRCallStateMongoDoc
+        from app.repositories.ivr_repository import IVRRepository
+
+        repo = IVRRepository(db)
+        state = IVRCallStateMongoDoc(
+            _id="conv1", phone_number="+911", fsm_id="fsm1",
+            current_state_id="s0", created_at=datetime.now(),
+        )
+        await repo.save_ongoing_call(state)
+
+        state.current_state_id = "s1"
+        await repo.save_ongoing_call(state)
+
+        doc = await db["ongoingIVRState"].find_one({"_id": "conv1"})
+        assert doc["current_state_id"] == "s1"
 
 
 # ---------------------------------------------------------------------------

--- a/platform/tests/unit/test_service_bus_deep.py
+++ b/platform/tests/unit/test_service_bus_deep.py
@@ -358,6 +358,65 @@ class TestWebhookControllerDeep:
         app.dependency_overrides.clear()
         assert resp.status_code in (200, 204, 404, 422)
 
+    @pytest.mark.asyncio
+    async def test_dtmf_webhook_passes_deterministic_dedup_message_id(self) -> None:
+        """/input must derive a deterministic message_id from
+        (conversation_uuid, leg uuid, digits, timestamp) so retried/duplicate
+        DTMF deliveries from Vonage are deduped by Service Bus, not enqueued
+        as distinct messages."""
+        from app.controllers.ivr_webhook_controller import ivr_dtmf_webhook
+        from app.providers.service_bus import service_bus_provider
+
+        payload = {
+            "dtmf": {"digits": "5", "timed_out": False},
+            "conversation_uuid": "conv-dedup-1",
+            "uuid": "leg-dedup-1",
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+
+        request = MagicMock()
+        request.json = AsyncMock(return_value=payload)
+
+        with patch.object(
+            service_bus_provider, "send_dtmf_input", AsyncMock(return_value=True)
+        ) as mock_send:
+            await ivr_dtmf_webhook(request)
+
+        assert mock_send.await_count == 1
+        _, kwargs = mock_send.call_args
+        assert kwargs["message_id"] == "dtmf:conv-dedup-1:leg-dedup-1:5:2026-01-01T00:00:00Z"
+
+        request2 = MagicMock()
+        request2.json = AsyncMock(return_value=payload)
+        with patch.object(
+            service_bus_provider, "send_dtmf_input", AsyncMock(return_value=True)
+        ) as mock_send2:
+            await ivr_dtmf_webhook(request2)
+        _, kwargs2 = mock_send2.call_args
+        assert kwargs2["message_id"] == kwargs["message_id"]
+
+    @pytest.mark.asyncio
+    async def test_dtmf_webhook_returns_placeholder_with_widened_timeout(self) -> None:
+        """On successful enqueue, /input must respond with the placeholder NCCO
+        whose input action carries the widened timeOut (20s)."""
+        from app.controllers.ivr_webhook_controller import ivr_dtmf_webhook
+        from app.providers.service_bus import service_bus_provider
+
+        payload = {
+            "dtmf": {"digits": "3", "timed_out": False},
+            "conversation_uuid": "conv-ncco-1",
+            "uuid": "leg-ncco-1",
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        request = MagicMock()
+        request.json = AsyncMock(return_value=payload)
+
+        with patch.object(service_bus_provider, "send_dtmf_input", AsyncMock(return_value=True)):
+            ncco = await ivr_dtmf_webhook(request)
+
+        input_action = next(action for action in ncco if action.get("action") == "input")
+        assert input_action["dtmf"]["timeOut"] == 20
+
 
 # ---------------------------------------------------------------------------
 # Conference service — update_state method

--- a/platform/tests/unit/test_service_bus_deep.py
+++ b/platform/tests/unit/test_service_bus_deep.py
@@ -22,10 +22,42 @@ class TestServiceBusProviderNullHandles:
 
         p = ServiceBusProvider.__new__(ServiceBusProvider)
         p._call_webhook = None
-        p._dtmf_input = None
         p._call_event = None
+        p._dtmf_input = None
         p._initialized = True
         return p
+
+    @pytest.mark.asyncio
+    async def test_send_dtmf_input_null_handle_returns_false(self) -> None:
+        p = self._make_provider()
+        p._dtmf_input = None
+        result = await p.send_dtmf_input({"call_id": "conv-1", "digits": "5"})
+        assert result is False
+
+    def test_dtmf_input_queue_name_property(self) -> None:
+        from app.platform.settings import Settings
+
+        s = Settings(azure_service_bus_queue_name="myqueue")
+        assert s.dtmf_input_queue_name == "dtmf_input_myqueue"
+
+    @pytest.mark.asyncio
+    async def test_send_dtmf_input_sends_to_dtmf_input_queue(self) -> None:
+        from app.providers.service_bus import MessageType, QueueMessage, ServiceBusProvider
+
+        p = ServiceBusProvider.__new__(ServiceBusProvider)
+        p._call_webhook = None
+        p._call_event = None
+        sent: list[QueueMessage] = []
+
+        class _FakeHandle:
+            async def send(self, message: QueueMessage) -> bool:
+                sent.append(message)
+                return True
+
+        p._dtmf_input = _FakeHandle()
+        result = await p.send_dtmf_input({"conversation_uuid": "conv-1", "digits": "5"})
+        assert result is True
+        assert sent[0].type == MessageType.DTMF_INPUT
 
     @pytest.mark.asyncio
     async def test_receive_messages_null_handle_returns_empty(self) -> None:
@@ -45,8 +77,8 @@ class TestServiceBusProviderNullHandles:
     async def test_abandon_message_null_handle_returns_false(self) -> None:
         from app.providers.service_bus import MessageType, QueueMessage
         p = self._make_provider()
-        msg = QueueMessage(type=MessageType.DTMF_INPUT, payload={})
-        result = await p.abandon_message("dtmf_input", msg)
+        msg = QueueMessage(type=MessageType.CALL_EVENT, payload={})
+        result = await p.abandon_message("call_event", msg)
         assert result is False
 
     @pytest.mark.asyncio
@@ -61,12 +93,6 @@ class TestServiceBusProviderNullHandles:
     async def test_send_call_webhook_null_handle_returns_false(self) -> None:
         p = self._make_provider()
         result = await p.send_call_webhook({"phone_number": "+111"})
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_send_dtmf_input_null_handle_returns_false(self) -> None:
-        p = self._make_provider()
-        result = await p.send_dtmf_input({"digits": "1"})
         assert result is False
 
     @pytest.mark.asyncio
@@ -94,7 +120,6 @@ class TestServiceBusProviderNullHandles:
 
         p = ServiceBusProvider.__new__(ServiceBusProvider)
         p._call_webhook = None
-        p._dtmf_input = None
         p._call_event = None
         p._initialized = True
 
@@ -114,6 +139,7 @@ class TestAzureQueueHandle:
         from app.providers.service_bus import _AzureQueueHandle
 
         handle = _AzureQueueHandle.__new__(_AzureQueueHandle)
+        handle.connection_string = "test-conn-str"
         handle.queue_name = queue_name
         handle._client = MagicMock()
         handle._receiver = AsyncMock()
@@ -166,7 +192,7 @@ class TestAzureQueueHandle:
         from app.providers.service_bus import MessageType, QueueMessage
 
         handle = self._make_handle()
-        msg = QueueMessage(type=MessageType.DTMF_INPUT, payload={})
+        msg = QueueMessage(type=MessageType.CALL_EVENT, payload={})
         raw_mock = MagicMock()
         handle._message_map[msg.message_id] = raw_mock
         handle._receiver.abandon_message = AsyncMock()
@@ -190,6 +216,36 @@ class TestAzureQueueHandle:
         handle._client.close = AsyncMock()
 
         await handle.close()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_receive_reconnects_after_fatal_error(self) -> None:
+        handle = self._make_handle()
+        handle._message_map["stale-id"] = MagicMock()
+        old_receiver = handle._receiver
+        old_receiver.receive_messages = AsyncMock(
+            side_effect=AttributeError(
+                "'NoneType' object has no attribute 'create_receiver_link'"
+            )
+        )
+        old_receiver.__aexit__ = AsyncMock()
+        old_client = handle._client
+        old_client.close = AsyncMock()
+
+        new_client = MagicMock()
+        new_receiver = AsyncMock()
+        new_client.get_queue_receiver = MagicMock(return_value=new_receiver)
+
+        with patch("azure.servicebus.aio.ServiceBusClient") as mock_sb_client_cls:
+            mock_sb_client_cls.from_connection_string = MagicMock(return_value=new_client)
+            result = await handle.receive()
+
+        assert result == []
+        old_receiver.__aexit__.assert_called_once()
+        old_client.close.assert_called_once()
+        new_receiver.__aenter__.assert_called_once()
+        assert handle._receiver is new_receiver
+        assert handle._client is new_client
+        assert handle._message_map == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- DTMF input is now processed in exactly one place (the queue consumer), not both the webhook and the consumer.
- Call state is tracked by the stable per-call id instead of an id that changes every time the call is updated.
- Hangup is sent as its own request instead of being bundled into the next menu update, which Vonage was rejecting.