### PR TITLE
feat: Introduce SyncJobConsumer and related functionality for job synchronization

### DIFF
--- a/ContentWebApp/src/components/Login.js
+++ b/ContentWebApp/src/components/Login.js
@@ -68,7 +68,7 @@ const tabButtonStyle = (active) => ({
 const labelStyle = {
   fontSize: "14px",
   fontWeight: 600,
-  color: "#fff",
+  color: "#0f172a",
   marginBottom: "6px",
 };
 

--- a/ContentWebApp/src/components/ViewIVR.js
+++ b/ContentWebApp/src/components/ViewIVR.js
@@ -38,7 +38,7 @@ function createFlowElements(data) {
                 {state.menu && state.menu.options ? (
                   state.menu.options.map((opt) => (
                     <div key={opt.key}>
-                      {opt.key === 0 ? "empty" : opt.key}: {opt.value}
+                      {String(opt.key) === "0" ? "empty" : opt.key}: {opt.value}
                     </div>
                   ))
                 ) : (

--- a/platform/app/aggregators/sync_job_models.py
+++ b/platform/app/aggregators/sync_job_models.py
@@ -53,22 +53,29 @@ class SyncJob:
     scope: str
     source_id: str | None
     status: str
-    started_at: str
+    created_at: str
+    started_at: str | None
     finished_at: str | None
     total_items: int
     error: str | None
+    options: dict[str, object]
+    retry_count: int = 0
 
     def to_doc(self) -> dict[str, object]:
         return {
             "_id": self.job_id, "tenant_id": self.tenant_id, "source_type": self.source_type, "scope": self.scope,
-            "source_id": self.source_id, "status": self.status, "started_at": self.started_at,
-            "finished_at": self.finished_at, "total_items": self.total_items, "error": self.error,
+            "source_id": self.source_id, "status": self.status, "created_at": self.created_at,
+            "started_at": self.started_at, "finished_at": self.finished_at,
+            "total_items": self.total_items, "error": self.error, "options": self.options,
+            "retry_count": self.retry_count,
         }
 
     @classmethod
     def from_doc(cls, doc: dict[str, object]) -> SyncJob:
         return cls(
             job_id=doc["_id"], tenant_id=doc["tenant_id"], source_type=doc["source_type"], scope=doc["scope"],
-            source_id=doc["source_id"], status=doc["status"], started_at=doc["started_at"], finished_at=doc["finished_at"],
-            total_items=doc["total_items"], error=doc["error"],
+            source_id=doc["source_id"], status=doc["status"], created_at=doc["created_at"],
+            started_at=doc.get("started_at"), finished_at=doc["finished_at"],
+            total_items=doc["total_items"], error=doc["error"], options=doc.get("options") or {},
+            retry_count=doc.get("retry_count", 0),
         )

--- a/platform/app/consumers/sync_job_consumer.py
+++ b/platform/app/consumers/sync_job_consumer.py
@@ -1,0 +1,152 @@
+"""SyncJobConsumer — polls contentAggregatorSyncJobs for pending Subodha sync jobs,
+claims and executes them. Mirrors ContentJobConsumer's standalone poll-and-claim
+pattern (not BaseConsumer).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from pymongo.asynchronous.database import AsyncDatabase
+
+from app.aggregators.sync_job_models import SyncJob
+from app.providers.service_bus import service_bus_provider
+from app.providers.subodha_client import SubodhaClient, get_subodha_client
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
+from app.repositories.content_aggregator_sync_job_repository import (
+    ContentAggregatorSyncJobRepository,
+)
+from app.services.content_aggregator_sync_jobs import finish_job
+from app.services.subodha_service import SubodhaService, get_subodha_service
+
+logger = logging.getLogger(__name__)
+
+SOURCE_TYPE = "subodha"
+
+
+async def _run_sync_job(
+    tenant_id: str,
+    job_id: str,
+    service: SubodhaService,
+    client: SubodhaClient,
+    job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
+    *,
+    only_new: bool,
+    dry_run: bool,
+    limit: int | None,
+) -> None:
+    try:
+        course_ids = None
+        if only_new:
+            diff = await service.get_course_diff(tenant_id, client)
+            course_ids = diff["newCourseIds"]
+            all_courses = diff["liveCourses"]
+        else:
+            all_courses = await client.list_all_courses()
+
+        await service.run_sync(
+            tenant_id, client, job_repo, item_repo, job_id, all_courses, course_ids=course_ids,
+            limit=limit if limit is not None else (len(course_ids) if course_ids is not None else None),
+            dry_run=dry_run,
+        )
+        await finish_job(job_repo, tenant_id, job_id, "completed")
+    except Exception as exc:  # noqa: BLE001
+        await finish_job(job_repo, tenant_id, job_id, "failed", error=str(exc))
+
+
+async def _run_course_sync_job(
+    tenant_id: str,
+    job_id: str,
+    service: SubodhaService,
+    client: SubodhaClient,
+    job_repo: ContentAggregatorSyncJobRepository,
+    item_repo: ContentAggregatorSyncJobItemRepository,
+    course_id: str,
+    *,
+    dry_run: bool,
+) -> None:
+    try:
+        await service.run_single_course_sync(tenant_id, client, job_repo, item_repo, job_id, course_id, dry_run=dry_run)
+        await finish_job(job_repo, tenant_id, job_id, "completed")
+    except Exception as exc:  # noqa: BLE001
+        await finish_job(job_repo, tenant_id, job_id, "failed", error=str(exc))
+
+
+class SyncJobConsumer:
+    name = "sync_job_consumer"
+
+    def __init__(
+        self,
+        job_repo: ContentAggregatorSyncJobRepository,
+        item_repo: ContentAggregatorSyncJobItemRepository,
+        db: AsyncDatabase,
+        poll_interval_seconds: float = 10.0,
+    ) -> None:
+        self._job_repo = job_repo
+        self._item_repo = item_repo
+        self._db = db
+        self._poll_interval_seconds = poll_interval_seconds
+        self._running = False
+
+    async def _sleep(self, seconds: float) -> None:
+        await asyncio.sleep(seconds)
+
+    async def _wait_for_next_poll(self) -> None:
+        """Wait for the next poll tick — either woken early by a Service Bus
+        sync_jobs message, or (if the queue isn't configured) a plain sleep.
+
+        Messages received here are just a wake signal; claim_next_pending()
+        still does the real work on the next loop iteration, so the message
+        content is ignored.
+        """
+        if service_bus_provider.get_sync_jobs_queue() is None:
+            await self._sleep(self._poll_interval_seconds)
+            return
+        try:
+            await service_bus_provider.receive_messages(
+                "sync_jobs", max_count=1, wait_seconds=self._poll_interval_seconds
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("sync_job_consumer: wake-up receive failed (%s) — falling back to sleep", exc)
+            await self._sleep(self._poll_interval_seconds)
+
+    async def run(self) -> None:
+        self._running = True
+        logger.info("SyncJobConsumer: started")
+        try:
+            await self._run_loop()
+        except asyncio.CancelledError:
+            logger.info("SyncJobConsumer: cancelled")
+        finally:
+            self._running = False
+
+    async def stop(self) -> None:
+        self._running = False
+
+    async def _run_loop(self) -> None:
+        while self._running:
+            job: SyncJob | None = await self._job_repo.claim_next_pending(SOURCE_TYPE)
+            if job is None:
+                await self._wait_for_next_poll()
+                continue
+            try:
+                client = get_subodha_client()
+                service = get_subodha_service(self._db)
+                if job.scope == "all":
+                    await _run_sync_job(
+                        job.tenant_id, job.job_id, service, client, self._job_repo, self._item_repo,
+                        only_new=bool(job.options.get("only_new", False)),
+                        dry_run=bool(job.options.get("dry_run", False)),
+                        limit=job.options.get("limit"),
+                    )
+                else:
+                    await _run_course_sync_job(
+                        job.tenant_id, job.job_id, service, client, self._job_repo, self._item_repo,
+                        job.source_id, dry_run=bool(job.options.get("dry_run", False)),
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.error("sync_job_consumer: job %s failed before/during dispatch: %s", job.job_id, exc)
+                await finish_job(self._job_repo, job.tenant_id, job.job_id, "failed", error=str(exc))

--- a/platform/app/controllers/content_aggregator_controller.py
+++ b/platform/app/controllers/content_aggregator_controller.py
@@ -10,14 +10,16 @@ JSON responses are snake_case.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
 
 from app.models.user import UserRole
 from app.platform.auth.dependencies import get_current_user
 from app.platform.error_handling import ConflictError, ForbiddenError, NotFoundError
+from app.providers.service_bus import service_bus_provider
 from app.providers.subodha_client import SubodhaClient, get_subodha_client
 from app.repositories.content_aggregator_sync_job_item_repository import (
     ContentAggregatorSyncJobItemRepository,
@@ -29,15 +31,23 @@ from app.repositories.content_aggregator_sync_job_repository import (
 )
 from app.services.content_aggregator_sync_jobs import (
     create_job,
-    finish_job,
     serialize_job,
     subscribe,
 )
 from app.services.subodha_service import CourseDiffResult, SubodhaService, get_subodha_service
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/content-aggregators", tags=["Content Aggregators"])
 
 SOURCE_TYPE = "subodha"
+
+
+async def _wake_sync_job_consumer(job_id: str) -> None:
+    try:
+        await service_bus_provider.send_sync_job({"job_id": job_id})
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to publish sync_jobs wake message for job %s: %s", job_id, exc)
 
 
 async def _require_tenant(user: dict[str, Any] = Depends(get_current_user)) -> dict[str, Any]:
@@ -57,55 +67,6 @@ async def _require_aggregator_access(user: dict[str, Any] = Depends(get_current_
     return user
 
 
-async def _run_sync_job(
-    tenant_id: str,
-    job_id: str,
-    service: SubodhaService,
-    client: SubodhaClient,
-    job_repo: ContentAggregatorSyncJobRepository,
-    item_repo: ContentAggregatorSyncJobItemRepository,
-    *,
-    only_new: bool,
-    dry_run: bool,
-    limit: int | None,
-) -> None:
-    try:
-        course_ids = None
-        if only_new:
-            diff = await service.get_course_diff(tenant_id, client)
-            course_ids = diff["newCourseIds"]
-            all_courses = diff["liveCourses"]
-        else:
-            all_courses = await client.list_all_courses()
-
-        await service.run_sync(
-            tenant_id, client, job_repo, item_repo, job_id, all_courses, course_ids=course_ids,
-            limit=limit if limit is not None else (len(course_ids) if course_ids is not None else None),
-            dry_run=dry_run,
-        )
-        await finish_job(job_repo, item_repo, tenant_id, job_id, "completed")
-    except Exception as exc:  # noqa: BLE001
-        await finish_job(job_repo, item_repo, tenant_id, job_id, "failed", error=str(exc))
-
-
-async def _run_course_sync_job(
-    tenant_id: str,
-    job_id: str,
-    service: SubodhaService,
-    client: SubodhaClient,
-    job_repo: ContentAggregatorSyncJobRepository,
-    item_repo: ContentAggregatorSyncJobItemRepository,
-    course_id: str,
-    *,
-    dry_run: bool,
-) -> None:
-    try:
-        await service.run_single_course_sync(tenant_id, client, job_repo, item_repo, job_id, course_id, dry_run=dry_run)
-        await finish_job(job_repo, item_repo, tenant_id, job_id, "completed")
-    except Exception as exc:  # noqa: BLE001
-        await finish_job(job_repo, item_repo, tenant_id, job_id, "failed", error=str(exc))
-
-
 @router.get("/diff", summary="Diff live Subodha courses against stored courses")
 async def get_diff(
     user: dict[str, Any] = Depends(_require_tenant),
@@ -117,24 +78,20 @@ async def get_diff(
 
 @router.post("/sync", status_code=202, summary="Start a full (or new-only) course sync")
 async def start_sync(
-    background_tasks: BackgroundTasks,
     body: dict[str, Any] | None = None,
     user: dict[str, Any] = Depends(_require_tenant),
-    service: SubodhaService = Depends(get_subodha_service),
-    client: SubodhaClient = Depends(get_subodha_client),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
-    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> dict[str, str]:
     body = body or {}
     tenant_id = user.get("tenant_id", "")
     active_jobs = await job_repo.get_active_jobs(tenant_id, source_type=SOURCE_TYPE)
     if any(j.scope == "all" for j in active_jobs):
         raise ConflictError("A Subodha sync-all job")
-    job = await create_job(job_repo, tenant_id=tenant_id, source_type=SOURCE_TYPE, scope="all", source_id=None, total_items=0)
-    background_tasks.add_task(
-        _run_sync_job, tenant_id, job.job_id, service, client, job_repo, item_repo,
-        only_new=bool(body.get("onlyNew", False)), dry_run=bool(body.get("dryRun", False)), limit=body.get("limit"),
+    options = {"only_new": bool(body.get("onlyNew", False)), "dry_run": bool(body.get("dryRun", False)), "limit": body.get("limit")}
+    job = await create_job(
+        job_repo, tenant_id=tenant_id, source_type=SOURCE_TYPE, scope="all", source_id=None, total_items=0, options=options,
     )
+    await _wake_sync_job_consumer(job.job_id)
     return {"job_id": job.job_id}
 
 
@@ -198,23 +155,20 @@ async def update_problem_block(
 @router.post("/sync/course/{course_id}", status_code=202, summary="Sync a single course")
 async def sync_course(
     course_id: str,
-    background_tasks: BackgroundTasks,
     body: dict[str, Any] | None = None,
     user: dict[str, Any] = Depends(_require_aggregator_access),
-    service: SubodhaService = Depends(get_subodha_service),
-    client: SubodhaClient = Depends(get_subodha_client),
     job_repo: ContentAggregatorSyncJobRepository = Depends(get_content_aggregator_sync_job_repo),
-    item_repo: ContentAggregatorSyncJobItemRepository = Depends(get_content_aggregator_sync_job_item_repo),
 ) -> dict[str, str]:
     body = body or {}
     tenant_id = user.get("tenant_id", "")
     active_jobs = await job_repo.get_active_jobs(tenant_id, source_type=SOURCE_TYPE)
     if any(j.scope == "course" and j.source_id == course_id for j in active_jobs):
         raise ConflictError(f'A sync for course "{course_id}"')
-    job = await create_job(job_repo, tenant_id=tenant_id, source_type=SOURCE_TYPE, scope="course", source_id=course_id, total_items=1)
-    background_tasks.add_task(
-        _run_course_sync_job, tenant_id, job.job_id, service, client, job_repo, item_repo, course_id, dry_run=bool(body.get("dryRun", False))
+    options = {"dry_run": bool(body.get("dryRun", False))}
+    job = await create_job(
+        job_repo, tenant_id=tenant_id, source_type=SOURCE_TYPE, scope="course", source_id=course_id, total_items=1, options=options,
     )
+    await _wake_sync_job_consumer(job.job_id)
     return {"job_id": job.job_id}
 
 

--- a/platform/app/platform/lifespan.py
+++ b/platform/app/platform/lifespan.py
@@ -19,9 +19,13 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI
 
+from app.consumers.sync_job_consumer import SyncJobConsumer
 from app.platform.database import close_database, get_database, init_database
 from app.platform.settings import get_settings
 from app.providers.subodha_client import close_subodha_client
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
 from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
 )
@@ -149,6 +153,18 @@ def _make_consumer_tasks(conference_manager: Any) -> list[asyncio.Task]:  # type
     except Exception as exc:  # noqa: BLE001
         logger.error("Failed to initialise ContentJobConsumer: %s", exc)
 
+    try:
+        consumer_specs.append((
+            "SyncJobConsumer",
+            SyncJobConsumer(
+                job_repo=ContentAggregatorSyncJobRepository(db),
+                item_repo=ContentAggregatorSyncJobItemRepository(db),
+                db=db,
+            ),
+        ))
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to initialise SyncJobConsumer: %s", exc)
+
     tasks: list[asyncio.Task] = []  # type: ignore[type-arg]
     for name, consumer in consumer_specs:
         try:
@@ -171,10 +187,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # ------------------------------------------------------------------
     await init_database()
 
-    reconciled = await ContentAggregatorSyncJobRepository(get_database()).reconcile_interrupted_jobs()
-    if reconciled:
-        logger.info("Reconciled %d interrupted content aggregator sync jobs", reconciled)
-
     # Init conference manager (available in all modes)
     try:
         conf_mgr = _init_conference_manager()
@@ -184,6 +196,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     consumer_tasks: list[asyncio.Task] = []  # type: ignore[type-arg]
     if settings.app_mode in ("consumer", "all"):
+        reconciled = await ContentAggregatorSyncJobRepository(get_database()).reconcile_interrupted_jobs()
+        if reconciled:
+            logger.info("Reconciled %d interrupted content aggregator sync jobs", reconciled)
         try:
             consumer_tasks = _make_consumer_tasks(conf_mgr)
         except Exception as exc:  # noqa: BLE001

--- a/platform/app/platform/settings.py
+++ b/platform/app/platform/settings.py
@@ -221,6 +221,10 @@ class Settings(BaseSettings):
         return f"call_event_{self.azure_service_bus_queue_name}"
 
     @property
+    def sync_jobs_queue_name(self) -> str:
+        return f"sync_jobs_{self.azure_service_bus_queue_name}"
+
+    @property
     def effective_mongo_connection_string(self) -> str:
         """Return the first non-empty MongoDB connection string available."""
         return self.mongo_db_connection_string or self.db_connection

--- a/platform/app/providers/service_bus.py
+++ b/platform/app/providers/service_bus.py
@@ -30,6 +30,7 @@ class MessageType(StrEnum):
     CALL_WEBHOOK = "call_webhook"
     DTMF_INPUT = "dtmf_input"
     CALL_EVENT = "call_event"
+    SYNC_JOBS = "sync_jobs"
 
 
 class QueueMessage:
@@ -196,12 +197,14 @@ class ServiceBusProvider:
         "call_webhook": "_call_webhook",
         "dtmf_input": "_dtmf_input",
         "call_event": "_call_event",
+        "sync_jobs": "_sync_jobs",
     }
 
     def __init__(self) -> None:
         self._call_webhook: _AzureQueueHandle | None = None
         self._dtmf_input: _AzureQueueHandle | None = None
         self._call_event: _AzureQueueHandle | None = None
+        self._sync_jobs: _AzureQueueHandle | None = None
         self._initialized = False
 
     async def initialize(self) -> None:
@@ -224,17 +227,19 @@ class ServiceBusProvider:
         self._call_webhook = _AzureQueueHandle(conn_str, settings.call_webhook_queue_name)
         self._dtmf_input = _AzureQueueHandle(conn_str, settings.dtmf_input_queue_name)
         self._call_event = _AzureQueueHandle(conn_str, settings.call_event_queue_name)
+        self._sync_jobs = _AzureQueueHandle(conn_str, settings.sync_jobs_queue_name)
 
         await asyncio.gather(
             self._call_webhook.initialize(),
             self._dtmf_input.initialize(),
             self._call_event.initialize(),
+            self._sync_jobs.initialize(),
         )
         self._initialized = True
-        logger.info("ServiceBusProvider initialized (3 queues)")
+        logger.info("ServiceBusProvider initialized (4 queues)")
 
     async def close(self) -> None:
-        handles = [self._call_webhook, self._dtmf_input, self._call_event]
+        handles = [self._call_webhook, self._dtmf_input, self._call_event, self._sync_jobs]
         close_tasks = [h.close() for h in handles if h is not None]
         if close_tasks:
             await asyncio.gather(*close_tasks, return_exceptions=True)
@@ -246,6 +251,7 @@ class ServiceBusProvider:
             "call_webhook": self._call_webhook,
             "dtmf_input": self._dtmf_input,
             "call_event": self._call_event,
+            "sync_jobs": self._sync_jobs,
         }
         handle = mapping.get(queue_name)
         if handle is None:
@@ -310,6 +316,9 @@ class ServiceBusProvider:
     async def send_call_event(self, payload: dict) -> bool:
         return await self.send_message("call_event", payload)
 
+    async def send_sync_job(self, payload: dict) -> bool:
+        return await self.send_message("sync_jobs", payload)
+
     def get_call_webhook_queue(self) -> _AzureQueueHandle | None:
         return self._call_webhook
 
@@ -318,6 +327,9 @@ class ServiceBusProvider:
 
     def get_call_event_queue(self) -> _AzureQueueHandle | None:
         return self._call_event
+
+    def get_sync_jobs_queue(self) -> _AzureQueueHandle | None:
+        return self._sync_jobs
 
 
 # ---------------------------------------------------------------------------

--- a/platform/app/repositories/content_aggregator_sync_job_repository.py
+++ b/platform/app/repositories/content_aggregator_sync_job_repository.py
@@ -1,7 +1,7 @@
 """Content aggregator sync job repository — PyMongo async data access for the
-contentAggregatorSyncJobs collection. Every read/write is tenant-scoped
-(except the startup-only reconcile_interrupted_jobs sweep), further scoped to
-source_type where a job belongs to one specific aggregator.
+contentAggregatorSyncJobs collection. Every read/write is tenant-scoped, except
+two intentionally-global operations: reconcile_interrupted_jobs (startup sweep)
+and claim_next_pending (cross-tenant work queue).
 """
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from typing import ClassVar
 
 from fastapi import Depends
-from pymongo import ReturnDocument
+from pymongo import ASCENDING, ReturnDocument, UpdateOne
 from pymongo.asynchronous.database import AsyncDatabase
 
 from app.aggregators.sync_job_models import SyncJob
@@ -18,20 +18,40 @@ from app.platform.auth.dependencies import get_db
 
 class ContentAggregatorSyncJobRepository:
     COLLECTION_NAME: ClassVar[str] = "contentAggregatorSyncJobs"
+    MAX_INTERRUPTED_RETRIES: ClassVar[int] = 3
 
     def __init__(self, db: AsyncDatabase) -> None:
         self._col = db[self.COLLECTION_NAME]
 
     async def create_job(
-        self, job_id: str, *, tenant_id: str, source_type: str, scope: str, source_id: str | None, total_items: int
+        self,
+        job_id: str,
+        *,
+        tenant_id: str,
+        source_type: str,
+        scope: str,
+        source_id: str | None,
+        total_items: int,
+        options: dict[str, object] = {},  # noqa: B006
     ) -> SyncJob:
         job = SyncJob(
             job_id=job_id, tenant_id=tenant_id, source_type=source_type, scope=scope, source_id=source_id,
-            status="running", started_at=datetime.now(UTC).isoformat(), finished_at=None,
-            total_items=total_items, error=None,
+            status="pending", created_at=datetime.now(UTC).isoformat(), started_at=None, finished_at=None,
+            total_items=total_items, error=None, options=options,
         )
         await self._col.insert_one(job.to_doc())
         return job
+
+    async def claim_next_pending(self, source_type: str) -> SyncJob | None:
+        """Atomically claims the oldest pending job for source_type. Not tenant-scoped —
+        this is a global work queue, same exception class as reconcile_interrupted_jobs."""
+        doc = await self._col.find_one_and_update(
+            {"status": "pending", "source_type": source_type},
+            {"$set": {"status": "running", "started_at": datetime.now(UTC).isoformat()}},
+            sort=[("created_at", ASCENDING)],
+            return_document=ReturnDocument.AFTER,
+        )
+        return SyncJob.from_doc(doc) if doc else None
 
     async def set_total_items(self, tenant_id: str, job_id: str, total: int) -> SyncJob | None:
         doc = await self._col.find_one_and_update(
@@ -61,22 +81,54 @@ class ContentAggregatorSyncJobRepository:
             query["scope"] = scope
         if source_id:
             query["source_id"] = source_id
-        docs = await self._col.find(query).sort("started_at", -1).to_list(length=limit)
+        docs = await self._col.find(query).sort("created_at", -1).to_list(length=limit)
         return [SyncJob.from_doc(d) for d in docs]
 
     async def get_active_jobs(self, tenant_id: str, source_type: str | None = None) -> list[SyncJob]:
-        query: dict[str, object] = {"tenant_id": tenant_id, "status": "running"}
+        query: dict[str, object] = {"tenant_id": tenant_id, "status": {"$in": ["pending", "running"]}}
         if source_type:
             query["source_type"] = source_type
         docs = await self._col.find(query).to_list(length=None)
         return [SyncJob.from_doc(d) for d in docs]
 
     async def reconcile_interrupted_jobs(self) -> int:
-        """Startup-only maintenance sweep — intentionally not tenant-scoped."""
-        result = await self._col.update_many(
-            {"status": "running"},
-            {"$set": {"status": "failed", "error": "interrupted by restart", "finished_at": datetime.now(UTC).isoformat()}},
-        )
+        """Startup-only maintenance sweep — intentionally not tenant-scoped. Only call this
+        from a process that hosts SyncJobConsumer (APP_MODE in ("consumer", "all")).
+
+        Jobs left in "running" state (the consumer died mid-processing) are re-queued back
+        to "pending" so claim_next_pending can retry them, up to MAX_INTERRUPTED_RETRIES.
+        Jobs that have already been interrupted that many times are marked "failed" instead.
+        "pending" jobs are left untouched — they were never claimed and remain safely resumable.
+        """
+        interrupted = await self._col.find({"status": "running"}).to_list(length=None)
+        if not interrupted:
+            return 0
+
+        now = datetime.now(UTC).isoformat()
+        ops: list[UpdateOne] = []
+        for doc in interrupted:
+            new_retry_count = doc.get("retry_count", 0) + 1
+            if new_retry_count <= self.MAX_INTERRUPTED_RETRIES:
+                update = {
+                    "$set": {
+                        "status": "pending",
+                        "retry_count": new_retry_count,
+                        "started_at": None,
+                        "error": None,
+                    }
+                }
+            else:
+                update = {
+                    "$set": {
+                        "status": "failed",
+                        "retry_count": new_retry_count,
+                        "error": "exceeded max retries after interruption",
+                        "finished_at": now,
+                    }
+                }
+            ops.append(UpdateOne({"_id": doc["_id"]}, update))
+
+        result = await self._col.bulk_write(ops)
         return result.modified_count
 
 

--- a/platform/app/services/content_aggregator_sync_jobs.py
+++ b/platform/app/services/content_aggregator_sync_jobs.py
@@ -1,6 +1,8 @@
 """Content aggregator sync job orchestration: id generation, persistence
-writes, in-process pub/sub for SSE, and snake_case JSON serialization for
-the /content-aggregators/* API.
+writes, DB-polling pub/sub for SSE, and snake_case JSON serialization for
+the /content-aggregators/* API. Job execution runs in a separate consumer
+process, so SSE subscribers can't rely on in-process broadcast — they poll
+the job document instead.
 """
 from __future__ import annotations
 
@@ -16,7 +18,7 @@ from app.repositories.content_aggregator_sync_job_repository import (
     ContentAggregatorSyncJobRepository,
 )
 
-_subscribers: dict[str, list[asyncio.Queue]] = {}
+POLL_INTERVAL_SECONDS = 1.0
 
 
 def serialize_job(job: SyncJob, stats: SyncStats) -> dict[str, object]:
@@ -34,62 +36,50 @@ def serialize_job(job: SyncJob, stats: SyncStats) -> dict[str, object]:
     }
 
 
-def _broadcast(job_id: str, event: dict[str, object]) -> None:
-    for queue in _subscribers.get(job_id, []):
-        queue.put_nowait(event)
-
-
 async def create_job(
-    repo: ContentAggregatorSyncJobRepository, *, tenant_id: str, source_type: str, scope: str, source_id: str | None, total_items: int
+    repo: ContentAggregatorSyncJobRepository,
+    *,
+    tenant_id: str,
+    source_type: str,
+    scope: str,
+    source_id: str | None,
+    total_items: int,
+    options: dict[str, object] = {},  # noqa: B006
 ) -> SyncJob:
     job_id = str(uuid.uuid4())
     return await repo.create_job(
-        job_id, tenant_id=tenant_id, source_type=source_type, scope=scope, source_id=source_id, total_items=total_items
+        job_id, tenant_id=tenant_id, source_type=source_type, scope=scope, source_id=source_id,
+        total_items=total_items, options=options,
     )
 
 
 async def set_total(
     job_repo: ContentAggregatorSyncJobRepository,
-    item_repo: ContentAggregatorSyncJobItemRepository,
     tenant_id: str,
     job_id: str,
     total: int,
 ) -> None:
-    job = await job_repo.set_total_items(tenant_id, job_id, total)
-    if job is not None:
-        stats = await item_repo.get_stats(tenant_id, job_id)
-        _broadcast(job_id, {"event": "progress", "job": serialize_job(job, stats)})
+    await job_repo.set_total_items(tenant_id, job_id, total)
 
 
 async def record_item_result(
-    job_repo: ContentAggregatorSyncJobRepository,
     item_repo: ContentAggregatorSyncJobItemRepository,
     tenant_id: str,
     job_id: str,
     entry: SyncItemResult,
 ) -> None:
     await item_repo.insert(tenant_id, job_id, entry)
-    if _subscribers.get(job_id):
-        job = await job_repo.get_job(tenant_id, job_id)
-        if job is not None:
-            stats = await item_repo.get_stats(tenant_id, job_id)
-            _broadcast(job_id, {"event": "progress", "job": serialize_job(job, stats)})
 
 
 async def finish_job(
     job_repo: ContentAggregatorSyncJobRepository,
-    item_repo: ContentAggregatorSyncJobItemRepository,
     tenant_id: str,
     job_id: str,
     status: str,
     *,
     error: str | None = None,
 ) -> None:
-    job = await job_repo.set_job_status(tenant_id, job_id, status, error=error)
-    if job is not None:
-        stats = await item_repo.get_stats(tenant_id, job_id)
-        _broadcast(job_id, {"event": "done", "job": serialize_job(job, stats)})
-    _subscribers.pop(job_id, None)
+    await job_repo.set_job_status(tenant_id, job_id, status, error=error)
 
 
 async def subscribe(
@@ -107,20 +97,16 @@ async def subscribe(
         return
     yield {"event": "progress", "job": serialize_job(current, stats)}
 
-    queue: asyncio.Queue = asyncio.Queue()
-    subs = _subscribers.setdefault(job_id, [])
-    subs.append(queue)
-    try:
+    last_processed = stats.total()
+    while True:
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
         current = await job_repo.get_job(tenant_id, job_id)
-        if current is not None and current.status != "running":
-            stats = await item_repo.get_stats(tenant_id, job_id)
+        if current is None:
+            return
+        stats = await item_repo.get_stats(tenant_id, job_id)
+        if current.status != "running":
             yield {"event": "done", "job": serialize_job(current, stats)}
             return
-        while True:
-            event = await queue.get()
-            yield event
-            if event["event"] == "done":
-                break
-    finally:
-        if queue in subs:
-            subs.remove(queue)
+        if stats.total() != last_processed:
+            last_processed = stats.total()
+            yield {"event": "progress", "job": serialize_job(current, stats)}

--- a/platform/app/services/fsm/instantiation/insti.py
+++ b/platform/app/services/fsm/instantiation/insti.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import uuid
+from urllib.parse import quote
 
 from pymongo.asynchronous.database import AsyncDatabase
 
@@ -40,7 +41,7 @@ from app.services.fsm.utils import get_blob_language_name
 
 
 class _Option:
-    def __init__(self, key: int, value: str) -> None:
+    def __init__(self, key: str, value: str) -> None:
         self.key = key
         self.value = value
 
@@ -82,7 +83,7 @@ def _get_key_press_url(key: str, language: str, speech_rate: str) -> str:
         pressKeyMessageUrl.replace("{language}", blob_lang)
         .replace("{speechRate}", str(speech_rate))
     )
-    replaced_url = re.sub(r"\{key\}", key, replaced_url)
+    replaced_url = re.sub(r"\{key\}", quote(key, safe=""), replaced_url)
     return pullMenuMainUrl + replaced_url
 
 
@@ -194,7 +195,7 @@ _attribute_handlers = {
 def _add_nav_action(
     actions: list,
     key_to_value_mapping: dict,
-    nav_key: int | str,
+    nav_key: str,
     message_template: str,
     language: str,
     speech_rate: str,
@@ -207,7 +208,7 @@ def _add_nav_action(
     )
     actions.append(StreamAction(url))
     actions.append(StreamAction(_get_key_press_url(str(nav_key), language, speech_rate)))
-    key_to_value_mapping[int(nav_key)] = description
+    key_to_value_mapping[str(nav_key)] = description
 
 
 def _get_stream_actions(
@@ -253,7 +254,7 @@ def _get_stream_actions(
         display_value = sorted_keys[start_index + idx]
         actions.append(StreamAction(complete_url))
         key = str(idx + 1)
-        key_to_value_mapping[int(key)] = display_value
+        key_to_value_mapping[key] = display_value
         option_language = display_value.lower() if category == "language" else language
         actions.append(StreamAction(_get_key_press_url(key, option_language, speechRate)))
 

--- a/platform/app/services/fsm/instantiation/ivr_constants.py
+++ b/platform/app/services/fsm/instantiation/ivr_constants.py
@@ -108,11 +108,11 @@ audioGoingTobePlayedDialogUrl = "audioDialogs/{language}/audioGoingToBePlayedDia
 audioFinishedMessageUrl = "audioDialogs/{language}/audioFinishedDialog/{speechRate}.mp3"
 
 # Navigation key constants
-number_of_categories_listed_in_one_state = 4
-next_n_categories_key = "5"
-previous_n_categories_key = "7"
-repeat_current_categories_key = "8"
+number_of_categories_listed_in_one_state = 7
+next_n_categories_key = "#"
+previous_n_categories_key = "*"
 previous_category_level_key = "9"
+repeat_current_categories_key = "8"
 
 content_attributes = [
     {"category": "language", "level": 0, "id": "LA"},

--- a/platform/app/services/fsm/instantiation/pure_audio.py
+++ b/platform/app/services/fsm/instantiation/pure_audio.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 class _Option:
-    def __init__(self, key: int, value: str) -> None:
+    def __init__(self, key: str, value: str) -> None:
         self.key = key
         self.value = value
 
@@ -126,9 +126,9 @@ class PureAudio:
         actions.append(InputAction(type_=["dtmf"], eventApi="/input", timeOut=10))
 
         options = [
-            _Option(key=8, value="repeat"),
-            _Option(key=9, value="exit"),
-            _Option(key=0, value="next (instructions to exit)"),
+            _Option(key="8", value="repeat"),
+            _Option(key="9", value="exit"),
+            _Option(key="0", value="pause/resume"),
         ]
         description = (
             f"{self.content_data.title.local} - {self.content_data.title.english} Audio Playing"

--- a/platform/app/services/sas_service.py
+++ b/platform/app/services/sas_service.py
@@ -110,9 +110,8 @@ class SASService:
         try:
             from azure.storage.blob import BlobSasPermissions, generate_blob_sas  # noqa: PLC0415
 
-            decoded = unquote(url)
-            parsed = urlparse(decoded)
-            parts = [p for p in parsed.path.split("/") if p]
+            parsed = urlparse(url)
+            parts = [unquote(p) for p in parsed.path.split("/") if p]
             if len(parts) < 2:
                 raise ValueError(f"Cannot parse blob URL: {url!r}")
             container_name = parts[0]

--- a/platform/app/services/subodha_service.py
+++ b/platform/app/services/subodha_service.py
@@ -247,7 +247,7 @@ class SubodhaService:
             to_process = to_process[:limit]
 
         logger.info("[subodha] %d of %d courses queued", len(to_process), len(all_courses))
-        await set_total(job_repo, item_repo, tenant_id, job_id, len(to_process))
+        await set_total(job_repo, tenant_id, job_id, len(to_process))
 
         semaphore = asyncio.Semaphore(self._settings.subodha_course_concurrency)
         session_box = {"cookie": session_cookie}
@@ -274,7 +274,7 @@ class SubodhaService:
                     source_id=result["courseId"], name=course.get("name") or "", status=result["status"],
                     error=result.get("error"), at=datetime.now(UTC).isoformat(),
                 )
-                await record_item_result(job_repo, item_repo, tenant_id, job_id, entry)
+                await record_item_result(item_repo, tenant_id, job_id, entry)
 
                 async with lock:
                     processed_count += 1
@@ -325,13 +325,13 @@ class SubodhaService:
             logger.error("[subodha] single-course run %s: course=%s not found among %d live courses", job_id, course_id, len(all_courses))
             raise ValueError(f"Course not found on Subodha: {course_id}")
 
-        await set_total(job_repo, item_repo, tenant_id, job_id, 1)
+        await set_total(job_repo, tenant_id, job_id, 1)
         result = await self.process_course(tenant_id, client, course, session_cookie, job_id, dry_run)
         entry = SyncItemResult(
             source_id=result["courseId"], name=course.get("name") or "", status=result["status"],
             error=result.get("error"), at=datetime.now(UTC).isoformat(),
         )
-        await record_item_result(job_repo, item_repo, tenant_id, job_id, entry)
+        await record_item_result(item_repo, tenant_id, job_id, entry)
 
         items = await item_repo.list_by_job(tenant_id, job_id)
         stats = SyncStats.from_items(items).to_doc()

--- a/platform/tests/integration/test_sync_job_consumer_tier.py
+++ b/platform/tests/integration/test_sync_job_consumer_tier.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.consumers.sync_job_consumer import SyncJobConsumer
+from app.repositories.content_aggregator_sync_job_item_repository import (
+    ContentAggregatorSyncJobItemRepository,
+)
+from app.repositories.content_aggregator_sync_job_repository import (
+    ContentAggregatorSyncJobRepository,
+)
+from app.services import content_aggregator_sync_jobs as jobs
+from app.services.content_aggregator_sync_jobs import subscribe
+from app.services.subodha_service import SubodhaService
+from tests.support.mongomock_async import AsyncMongoMockClient
+
+
+class FakeSubodhaClient:
+    def __init__(self, courses):
+        self._courses = courses
+
+    async def get_session(self):
+        return "cookie"
+
+    def clear_session_cache(self):
+        pass
+
+    async def list_all_courses(self):
+        return self._courses
+
+    async def fetch_blocks(self, course_id, session_cookie):
+        return {
+            "root": "course",
+            "blocks": {
+                "course": {"type": "course", "children": ["chapter-1"]},
+                "chapter-1": {"type": "chapter", "children": ["seq-1"]},
+                "seq-1": {"type": "sequential", "children": ["vert-1"]},
+                "vert-1": {"type": "vertical", "children": ["html-1"]},
+                "html-1": {"type": "html", "display_name": "Welcome", "student_view_html": "<p>Hi</p>",
+                           "student_view_data": None, "lms_web_url": "https://lms/html-1"},
+            },
+        }
+
+    async def enrich_blocks_with_content(self, blocks_response, session_cookie):
+        return None
+
+
+class FakeBlobStorageProvider:
+    def __init__(self):
+        self.uploaded: dict[str, bytes] = {}
+
+    async def upload_file(self, container, blob_name, data, content_type="application/octet-stream"):
+        self.uploaded[blob_name] = data
+        return f"https://blob.test/{container}/{blob_name}"
+
+    async def download_from_url(self, blob_url: str) -> bytes:
+        prefix = "https://blob.test/subodha/"
+        blob_name = blob_url[len(prefix):]
+        return self.uploaded[blob_name]
+
+
+def _course(course_id: str, name: str) -> dict[str, object]:
+    return {
+        "id": course_id, "name": name, "org": "edX", "number": course_id.upper(), "short_description": "",
+        "language": "en", "start": "2030-01-01T00:00:00+00:00", "pacing": "self_paced",
+        "hidden": False, "invitation_only": False, "mobile_available": True,
+    }
+
+
+@pytest.fixture
+def mock_db():
+    return AsyncMongoMockClient()["test_seeds_sync_job_consumer_tier"]
+
+
+@pytest.fixture
+def job_repo(mock_db):
+    return ContentAggregatorSyncJobRepository(mock_db)
+
+
+@pytest.fixture
+def item_repo(mock_db):
+    return ContentAggregatorSyncJobItemRepository(mock_db)
+
+
+@pytest.fixture
+def mock_subodha_service(mock_db):
+    return SubodhaService(mock_db, blob=FakeBlobStorageProvider())
+
+
+@pytest.fixture
+def mock_subodha_client():
+    return FakeSubodhaClient([_course("c1", "Course One")])
+
+
+@pytest.mark.asyncio
+async def test_full_sync_job_lifecycle_through_consumer(
+    job_repo, item_repo, mock_db, mock_subodha_service, mock_subodha_client, monkeypatch,
+):
+    job = await jobs.create_job(
+        job_repo, tenant_id="t1", source_type="subodha", scope="all", source_id=None, total_items=0,
+    )
+    assert job.status == "pending"
+
+    monkeypatch.setattr("app.consumers.sync_job_consumer.get_subodha_client", lambda: mock_subodha_client)
+    monkeypatch.setattr("app.consumers.sync_job_consumer.get_subodha_service", lambda db: mock_subodha_service)
+
+    consumer = SyncJobConsumer(job_repo=job_repo, item_repo=item_repo, db=mock_db, poll_interval_seconds=0.01)
+    consumer._running = True
+    consumer_task = asyncio.create_task(consumer._run_loop())
+
+    # subscribe() treats any non-"running" status as terminal, so wait for the
+    # consumer to actually claim the job (pending -> running) before starting
+    # to poll — otherwise we'd race the claim and see a stale "done" for the
+    # still-"pending" job.
+    for _ in range(200):
+        current = await job_repo.get_job("t1", job.job_id)
+        if current is not None and current.status != "pending":
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("consumer never claimed the pending job")
+
+    events = []
+    async for event in subscribe(job_repo, item_repo, "t1", job.job_id):
+        events.append(event)
+        if event["event"] == "done":
+            break
+
+    consumer._running = False
+    consumer_task.cancel()
+
+    assert events[-1]["event"] == "done"
+    final = await job_repo.get_job("t1", job.job_id)
+    assert final.status == "completed"

--- a/platform/tests/unit/test_consumers_audio_deep.py
+++ b/platform/tests/unit/test_consumers_audio_deep.py
@@ -181,14 +181,14 @@ class TestPureAudioBuilder:
     def test_pure_audio_option_creation(self) -> None:
         from app.services.fsm.instantiation.pure_audio import _Option
 
-        opt = _Option(key=1, value="Lesson 1")
-        assert opt.key == 1
+        opt = _Option(key="1", value="Lesson 1")
+        assert opt.key == "1"
         assert opt.value == "Lesson 1"
 
     def test_pure_audio_menu_dict(self) -> None:
         from app.services.fsm.instantiation.pure_audio import _Menu, _Option
 
-        opt = _Option(key=1, value="Lesson 1")
+        opt = _Option(key="1", value="Lesson 1")
         menu = _Menu(description="Content menu", options=[opt], level=2, language="english")
         d = menu.dict()
         assert d["description"] == "Content menu"

--- a/platform/tests/unit/test_content_aggregator_sync_job_repository.py
+++ b/platform/tests/unit/test_content_aggregator_sync_job_repository.py
@@ -17,8 +17,10 @@ def repo():
 @pytest.mark.asyncio
 async def test_create_and_get_job(repo):
     job = await repo.create_job("job-1", tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    assert job.status == "running"
+    assert job.status == "pending"
     assert job.source_type == "subodha"
+    assert job.created_at is not None
+    assert job.started_at is None
 
     fetched = await repo.get_job("tenant-a", "job-1")
     assert fetched.job_id == "job-1"
@@ -63,9 +65,71 @@ async def test_get_active_jobs(repo):
 
 
 @pytest.mark.asyncio
-async def test_reconcile_interrupted_jobs_not_tenant_scoped(repo):
+async def test_reconcile_interrupted_jobs_leaves_pending_jobs_untouched(repo):
     await repo.create_job("job-1", tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
     reconciled = await repo.reconcile_interrupted_jobs()
-    assert reconciled == 1
+    assert reconciled == 0
     job = await repo.get_job("tenant-a", "job-1")
+    assert job.status == "pending"
+    assert job.retry_count == 0
+
+
+@pytest.mark.asyncio
+async def test_claim_next_pending_returns_oldest_first(repo):
+    await repo.create_job("job-a", tenant_id="t1", source_type="subodha", scope="all", source_id=None, total_items=0)
+    await repo.create_job("job-b", tenant_id="t1", source_type="subodha", scope="all", source_id=None, total_items=0)
+    claimed = await repo.claim_next_pending("subodha")
+    assert claimed.job_id == "job-a"
+    assert claimed.status == "running"
+    assert claimed.started_at is not None
+
+
+@pytest.mark.asyncio
+async def test_claim_next_pending_filters_by_source_type(repo):
+    await repo.create_job("job-d", tenant_id="t1", source_type="other-source", scope="all", source_id=None, total_items=0)
+    claimed = await repo.claim_next_pending("subodha")
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_claim_next_pending_returns_none_when_no_pending_jobs(repo):
+    await repo.create_job("job-e", tenant_id="t1", source_type="subodha", scope="all", source_id=None, total_items=0)
+    await repo.claim_next_pending("subodha")
+    claimed = await repo.claim_next_pending("subodha")
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_interrupted_jobs_requeues_running_job(repo):
+    await repo.create_job("job-f", tenant_id="t1", source_type="subodha", scope="all", source_id=None, total_items=0)
+    await repo.create_job("job-g", tenant_id="t1", source_type="subodha", scope="all", source_id=None, total_items=0)
+    await repo.claim_next_pending("subodha")  # claims job-f (oldest), leaves it "running"
+
+    count = await repo.reconcile_interrupted_jobs()
+    assert count == 1  # only job-f was "running"; job-g ("pending") is untouched
+
+    f = await repo.get_job("t1", "job-f")
+    g = await repo.get_job("t1", "job-g")
+    assert f.status == "pending"
+    assert f.started_at is None
+    assert f.error is None
+    assert f.retry_count == 1
+    assert g.status == "pending"
+    assert g.retry_count == 0
+
+    # requeued job is claimable again
+    reclaimed = await repo.claim_next_pending("subodha")
+    assert reclaimed.job_id == "job-f"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_interrupted_jobs_fails_job_after_max_retries(repo):
+    await repo.create_job("job-h", tenant_id="t1", source_type="subodha", scope="all", source_id=None, total_items=0)
+    for _ in range(4):  # simulate MAX_INTERRUPTED_RETRIES (3) prior interruptions, then one more
+        await repo.claim_next_pending("subodha")
+        await repo.reconcile_interrupted_jobs()
+
+    job = await repo.get_job("t1", "job-h")
     assert job.status == "failed"
+    assert job.error == "exceeded max retries after interruption"
+    assert job.retry_count == 4

--- a/platform/tests/unit/test_content_aggregator_sync_jobs.py
+++ b/platform/tests/unit/test_content_aggregator_sync_jobs.py
@@ -28,7 +28,7 @@ def item_repo():
 @pytest.mark.asyncio
 async def test_serialize_job_maps_to_snake_case_shape(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="course", source_id="c1", total_items=1)
-    await jobs.record_item_result(repo, item_repo, "tenant-a", job.job_id, SyncItemResult("c1", "Course One", "saved", None, "2026-08-06T00:00:00Z"))
+    await jobs.record_item_result(item_repo, "tenant-a", job.job_id, SyncItemResult("c1", "Course One", "saved", None, "2026-08-06T00:00:00Z"))
     stored = await repo.get_job("tenant-a", job.job_id)
     items = await item_repo.list_by_job("tenant-a", job.job_id)
 
@@ -48,7 +48,7 @@ async def test_serialize_job_maps_to_snake_case_shape(repo, item_repo):
 @pytest.mark.asyncio
 async def test_subscribe_replays_done_immediately_for_finished_job(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    await jobs.finish_job(repo, item_repo, "tenant-a", job.job_id, "completed")
+    await jobs.finish_job(repo, "tenant-a", job.job_id, "completed")
     events = [e async for e in jobs.subscribe(repo, item_repo, "tenant-a", job.job_id)]
     assert len(events) == 1
     assert events[0]["event"] == "done"
@@ -64,15 +64,39 @@ async def test_subscribe_wrong_tenant_yields_nothing(repo, item_repo):
 @pytest.mark.asyncio
 async def test_set_total_broadcasts_progress(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    await jobs.set_total(repo, item_repo, "tenant-a", job.job_id, 3)
+    await jobs.set_total(repo, "tenant-a", job.job_id, 3)
     stored = await repo.get_job("tenant-a", job.job_id)
     assert stored.total_items == 3
 
 
 @pytest.mark.asyncio
+async def test_subscribe_polls_for_progress_then_done(repo, item_repo, monkeypatch):
+    monkeypatch.setattr(jobs, "POLL_INTERVAL_SECONDS", 0)
+    job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=2)
+    job = await repo.claim_next_pending("subodha")
+
+    events = []
+
+    async def _consume():
+        async for event in jobs.subscribe(repo, item_repo, "tenant-a", job.job_id):
+            events.append(event)
+            if len(events) == 1:
+                await jobs.record_item_result(
+                    item_repo, "tenant-a", job.job_id,
+                    SyncItemResult("c1", "Course One", "saved", None, "2026-08-06T00:00:00Z"),
+                )
+            elif len(events) == 2:
+                await jobs.finish_job(repo, "tenant-a", job.job_id, "completed")
+
+    await _consume()
+
+    assert [e["event"] for e in events] == ["progress", "progress", "done"]
+
+
+@pytest.mark.asyncio
 async def test_finish_job_sets_status(repo, item_repo):
     job = await jobs.create_job(repo, tenant_id="tenant-a", source_type="subodha", scope="all", source_id=None, total_items=0)
-    await jobs.finish_job(repo, item_repo, "tenant-a", job.job_id, "failed", error="boom")
+    await jobs.finish_job(repo, "tenant-a", job.job_id, "failed", error="boom")
     stored = await repo.get_job("tenant-a", job.job_id)
     assert stored.status == "failed"
     assert stored.error == "boom"

--- a/platform/tests/unit/test_insti_nav_keys.py
+++ b/platform/tests/unit/test_insti_nav_keys.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+
+def _make_theme_items(count: int) -> tuple[list[str], list[str]]:
+    urls = [f"http://example.com/theme{i}.mp3" for i in range(count)]
+    keys = [f"Theme{i}" for i in range(count)]
+    return urls, keys
+
+
+class TestPageSizeSeven:
+    def test_seven_items_no_pagination_keys(self) -> None:
+        from app.services.fsm.instantiation.insti import _get_stream_actions
+
+        urls, keys = _make_theme_items(7)
+        result = _get_stream_actions(urls, keys, level=1, state=0, parent_selections={"language": "en"})
+
+        option_keys = {o.key for o in result["menu"].options}
+        assert "#" not in option_keys, "no next-page key when everything fits on one page"
+        assert "*" not in option_keys, "no prev-page key on the only page"
+
+    def test_seventh_item_maps_to_content_not_nav(self) -> None:
+        from app.services.fsm.instantiation.insti import _get_stream_actions
+
+        urls, keys = _make_theme_items(7)
+        result = _get_stream_actions(urls, keys, level=1, state=0, parent_selections={"language": "en"})
+
+        option_by_key = {o.key: o.value for o in result["menu"].options}
+        assert option_by_key["7"] == "Theme6", "key 7 must select the 7th item, not trigger repeat"
+
+    def test_eight_items_first_page_has_next_only(self) -> None:
+        from app.services.fsm.instantiation.insti import _get_stream_actions
+
+        urls, keys = _make_theme_items(8)
+        result = _get_stream_actions(urls, keys, level=1, state=0, parent_selections={"language": "en"})
+
+        option_keys = {o.key for o in result["menu"].options}
+        assert "#" in option_keys, "next-page key must appear when a second page exists"
+        assert "*" not in option_keys, "no prev-page key on the first page"
+
+    def test_eight_items_second_page_has_prev_only(self) -> None:
+        from app.services.fsm.instantiation.insti import _get_stream_actions
+
+        urls, keys = _make_theme_items(8)
+        result = _get_stream_actions(urls, keys, level=1, state=1, parent_selections={"language": "en"})
+
+        option_keys = {o.key for o in result["menu"].options}
+        assert "*" in option_keys, "prev-page key must appear on the second page"
+        assert "#" not in option_keys, "no next-page key past the last page"
+        option_by_key = {o.key: o.value for o in result["menu"].options}
+        assert option_by_key["1"] == "Theme7"
+
+
+class TestRepeatKeyKept:
+    def test_repeat_option_in_menu_on_key_eight(self) -> None:
+        from app.services.fsm.instantiation.insti import _get_stream_actions
+
+        urls, keys = _make_theme_items(3)
+        result = _get_stream_actions(urls, keys, level=1, state=0, parent_selections={"language": "en"})
+
+        option_by_key = {o.key: o.value for o in result["menu"].options}
+        assert option_by_key["8"] == "repeatCurrentMenu"
+
+    def test_back_a_level_key_still_present(self) -> None:
+        from app.services.fsm.instantiation.insti import _get_stream_actions
+
+        urls, keys = _make_theme_items(3)
+        result = _get_stream_actions(urls, keys, level=1, state=0, parent_selections={"language": "en"})
+
+        option_by_key = {o.key: o.value for o in result["menu"].options}
+        assert option_by_key["9"] == "previous category level"

--- a/platform/tests/unit/test_ivr_constants.py
+++ b/platform/tests/unit/test_ivr_constants.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+def test_page_size_is_seven() -> None:
+    from app.services.fsm.instantiation.ivr_constants import (
+        number_of_categories_listed_in_one_state,
+    )
+
+    assert number_of_categories_listed_in_one_state == 7
+
+
+def test_pagination_keys_are_star_and_hash() -> None:
+    from app.services.fsm.instantiation.ivr_constants import (
+        next_n_categories_key,
+        previous_n_categories_key,
+    )
+
+    assert next_n_categories_key == "#"
+    assert previous_n_categories_key == "*"
+
+
+def test_previous_category_level_key_unchanged() -> None:
+    from app.services.fsm.instantiation.ivr_constants import (
+        previous_category_level_key,
+    )
+
+    assert previous_category_level_key == "9"
+
+
+def test_repeat_key_constant_is_eight() -> None:
+    from app.services.fsm.instantiation.ivr_constants import (
+        repeat_current_categories_key,
+    )
+
+    assert repeat_current_categories_key == "8"

--- a/platform/tests/unit/test_providers_extra.py
+++ b/platform/tests/unit/test_providers_extra.py
@@ -80,6 +80,7 @@ class TestServiceBusProvider:
         mock_settings.call_webhook_queue_name = "call_webhook"
         mock_settings.dtmf_input_queue_name = "dtmf_input"
         mock_settings.call_event_queue_name = "call_event"
+        mock_settings.sync_jobs_queue_name = "sync_jobs"
 
         with patch("app.platform.settings.get_settings", return_value=mock_settings):
             svc = ServiceBusProvider()
@@ -87,6 +88,7 @@ class TestServiceBusProvider:
 
         assert svc._initialized is True
         assert svc._call_webhook is None
+        assert svc._sync_jobs is None
 
     def test_get_handle_returns_none_for_unknown(self) -> None:
         from app.providers.service_bus import ServiceBusProvider
@@ -95,6 +97,7 @@ class TestServiceBusProvider:
         svc._call_webhook = None
         svc._dtmf_input = None
         svc._call_event = None
+        svc._sync_jobs = None
         svc._initialized = True
 
         result = svc._get_handle("nonexistent_queue")
@@ -107,10 +110,12 @@ class TestServiceBusProvider:
         svc._call_webhook = None
         svc._dtmf_input = None
         svc._call_event = None
+        svc._sync_jobs = None
 
         assert svc.get_call_webhook_queue() is None
         assert svc.get_dtmf_input_queue() is None
         assert svc.get_call_event_queue() is None
+        assert svc.get_sync_jobs_queue() is None
 
     @pytest.mark.asyncio
     async def test_send_message_no_handle_returns_false(self) -> None:

--- a/platform/tests/unit/test_pure_audio_nav_keys.py
+++ b/platform/tests/unit/test_pure_audio_nav_keys.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.services.fsm.fsm import FSM
+from app.services.fsm.instantiation.pure_audio import PureAudio
+from app.services.fsm.state import State
+
+
+def _make_content_data() -> MagicMock:
+    data = MagicMock()
+    data.language = "en"
+    data.title.local = "Local Title"
+    data.title.english = "English Title"
+    data.audio_content = []  # skip the WebSocket/duration branch entirely
+    data.school_id = ""
+    return data
+
+
+def _build_fsm_with_playback_state():
+    with patch("app.services.fsm.instantiation.pure_audio.get_settings") as mock_settings:
+        mock_settings.return_value.azure_storage_account_name = ""
+        mock_settings.return_value.websocket_service_url = "ws://example.com"
+
+        with patch("app.services.fsm.fsm.get_settings") as mock_fsm_settings:
+            mock_fsm_settings.return_value.azure_storage_account_name = ""
+            fsm = FSM(fsm_id="test")
+
+        parent_state_id = "TI0"
+        fsm.add_state(State(state_id=parent_state_id, actions=[]))
+
+        pure_audio = PureAudio(_make_content_data(), speech_rate="1.0")
+        pure_audio.generate_state(
+            fsm,
+            prefix_state_id="TI0-Op0(Title)-",
+            parent_block_state_id=parent_state_id,
+            key_chosen=1,
+            level=3,
+        )
+
+    return fsm, "TI0-Op0(Title)"
+
+
+class TestPureAudioRepeatKept:
+    def test_repeat_option_in_menu(self) -> None:
+        fsm, state_id = _build_fsm_with_playback_state()
+
+        state = fsm.states[state_id]
+        option_by_key = {o.key: o.value for o in state.menu.options}
+        assert option_by_key["8"] == "repeat"
+
+    def test_key_8_self_loop_transition(self) -> None:
+        fsm, state_id = _build_fsm_with_playback_state()
+
+        state = fsm.states[state_id]
+        assert "8" in state.transition_map
+        assert state.transition_map["8"].dest_state_id == state_id
+
+    def test_exit_key_9_unaffected(self) -> None:
+        fsm, state_id = _build_fsm_with_playback_state()
+
+        state = fsm.states[state_id]
+        assert "9" in state.transition_map
+        assert state.transition_map["9"].dest_state_id == "TI0"
+        option_by_key = {o.key: o.value for o in state.menu.options}
+        assert option_by_key["9"] == "exit"

--- a/platform/tests/unit/test_service_bus_deep.py
+++ b/platform/tests/unit/test_service_bus_deep.py
@@ -24,6 +24,7 @@ class TestServiceBusProviderNullHandles:
         p._call_webhook = None
         p._dtmf_input = None
         p._call_event = None
+        p._sync_jobs = None
         p._initialized = True
         return p
 
@@ -73,6 +74,12 @@ class TestServiceBusProviderNullHandles:
     async def test_send_call_event_null_handle_returns_false(self) -> None:
         p = self._make_provider()
         result = await p.send_call_event({"status": "completed"})
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_sync_job_null_handle_returns_false(self) -> None:
+        p = self._make_provider()
+        result = await p.send_sync_job({"job_id": "j1", "tenant_id": "t1"})
         assert result is False
 
     def test_get_handle_returns_none_for_unknown_queue(self) -> None:

--- a/platform/tests/unit/test_sync_job_consumer.py
+++ b/platform/tests/unit/test_sync_job_consumer.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.consumers.sync_job_consumer import SyncJobConsumer
+
+
+@pytest.mark.asyncio
+async def test_run_loop_claims_and_stops_when_no_job_available():
+    job_repo = MagicMock()
+    job_repo.claim_next_pending = AsyncMock(return_value=None)
+    consumer = SyncJobConsumer(job_repo=job_repo, item_repo=MagicMock(), db=MagicMock(), poll_interval_seconds=0)
+    consumer._running = True
+
+    async def _stop(*_):
+        consumer._running = False
+
+    consumer._sleep = AsyncMock(side_effect=_stop)
+    await consumer._run_loop()
+    job_repo.claim_next_pending.assert_awaited_with("subodha")
+
+
+@pytest.mark.asyncio
+async def test_run_loop_marks_job_failed_when_client_construction_raises(monkeypatch):
+    from app.aggregators.sync_job_models import SyncJob
+
+    claimed_job = SyncJob(
+        job_id="job-x", tenant_id="t1", source_type="subodha", scope="all", source_id=None,
+        status="running", created_at="now", started_at="now", finished_at=None, total_items=0, error=None, options={},
+    )
+    job_repo = MagicMock()
+    job_repo.claim_next_pending = AsyncMock(side_effect=[claimed_job, None])
+    item_repo = MagicMock()
+
+    finish_job_mock = AsyncMock()
+    monkeypatch.setattr("app.consumers.sync_job_consumer.finish_job", finish_job_mock)
+
+    def _boom():
+        raise RuntimeError("tenant Subodha creds missing")
+
+    monkeypatch.setattr("app.consumers.sync_job_consumer.get_subodha_client", _boom)
+
+    consumer = SyncJobConsumer(job_repo=job_repo, item_repo=item_repo, db=MagicMock(), poll_interval_seconds=0)
+    consumer._running = True
+    tick_count = 0
+
+    async def _one_tick(*_):
+        nonlocal tick_count
+        tick_count += 1
+        if tick_count >= 1:
+            consumer._running = False
+
+    consumer._sleep = AsyncMock(side_effect=_one_tick)
+    await consumer._run_loop()
+
+    finish_job_mock.assert_awaited_once_with(job_repo, "t1", "job-x", "failed", error="tenant Subodha creds missing")
+
+
+@pytest.mark.asyncio
+async def test_run_loop_dispatches_scope_all_job_with_options(monkeypatch):
+    from app.aggregators.sync_job_models import SyncJob
+
+    claimed_job = SyncJob(
+        job_id="job-y", tenant_id="t1", source_type="subodha", scope="all", source_id=None,
+        status="running", created_at="now", started_at="now", finished_at=None, total_items=0, error=None,
+        options={"only_new": True, "dry_run": True, "limit": 5},
+    )
+    job_repo = MagicMock()
+    job_repo.claim_next_pending = AsyncMock(side_effect=[claimed_job, None])
+    item_repo = MagicMock()
+
+    monkeypatch.setattr("app.consumers.sync_job_consumer.get_subodha_client", lambda: MagicMock())
+    monkeypatch.setattr("app.consumers.sync_job_consumer.get_subodha_service", lambda db: MagicMock())
+
+    run_sync_job_mock = AsyncMock()
+    monkeypatch.setattr("app.consumers.sync_job_consumer._run_sync_job", run_sync_job_mock)
+
+    consumer = SyncJobConsumer(job_repo=job_repo, item_repo=item_repo, db=MagicMock(), poll_interval_seconds=0)
+    consumer._running = True
+    consumer._sleep = AsyncMock(side_effect=lambda *_: setattr(consumer, "_running", False))
+    await consumer._run_loop()
+
+    _, kwargs = run_sync_job_mock.call_args
+    assert kwargs == {"only_new": True, "dry_run": True, "limit": 5}
+
+
+@pytest.mark.asyncio
+async def test_run_loop_dispatches_scope_course_job(monkeypatch):
+    from app.aggregators.sync_job_models import SyncJob
+
+    claimed_job = SyncJob(
+        job_id="job-z", tenant_id="t1", source_type="subodha", scope="course", source_id="course-1",
+        status="running", created_at="now", started_at="now", finished_at=None, total_items=1, error=None,
+        options={"dry_run": True},
+    )
+    job_repo = MagicMock()
+    job_repo.claim_next_pending = AsyncMock(side_effect=[claimed_job, None])
+    item_repo = MagicMock()
+
+    monkeypatch.setattr("app.consumers.sync_job_consumer.get_subodha_client", lambda: MagicMock())
+    monkeypatch.setattr("app.consumers.sync_job_consumer.get_subodha_service", lambda db: MagicMock())
+
+    run_course_sync_job_mock = AsyncMock()
+    monkeypatch.setattr("app.consumers.sync_job_consumer._run_course_sync_job", run_course_sync_job_mock)
+
+    consumer = SyncJobConsumer(job_repo=job_repo, item_repo=item_repo, db=MagicMock(), poll_interval_seconds=0)
+    consumer._running = True
+    consumer._sleep = AsyncMock(side_effect=lambda *_: setattr(consumer, "_running", False))
+    await consumer._run_loop()
+
+    args, kwargs = run_course_sync_job_mock.call_args
+    assert args[-1] == "course-1"
+    assert kwargs == {"dry_run": True}
+
+
+@pytest.mark.asyncio
+async def test_wait_for_next_poll_falls_back_to_sleep_when_queue_unconfigured(monkeypatch):
+    from app.consumers import sync_job_consumer as mod
+
+    monkeypatch.setattr(mod.service_bus_provider, "get_sync_jobs_queue", lambda: None)
+    consumer = SyncJobConsumer(job_repo=MagicMock(), item_repo=MagicMock(), db=MagicMock(), poll_interval_seconds=7)
+    consumer._sleep = AsyncMock()
+
+    await consumer._wait_for_next_poll()
+
+    consumer._sleep.assert_awaited_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_next_poll_receives_from_sync_jobs_queue_when_configured(monkeypatch):
+    from app.consumers import sync_job_consumer as mod
+
+    monkeypatch.setattr(mod.service_bus_provider, "get_sync_jobs_queue", lambda: MagicMock())
+    receive_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr(mod.service_bus_provider, "receive_messages", receive_mock)
+    consumer = SyncJobConsumer(job_repo=MagicMock(), item_repo=MagicMock(), db=MagicMock(), poll_interval_seconds=7)
+    consumer._sleep = AsyncMock()
+
+    await consumer._wait_for_next_poll()
+
+    receive_mock.assert_awaited_once_with("sync_jobs", max_count=1, wait_seconds=7)
+    consumer._sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_next_poll_falls_back_to_sleep_on_receive_error(monkeypatch):
+    from app.consumers import sync_job_consumer as mod
+
+    monkeypatch.setattr(mod.service_bus_provider, "get_sync_jobs_queue", lambda: MagicMock())
+    monkeypatch.setattr(
+        mod.service_bus_provider, "receive_messages", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    consumer = SyncJobConsumer(job_repo=MagicMock(), item_repo=MagicMock(), db=MagicMock(), poll_interval_seconds=3)
+    consumer._sleep = AsyncMock()
+
+    await consumer._wait_for_next_poll()
+
+    consumer._sleep.assert_awaited_once_with(3)

--- a/platform/tests/unit/test_sync_job_models.py
+++ b/platform/tests/unit/test_sync_job_models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from app.aggregators.sync_job_models import SyncJob
+
+
+def test_sync_job_retry_count_defaults_to_zero_and_round_trips():
+    job = SyncJob(
+        job_id="job-1", tenant_id="tenant-1", source_type="subodha", scope="all",
+        source_id=None, status="pending", created_at="2026-09-09T00:00:00+00:00",
+        started_at=None, finished_at=None, total_items=0, error=None, options={},
+    )
+    assert job.retry_count == 0
+    assert job.to_doc()["retry_count"] == 0
+
+    restored = SyncJob.from_doc({**job.to_doc()})
+    assert restored.retry_count == 0
+
+
+def test_sync_job_from_doc_defaults_retry_count_for_legacy_docs():
+    doc = {
+        "_id": "job-2", "tenant_id": "tenant-1", "source_type": "subodha", "scope": "all",
+        "source_id": None, "status": "running", "created_at": "2026-09-09T00:00:00+00:00",
+        "started_at": "2026-09-09T00:00:00+00:00", "finished_at": None,
+        "total_items": 0, "error": None, "options": {},
+        # no "retry_count" key — simulates a doc written before this change
+    }
+    job = SyncJob.from_doc(doc)
+    assert job.retry_count == 0

--- a/platform/tests/unit/test_tts_and_insti.py
+++ b/platform/tests/unit/test_tts_and_insti.py
@@ -217,14 +217,14 @@ class TestInstiHelpers:
     def test_option_class(self) -> None:
         from app.services.fsm.instantiation.insti import _Option
 
-        opt = _Option(1, "Mathematics")
-        assert opt.key == 1
+        opt = _Option("1", "Mathematics")
+        assert opt.key == "1"
         assert opt.value == "Mathematics"
 
     def test_menu_class_dict(self) -> None:
         from app.services.fsm.instantiation.insti import _Menu, _Option
 
-        opts = [_Option(1, "Math"), _Option(2, "Science")]
+        opts = [_Option("1", "Math"), _Option("2", "Science")]
         menu = _Menu("Select subject", opts, level=1, language="english")
         d = menu.dict()
         assert d["description"] == "Select subject"


### PR DESCRIPTION
- Added SyncJobConsumer to handle synchronization jobs, including job claiming and processing.
- Implemented job reconciliation logic to manage interrupted jobs and retry mechanisms.
- Enhanced ContentAggregatorSyncJobRepository with methods for claiming pending jobs and handling retries.
- Updated lifespan management to initialize SyncJobConsumer and reconcile jobs on startup.
- Introduced new settings for sync jobs queue and integrated with ServiceBusProvider.
- Refactored job creation and result recording to support new job options and status updates.
- Added unit and integration tests for SyncJobConsumer and related job processing logic.
- Updated existing tests to accommodate changes in job status handling and retry logic.
