### PR TITLE
feat: add localization UI (#436)

### DIFF
--- a/ContentWebApp/jest.config.js
+++ b/ContentWebApp/jest.config.js
@@ -15,6 +15,8 @@ module.exports = {
   moduleNameMapper: {
     "\\.(css|less|scss|sass)$": "<rootDir>/tests/styleMock.js",
     "\\.svg$": "<rootDir>/tests/svgMock.js",
+    "^@radix-ui/primitive/is-development$":
+      "<rootDir>/node_modules/@radix-ui/primitive/dist/internal/is-development.false.js",
   },
   coverageDirectory: "coverage",
   coverageReporters: ["json-summary", "text", "lcov", "html"],

--- a/ContentWebApp/package-lock.json
+++ b/ContentWebApp/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@azure/storage-blob": "^12.12.0",
+        "@fontsource/inter": "^5.3.0",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.0.0",
@@ -376,7 +377,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1026,7 +1026,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
       "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1910,7 +1909,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -2770,6 +2768,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fontsource/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -3401,7 +3408,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4666,7 +4672,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -5250,7 +5255,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5394,7 +5398,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -5448,7 +5451,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5832,7 +5834,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5937,7 +5938,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6918,7 +6918,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -8255,7 +8254,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9308,7 +9306,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9365,7 +9362,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11941,7 +11937,6 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12818,7 +12813,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -16678,7 +16672,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17866,7 +17859,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18108,7 +18100,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -18259,7 +18250,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -18332,7 +18322,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -18542,7 +18531,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -18718,7 +18706,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19041,8 +19028,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -19573,7 +19559,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -19819,7 +19804,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21744,7 +21728,6 @@
       "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.3.0",
         "node-gyp-build": "^4.8.4"
@@ -21900,7 +21883,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -22674,7 +22656,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -22746,7 +22727,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -23153,7 +23133,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/ContentWebApp/package.json
+++ b/ContentWebApp/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@azure/storage-blob": "^12.12.0",
+    "@fontsource/inter": "^5.3.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",

--- a/ContentWebApp/public/index.html
+++ b/ContentWebApp/public/index.html
@@ -41,5 +41,11 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <script
+      src="/sdk.js"
+      data-site-id="%REACT_APP_SDK_SITE_ID%"
+      data-api-base="%REACT_APP_SDK_API_BASE%"
+      defer>
+    </script>
   </body>
 </html>

--- a/ContentWebApp/public/sdk.js
+++ b/ContentWebApp/public/sdk.js
@@ -1,0 +1,369 @@
+(function () {
+  "use strict";
+
+  if (window.__translationSdkInitialized) return;
+  window.__translationSdkInitialized = true;
+
+  var LANGUAGES = {};
+  var DEFAULT_LANG = "en";
+  var LANG_STORAGE_KEY = "translationSdk.lang";
+  var EXTRACT_DEBOUNCE_MS = 800;
+  var EXTRACT_CHUNK_SIZE = 500;
+  var SKIP_TAGS = { SCRIPT: 1, STYLE: 1, NOSCRIPT: 1, TITLE: 1 };
+  var ATTR_NAMES = ["placeholder", "aria-label", "title", "alt", "aria-placeholder", "value"];
+
+  var CURRENT_SCRIPT = document.currentScript;
+  var SITE_ID = CURRENT_SCRIPT.getAttribute("data-site-id");
+  var API_BASE = CURRENT_SCRIPT.getAttribute("data-api-base");
+
+  var registry = new Map();
+  var pendingKeys = new Map();
+  var extractTimer = null;
+
+  function getDescriptors(key) {
+    var descriptors = registry.get(key);
+    if (!descriptors) {
+      descriptors = [];
+      registry.set(key, descriptors);
+    }
+    return descriptors;
+  }
+
+  function currentRoute() {
+    return window.location.pathname;
+  }
+
+  function currentLang() {
+    return localStorage.getItem(LANG_STORAGE_KEY) || DEFAULT_LANG;
+  }
+
+  function setCurrentLang(lang) {
+    localStorage.setItem(LANG_STORAGE_KEY, lang);
+  }
+
+  function hashText(text) {
+    var hash = 0;
+    for (var i = 0; i < text.length; i++) {
+      hash = (hash << 5) - hash + text.charCodeAt(i);
+      hash |= 0;
+    }
+    return "t" + Math.abs(hash).toString(36);
+  }
+
+  function isTranslatable(text) {
+    var trimmed = text.trim();
+    if (!trimmed) return false;
+    return !/^[\d\s.,%$₹-]+$/.test(trimmed);
+  }
+
+  function isSkippableElement(el) {
+    if (!el) return false;
+    if (SKIP_TAGS[el.tagName]) return true;
+    if (el.closest("[data-no-translate]")) return true;
+    if (el.closest("#translation-sdk-widget")) return true;
+    return false;
+  }
+
+  function isValueAttrTranslatable(el) {
+    if (el.tagName !== "INPUT") return false;
+    var t = (el.getAttribute("type") || "text").toLowerCase();
+    return t === "button" || t === "submit" || t === "reset";
+  }
+
+  function registerNode(node) {
+    var text = node.textContent;
+    if (!isTranslatable(text)) return;
+    if (isSkippableElement(node.parentElement)) return;
+    if (node.__translationOriginal !== undefined && node.textContent !== node.__translationOriginal) return;
+    if (node.__translationSelfWrite) return;
+
+    var key = hashText(text.trim());
+    if (!node.__translationOriginal) node.__translationOriginal = text;
+
+    var descriptors = getDescriptors(key);
+    var alreadyRegistered = descriptors.some(function (d) {
+      return d.kind === "text" && d.node === node;
+    });
+    if (alreadyRegistered) return;
+    descriptors.push({ kind: "text", node: node });
+    pendingKeys.set(key, text.trim());
+    scheduleExtractFlush();
+  }
+
+  function registerAttr(el, attr) {
+    var text = el.getAttribute(attr);
+    if (!isTranslatable(text)) return;
+    if (isSkippableElement(el)) return;
+
+    if (!el.__translationRegisteredAttrs) el.__translationRegisteredAttrs = {};
+    if (el.__translationRegisteredAttrs[attr] !== undefined) return;
+
+    var trimmed = text.trim();
+    var key = hashText(trimmed);
+
+    el.__translationRegisteredAttrs[attr] = text;
+
+    var descriptors = getDescriptors(key);
+    descriptors.push({ kind: "attr", el: el, attr: attr });
+    pendingKeys.set(key, trimmed);
+    scheduleExtractFlush();
+  }
+
+  function walkAttributes(root) {
+    var elements = root.nodeType === Node.ELEMENT_NODE ? [root] : [];
+    elements = elements.concat(Array.prototype.slice.call(root.querySelectorAll("*")));
+    elements.forEach(function (el) {
+      if (isSkippableElement(el)) return;
+      ATTR_NAMES.forEach(function (attr) {
+        if (!el.hasAttribute(attr)) return;
+        if (attr === "value" && !isValueAttrTranslatable(el)) return;
+        registerAttr(el, attr);
+      });
+    });
+  }
+
+  function walk(root) {
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+    var node;
+    while ((node = walker.nextNode())) registerNode(node);
+    walkAttributes(root);
+  }
+
+  function scheduleExtractFlush() {
+    clearTimeout(extractTimer);
+    extractTimer = setTimeout(flushExtracted, EXTRACT_DEBOUNCE_MS);
+  }
+
+  async function flushExtracted() {
+    clearTimeout(extractTimer);
+    extractTimer = null;
+    if (pendingKeys.size === 0) return;
+
+    var route = currentRoute();
+    var items = [];
+    pendingKeys.forEach(function (text, key) {
+      items.push({ key: key, text: text, route: route });
+    });
+    pendingKeys.clear();
+
+    var requests = [];
+    for (var i = 0; i < items.length; i += EXTRACT_CHUNK_SIZE) {
+      var chunk = items.slice(i, i + EXTRACT_CHUNK_SIZE);
+      requests.push(
+        fetch(API_BASE + "/translations/extract", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ site_id: SITE_ID, items: chunk }),
+        })
+      );
+    }
+    await Promise.all(requests);
+  }
+
+  var applyInFlight = false;
+  var applyPendingLang = null;
+
+  async function applyTranslations(lang) {
+    if (applyInFlight) {
+      applyPendingLang = lang;
+      return;
+    }
+    applyInFlight = true;
+    await runApplyTranslations(lang);
+    applyInFlight = false;
+    if (applyPendingLang !== null) {
+      var next = applyPendingLang;
+      applyPendingLang = null;
+      applyTranslations(next);
+    }
+  }
+
+  async function runApplyTranslations(lang) {
+    var route = currentRoute();
+    if (lang === DEFAULT_LANG) {
+      registry.forEach(function (descriptors) {
+        applyValues(descriptors, function (d) {
+          return d.kind === "attr" ? d.el.__translationRegisteredAttrs[d.attr] : d.node.__translationOriginal;
+        });
+      });
+      return;
+    }
+
+    await flushExtracted();
+    var url =
+      API_BASE +
+      "/translations?site_id=" + encodeURIComponent(SITE_ID) +
+      "&route=" + encodeURIComponent(route) +
+      "&lang=" + encodeURIComponent(lang);
+    var r = await fetch(url);
+    var translations = await r.json();
+    swapText(translations);
+  }
+
+  function applyValues(descriptors, getValue) {
+    descriptors.forEach(function (d) {
+      var value = getValue(d);
+      if (d.kind === "attr") {
+        if (d.el.getAttribute(d.attr) === value) return;
+        d.el.setAttribute(d.attr, value);
+      } else {
+        d.node.__translationApplied = value;
+        if (d.node.textContent === value) return;
+        d.node.__translationSelfWrite = true;
+        d.node.textContent = value;
+      }
+    });
+  }
+
+  function swapText(translations) {
+    Object.keys(translations).forEach(function (key) {
+      var descriptors = registry.get(key);
+      if (!descriptors) return;
+      applyValues(descriptors, function () {
+        return translations[key];
+      });
+    });
+  }
+
+  function createWidget() {
+    var widget = document.createElement("div");
+    widget.id = "translation-sdk-widget";
+    widget.setAttribute("data-no-translate", "true");
+    widget.style.cssText =
+      "position:fixed;bottom:16px;right:16px;z-index:2147483647;font-family:sans-serif;";
+
+    var select = document.createElement("select");
+    select.style.cssText =
+      "padding:8px 12px;border-radius:6px;border:1px solid #ccc;background:#fff;box-shadow:0 2px 8px rgba(0,0,0,.15);cursor:pointer;";
+    Object.keys(LANGUAGES).forEach(function (code) {
+      var opt = document.createElement("option");
+      opt.value = code;
+      opt.textContent = LANGUAGES[code];
+      select.appendChild(opt);
+    });
+    select.value = currentLang();
+    select.addEventListener("change", function () {
+      var lang = select.value;
+      setCurrentLang(lang);
+      applyTranslations(lang);
+    });
+
+    widget.appendChild(select);
+    document.body.appendChild(widget);
+  }
+
+  function observeMutations() {
+    var observer = new MutationObserver(function (mutations) {
+      var newRoots = [];
+      var changedTextNodes = [];
+
+      mutations.forEach(function (m) {
+        if (m.type === "childList") {
+          m.addedNodes.forEach(function (n) {
+            if (n.nodeType === Node.TEXT_NODE) {
+              registerNode(n);
+            } else if (n.nodeType === Node.ELEMENT_NODE) {
+              newRoots.push(n);
+            }
+          });
+        } else if (m.type === "characterData") {
+          var node = m.target;
+          if (
+            node.__translationApplied !== undefined &&
+            node.textContent === node.__translationApplied
+          ) {
+            node.__translationSelfWrite = false;
+            return;
+          }
+          if (node.__translationSelfWrite) {
+            node.__translationSelfWrite = false;
+            return;
+          }
+          node.__translationOriginal = undefined;
+          changedTextNodes.push(node);
+        }
+      });
+
+      newRoots.forEach(walk);
+      changedTextNodes.forEach(registerNode);
+
+      var lang = currentLang();
+      if (lang !== DEFAULT_LANG && (newRoots.length > 0 || changedTextNodes.length > 0)) {
+        applyTranslations(lang);
+      }
+    });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      characterDataOldValue: true,
+    });
+  }
+
+  var lastRoute = null;
+  var routeChangeTimer = null;
+
+  function applyCurrentLangIfNeeded() {
+    var lang = currentLang();
+    if (lang !== DEFAULT_LANG) applyTranslations(lang);
+  }
+
+  function checkRouteChange() {
+    routeChangeTimer = null;
+    var route = currentRoute();
+    if (route === lastRoute) return;
+    lastRoute = route;
+
+    walk(document.body);
+    applyCurrentLangIfNeeded();
+  }
+
+  function scheduleRouteChangeCheck() {
+    if (routeChangeTimer) return;
+    routeChangeTimer = setTimeout(checkRouteChange, 50);
+  }
+
+  function patchHistoryMethod(name) {
+    var original = window.history[name];
+    window.history[name] = function () {
+      var result = original.apply(this, arguments);
+      scheduleRouteChangeCheck();
+      return result;
+    };
+  }
+
+  function observeRouteChanges() {
+    lastRoute = currentRoute();
+
+    patchHistoryMethod("pushState");
+    patchHistoryMethod("replaceState");
+    window.addEventListener("popstate", scheduleRouteChangeCheck);
+    window.addEventListener("hashchange", scheduleRouteChangeCheck);
+  }
+
+  async function loadLanguages() {
+    var r = await fetch(API_BASE + "/languages?enabledOnly=true");
+    var list = await r.json();
+    var map = {};
+    list.forEach(function (lang) {
+      map[lang.code] = lang.name;
+    });
+    return map;
+  }
+
+  async function init() {
+    walk(document.body);
+    observeMutations();
+    observeRouteChanges();
+
+    LANGUAGES = await loadLanguages();
+    createWidget();
+    applyCurrentLangIfNeeded();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/ContentWebApp/src/components/AllContent.js
+++ b/ContentWebApp/src/components/AllContent.js
@@ -13,6 +13,7 @@ import ContentTab from "./AllContent/ContentTab/ContentTab";
 import IVRTab from "./AllContent/IVRTab/IVRTab";
 import RegistrationTab from "./AllContent/RegistrationTab/RegistrationTab";
 import AnalyticsTab from "./AllContent/AnalyticsTab/AnalyticsTab";
+import LocalizationUI from "../localization-ui/LocalizationUI";
 import { USER_ROLES } from "../Constants";
 import "./AllContent/AllContent.css";
 import "./AllContent/shared/responsive.css";
@@ -148,11 +149,12 @@ const AllContent = () => {
           showContent={canViewContent}
           showRegistration={canViewRegistration}
           showAnalytics={canViewAnalytics}
+          showLocalization={true}
         />
 
         {updateIVRStatus && <div className="status-message">{updateIVRStatus}</div>}
 
-        {canViewContent && activeTab !== "registration" && activeTab !== "analytics" && (
+        {canViewContent && activeTab !== "registration" && activeTab !== "analytics" && activeTab !== "localization" && (
           <div className="tabs-container">
             <button
               type="button"
@@ -202,6 +204,8 @@ const AllContent = () => {
         {canViewContent && activeTab === "ivr" && <IVRTab />}
 
         {canViewAnalytics && activeTab === "analytics" && <AnalyticsTab />}
+
+        {canViewContent && activeTab === "localization" && <LocalizationUI />}
 
         {canViewRegistration && activeTab === "registration" && (
           <RegistrationTab

--- a/ContentWebApp/src/components/AllContent/Header/AppHeader.js
+++ b/ContentWebApp/src/components/AllContent/Header/AppHeader.js
@@ -14,6 +14,7 @@ const AppHeader = ({
   showContent = true,
   showRegistration = true,
   showAnalytics = true,
+  showLocalization = true,
 }) => {
   const [showUserDropdown, setShowUserDropdown] = useState(false);
   const navigate = useNavigate();
@@ -58,6 +59,14 @@ const AppHeader = ({
               onClick={() => onTabChange("analytics")}
             >
               Analytics
+            </button>
+          )}
+          {showLocalization && (
+            <button
+              className={`nav-link ${activeTab === "localization" ? "active" : ""}`}
+              onClick={() => onTabChange("localization")}
+            >
+              Localization
             </button>
           )}
         </div>

--- a/ContentWebApp/src/components/AllContent/shared/Select.css
+++ b/ContentWebApp/src/components/AllContent/shared/Select.css
@@ -24,6 +24,11 @@
   border-color: var(--color-primary);
 }
 
+.custom-select-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .custom-select-trigger:focus-visible,
 .custom-select-trigger[aria-expanded="true"] {
   outline: none;

--- a/ContentWebApp/src/components/AllContent/shared/Select.js
+++ b/ContentWebApp/src/components/AllContent/shared/Select.js
@@ -3,12 +3,12 @@ import { ReactComponent as ChevronDownIcon } from "../../../assets/icons/chevron
 import { ReactComponent as CheckmarkIcon } from "../../../assets/icons/checkmark.svg";
 import "./Select.css";
 
-const Select = ({ id, value, onChange, options, placeholder }) => {
+const Select = ({ id, value, onChange, options, placeholder, disabled }) => {
   const [open, setOpen] = useState(false);
   const rootRef = useRef(null);
 
   useEffect(() => {
-    if (!open) return undefined;
+    if (!open || disabled) return undefined;
     const handleOutsideClick = (event) => {
       if (rootRef.current && !rootRef.current.contains(event.target)) setOpen(false);
     };
@@ -34,6 +34,7 @@ const Select = ({ id, value, onChange, options, placeholder }) => {
         onClick={() => setOpen((prev) => !prev)}
         aria-haspopup="listbox"
         aria-expanded={open}
+        disabled={disabled}
       >
         <span className={selected ? "" : "custom-select-placeholder"}>
           {selected ? selected.label : placeholder}

--- a/ContentWebApp/src/hooks/useLocalization.js
+++ b/ContentWebApp/src/hooks/useLocalization.js
@@ -1,0 +1,202 @@
+import { useEffect, useState } from "react";
+import { onboardingService } from "../services/onboardingService";
+import { languageService } from "../services/languageService";
+
+export const useLocalization = () => {
+
+  const [projects, setProjects] = useState([]);
+
+  const [sites, setSites] = useState([]);
+
+  const [isLoadingWorkspace, setIsLoadingWorkspace] = useState(true);
+
+  const [workspaceLoadError, setWorkspaceLoadError] = useState("");
+
+  useEffect(() => {
+
+    let cancelled = false;
+
+    const load = async () => {
+
+      setIsLoadingWorkspace(true);
+      setWorkspaceLoadError("");
+
+      try {
+
+        const [loadedProjects, loadedSites, loadedLanguages] = await Promise.all([
+          onboardingService.listProjects(),
+          onboardingService.listSites(),
+          languageService.listLanguages(),
+        ]);
+
+        if (cancelled) return;
+
+        setProjects(loadedProjects);
+        setSites(loadedSites);
+        setLanguages(loadedLanguages);
+
+      } catch (error) {
+
+        if (!cancelled) {
+          setWorkspaceLoadError(error.message);
+        }
+
+      } finally {
+
+        if (!cancelled) {
+          setIsLoadingWorkspace(false);
+        }
+
+      }
+
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+
+  }, []);
+
+  const [languages, setLanguages] = useState([]);
+
+  const handleCreateLanguage = async (language) => {
+    const created = await languageService.createLanguage({
+      name: language.name,
+      code: language.code,
+      direction: language.direction,
+      enabled: language.enabled,
+    });
+
+    setLanguages((prevLanguages) => [...prevLanguages, created]);
+
+    return created;
+  };
+
+  const handleUpdateLanguage = async (id, fields) => {
+    const updated = await languageService.updateLanguage(id, fields);
+
+    setLanguages((prevLanguages) =>
+      prevLanguages.map((language) => (language.id === id ? updated : language))
+    );
+
+    return updated;
+  };
+
+  const handleDeleteLanguage = async (id) => {
+    await languageService.deleteLanguage(id);
+
+    setLanguages((prevLanguages) =>
+      prevLanguages.filter((language) => language.id !== id)
+    );
+  };
+
+  const [showProjectModal, setShowProjectModal] =
+    useState(false);
+
+  const [showSiteModal, setShowSiteModal] =
+    useState(false);
+
+  const [showLanguageModal, setShowLanguageModal] =
+    useState(false);
+
+  const handleCreateProject = async (project) => {
+    const created = await onboardingService.createProject({
+      name: project.name,
+      description: project.description,
+      sourceLanguage: project.sourceLanguage,
+      status: project.status,
+    });
+
+    setProjects((prevProjects) => [...prevProjects, created]);
+
+    return created;
+  };
+
+  const handleUpdateProject = async (id, fields) => {
+    const updated = await onboardingService.updateProject(id, fields);
+
+    setProjects((prevProjects) =>
+      prevProjects.map((project) =>
+        project.id === id ? updated : project
+      )
+    );
+
+    return updated;
+  };
+
+  const handleDeleteProject = async (id) => {
+    await onboardingService.deleteProject(id);
+
+    setProjects((prevProjects) =>
+      prevProjects.filter((project) => project.id !== id)
+    );
+  };
+
+  const handleCreateSite = async (site) => {
+    const created = await onboardingService.createSite({
+      projectId: site.projectId,
+      domain: site.domain,
+      name: site.name,
+      status: site.status,
+    });
+
+    setSites((prevSites) => [...prevSites, created]);
+
+    return created;
+  };
+
+  const handleUpdateSite = async (id, fields) => {
+    const updated = await onboardingService.updateSite(id, fields);
+
+    setSites((prevSites) =>
+      prevSites.map((site) => (site.id === id ? updated : site))
+    );
+
+    return updated;
+  };
+
+  const handleDeleteSite = async (id) => {
+    await onboardingService.deleteSite(id);
+
+    setSites((prevSites) =>
+      prevSites.filter((site) => site.id !== id)
+    );
+  };
+
+  return {
+
+    projects,
+    setProjects,
+    handleCreateProject,
+    handleUpdateProject,
+    handleDeleteProject,
+
+    sites,
+    setSites,
+    handleCreateSite,
+    handleUpdateSite,
+    handleDeleteSite,
+
+    isLoadingWorkspace,
+    workspaceLoadError,
+
+    languages,
+    setLanguages,
+    handleCreateLanguage,
+    handleUpdateLanguage,
+    handleDeleteLanguage,
+
+    showProjectModal,
+    setShowProjectModal,
+
+    showSiteModal,
+    setShowSiteModal,
+
+    showLanguageModal,
+    setShowLanguageModal,
+
+  };
+
+};

--- a/ContentWebApp/src/localization-ui/AppShell.jsx
+++ b/ContentWebApp/src/localization-ui/AppShell.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { cn } from "./lib/cn";
+
+export function AppShell({ nav, onNav, flush, children }) {
+  const Item = ({ id, label, count }) => (
+    <button className={cn("s-item", nav === id && "on")} onClick={() => onNav(id)}>
+      <span className="s-label">{label}</span>
+      {count ? <span className="s-count num">{count}</span> : null}
+    </button>
+  );
+
+  return (
+    <div className="loca-shell">
+      <aside className="loca-side" aria-label="Localization navigation">
+        <div className="s-scroll">
+          <Item id="dashboard" label="Registration" />
+          <Item id="workspace" label="Translate & Review" />
+        </div>
+      </aside>
+
+      <div className="loca-main">
+        <main className={cn("loca-content", flush && "flush")}>{children}</main>
+      </div>
+    </div>
+  );
+}
+
+export default AppShell;

--- a/ContentWebApp/src/localization-ui/LocalizationUI.jsx
+++ b/ContentWebApp/src/localization-ui/LocalizationUI.jsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useMemo, useState } from "react";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
+import "@fontsource/inter/700.css";
+import "./tokens.css";
+import "./ui.css";
+import "./shell.css";
+import "./manage.css";
+
+import { useLocalization } from "../hooks/useLocalization";
+import { translationService } from "../services/translationService";
+import { ToastProvider } from "./Toast";
+import { AppShell } from "./AppShell";
+import { usePersistentState, useLastSession } from "./lib/prefs";
+import { pagesFromDocs } from "./lib/segments";
+import { DashboardScreen } from "./screens/Dashboard";
+import { WorkspaceScreen } from "./screens/Workspace";
+import { PlaceholderScreen } from "./screens/Placeholder";
+
+export default function LocalizationUI() {
+  const loc = useLocalization();
+  const { sites, languages, isLoadingWorkspace } = loc;
+
+  const [nav, setNav] = useState("dashboard");
+  const [theme] = usePersistentState("theme", "");
+  const [scope, setScope] = usePersistentState("scope", {
+    projectId: "",
+    siteId: "",
+    route: "",
+    lang: "hi",
+  });
+  const [uiLanguage, setUiLanguage] = usePersistentState("uiLanguage", "");
+  const [lastSession, rememberSession] = useLastSession();
+
+  const [siteDocs, setSiteDocs] = useState([]);
+  const [pagesError, setPagesError] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    if (!scope.siteId || nav !== "workspace") {
+      setSiteDocs([]);
+      setPagesError(null);
+      return;
+    }
+    setPagesError(null);
+    translationService
+      .listTranslations({ siteId: scope.siteId })
+      .then((docs) => {
+        if (!cancelled) setSiteDocs(docs);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setSiteDocs([]);
+        setPagesError(e.status === 403 ? "forbidden" : e.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [scope.siteId, nav]);
+
+  const pages = useMemo(() => pagesFromDocs(siteDocs, scope.lang), [siteDocs, scope.lang]);
+
+  useEffect(() => {
+    if (!scope.lang && languages.length) setScope((s) => ({ ...s, lang: languages[0].code }));
+  }, [languages, scope.lang, setScope]);
+
+  useEffect(() => {
+    if (!uiLanguage && languages.length) setUiLanguage(languages[0].code);
+  }, [languages, uiLanguage, setUiLanguage]);
+
+  useEffect(() => {
+    const routeMissing =
+      !scope.route || (pages.length > 0 && !pages.some((p) => p.route === scope.route));
+    if (scope.siteId && routeMissing) {
+      setScope((s) => ({ ...s, route: pages.length ? pages[0].route : "/" }));
+    }
+  }, [scope.siteId, scope.route, pages, setScope]);
+
+  useEffect(() => {
+    if (!scope.siteId && sites.length) {
+      const first = sites[0];
+      setScope((s) => ({ ...s, siteId: first.siteId }));
+    }
+  }, [sites, scope.siteId, setScope]);
+
+  useEffect(() => {
+    if (scope.siteId && scope.route) rememberSession(scope);
+  }, [scope.siteId, scope.route, scope.lang, rememberSession]);
+
+  const goWorkspace = (next) => {
+    setScope((s) => ({ ...s, ...next }));
+    setNav("workspace");
+  };
+
+  const rootRef = React.useRef(null);
+  const [shellH, setShellH] = useState("100vh");
+  React.useLayoutEffect(() => {
+    const measure = () => {
+      const el = rootRef.current;
+      if (!el) return;
+      setShellH(`${Math.max(480, window.innerHeight - el.getBoundingClientRect().top)}px`);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [nav]);
+
+  let screen;
+  if (nav === "dashboard") {
+    screen = (
+      <DashboardScreen
+        loc={loc}
+        scope={scope}
+        lastSession={lastSession}
+        onResume={(sc) => goWorkspace(sc)}
+        onOpenReview={(sc) => goWorkspace(sc)}
+      />
+    );
+  } else if (nav === "workspace") {
+    screen = (
+      <WorkspaceScreen
+        scope={scope}
+        languages={languages.filter((l) => l.enabled)}
+        sites={sites}
+        onScope={setScope}
+        pages={pages}
+        pagesError={pagesError}
+      />
+    );
+  } else {
+    screen = <PlaceholderScreen nav={nav} />;
+  }
+
+  return (
+    <div
+      className="loca-ui"
+      data-theme={theme || undefined}
+      ref={rootRef}
+      style={{ height: shellH }}
+    >
+      <ToastProvider>
+        <AppShell nav={nav} onNav={setNav} flush={nav === "workspace"}>
+          {isLoadingWorkspace && nav === "dashboard" ? (
+            <div style={{ padding: 28 }}>
+              <SkeletonTheme baseColor="var(--surface-2)" highlightColor="var(--surface-3)">
+                <Skeleton count={6} height={64} borderRadius={10} style={{ marginBottom: 8 }} />
+              </SkeletonTheme>
+            </div>
+          ) : (
+            screen
+          )}
+        </AppShell>
+      </ToastProvider>
+    </div>
+  );
+}

--- a/ContentWebApp/src/localization-ui/Toast.jsx
+++ b/ContentWebApp/src/localization-ui/Toast.jsx
@@ -1,0 +1,60 @@
+import React, { createContext, useCallback, useContext, useRef, useState } from "react";
+
+const ToastCtx = createContext(null);
+export const useToast = () => {
+  const ctx = useContext(ToastCtx);
+  if (!ctx) throw new Error("useToast must be used within <ToastProvider>");
+  return ctx;
+};
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+  const timers = useRef({});
+
+  const dismiss = useCallback((id) => {
+    setToasts((t) => t.filter((x) => x.id !== id));
+    clearTimeout(timers.current[id]);
+    delete timers.current[id];
+  }, []);
+
+  const toast = useCallback(
+    ({ message, tone = "info", duration = 5000, onUndo }) => {
+      const id = Math.random().toString(36).slice(2);
+      setToasts((t) => [...t, { id, message, tone, onUndo }]);
+      timers.current[id] = setTimeout(() => dismiss(id), duration);
+      return id;
+    },
+    [dismiss]
+  );
+
+  return (
+    <ToastCtx.Provider value={{ toast, dismiss }}>
+      {children}
+      <div className="loca-ui-toasts" role="region" aria-label="Notifications">
+        <div aria-live="polite" aria-atomic="true" style={{ display: "contents" }}>
+          {toasts.map((t) => (
+            <div key={t.id} className={`loca-ui-toast ${t.tone}`} role="status">
+              <span className="msg">{t.message}</span>
+              {t.onUndo ? (
+                <button
+                  className="undo"
+                  onClick={() => {
+                    t.onUndo();
+                    dismiss(t.id);
+                  }}
+                >
+                  Undo
+                </button>
+              ) : null}
+              <button className="modal-close" aria-label="Dismiss" onClick={() => dismiss(t.id)}>
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </ToastCtx.Provider>
+  );
+}
+
+export default ToastProvider;

--- a/ContentWebApp/src/localization-ui/dashboard.css
+++ b/ContentWebApp/src/localization-ui/dashboard.css
@@ -1,0 +1,291 @@
+.loca-ui .onb-page {
+  max-width: 880px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 8px 0 32px;
+}
+
+.loca-ui .onb-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: var(--sh-2);
+  padding: 32px;
+}
+.loca-ui .onb-title {
+  font-size: var(--fs-24);
+  font-weight: 700;
+}
+.loca-ui .onb-sub {
+  color: var(--muted);
+  font-size: var(--fs-13);
+  margin-top: 4px;
+}
+.loca-ui .onb-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.loca-ui .onb-success-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.loca-ui .onb-success-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  color: var(--good);
+  background: var(--good-bg);
+}
+.loca-ui .onb-success-title {
+  font-size: var(--fs-20);
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.loca-ui .onb-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  padding: 14px 16px;
+}
+.loca-ui .onb-meta-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.loca-ui .onb-meta-label {
+  font-size: var(--fs-12);
+  color: var(--muted);
+  font-weight: 600;
+}
+.loca-ui .onb-meta-value {
+  font-size: var(--fs-14);
+  color: var(--ink);
+}
+.loca-ui .onb-meta-good {
+  color: var(--good);
+  font-weight: 600;
+}
+
+.loca-ui .onb-steps {
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--info-bg);
+  padding: 14px 16px;
+}
+.loca-ui .onb-steps-title {
+  font-size: var(--fs-13);
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+.loca-ui .onb-steps ol {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.loca-ui .onb-steps li {
+  font-size: var(--fs-13);
+  color: var(--ink-2);
+}
+.loca-ui .onb-steps code {
+  font-family: var(--mono);
+  background: var(--surface);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+
+.loca-ui .onb-dev-section {
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.loca-ui .onb-dev-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 0;
+  background: var(--surface-2);
+  color: var(--ink);
+  cursor: pointer;
+  font-size: var(--fs-13);
+  font-weight: 600;
+  text-align: left;
+}
+.loca-ui .onb-dev-toggle span {
+  flex: 1 1 auto;
+}
+.loca-ui .onb-dev-chev {
+  color: var(--muted);
+  transition: transform var(--dur) var(--ease);
+}
+.loca-ui .onb-dev-chev.open {
+  transform: rotate(180deg);
+}
+.loca-ui .onb-dev-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border-top: 1px solid var(--line);
+}
+.loca-ui .onb-dev-desc {
+  font-size: var(--fs-13);
+  color: var(--ink-2);
+}
+.loca-ui .onb-dev-desc code {
+  font-family: var(--mono);
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+.loca-ui .onb-dev-steps {
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  padding: 12px 14px;
+}
+.loca-ui .onb-dev-steps ol {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.loca-ui .onb-dev-steps li {
+  font-size: var(--fs-13);
+  color: var(--ink-2);
+}
+.loca-ui .onb-dev-steps code {
+  font-family: var(--mono);
+  background: var(--surface);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+.loca-ui .onb-dev-warn {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  border: 1px solid var(--warn);
+  border-radius: var(--r-md);
+  background: var(--warn-bg);
+  color: var(--warn);
+  padding: 12px 14px;
+}
+.loca-ui .onb-dev-warn svg {
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+.loca-ui .onb-dev-warn-title {
+  font-size: var(--fs-13);
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.loca-ui .onb-dev-warn p {
+  font-size: var(--fs-13);
+  color: var(--ink-2);
+}
+.loca-ui .onb-dev-warn code {
+  font-family: var(--mono);
+  background: var(--surface);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+
+.loca-ui .onb-code {
+  position: relative;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.loca-ui .onb-code-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  border: 1px solid var(--line-2);
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease);
+}
+.loca-ui .onb-code-copy:hover {
+  color: var(--ink);
+  border-color: var(--accent);
+}
+.loca-ui .onb-code-pre {
+  margin: 0;
+  padding: 12px 0;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: var(--fs-13);
+}
+.loca-ui .onb-code-line {
+  display: flex;
+}
+.loca-ui .onb-code-num {
+  flex: 0 0 auto;
+  width: 34px;
+  text-align: right;
+  padding-right: 12px;
+  color: var(--muted);
+  opacity: 0.6;
+  user-select: none;
+}
+.loca-ui .onb-code-text {
+  white-space: pre;
+  color: var(--ink-2);
+  padding-right: 40px;
+}
+
+.loca-ui .onb-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 620px) {
+  .loca-ui .onb-card,
+  .loca-ui .onb-page .mng {
+    padding: 20px;
+  }
+  .loca-ui .onb-meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ContentWebApp/src/localization-ui/lib/api.js
+++ b/ContentWebApp/src/localization-ui/lib/api.js
@@ -1,0 +1,11 @@
+import { SEEDS_URL } from "../../Constants";
+import { getAuthHeaders } from "../../utils/authHelpers";
+import { apiFetch, buildQueryString } from "../../services/api";
+
+export async function getAnalyticsSummary(siteId) {
+  const qs = buildQueryString({ siteId });
+  return apiFetch(`${SEEDS_URL}/translations/analytics/summary${qs ? `?${qs}` : ""}`, {
+    method: "GET",
+    headers: getAuthHeaders(),
+  });
+}

--- a/ContentWebApp/src/localization-ui/lib/cn.js
+++ b/ContentWebApp/src/localization-ui/lib/cn.js
@@ -1,0 +1,3 @@
+export function cn(...parts) {
+  return parts.filter(Boolean).join(" ");
+}

--- a/ContentWebApp/src/localization-ui/lib/portal.js
+++ b/ContentWebApp/src/localization-ui/lib/portal.js
@@ -1,0 +1,4 @@
+export function portalContainer() {
+  if (typeof document === "undefined") return undefined;
+  return document.querySelector(".loca-ui") || undefined;
+}

--- a/ContentWebApp/src/localization-ui/lib/prefs.js
+++ b/ContentWebApp/src/localization-ui/lib/prefs.js
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useState } from "react";
+
+const NS = "locaui.";
+
+export function usePersistentState(key, initial) {
+  const full = NS + key;
+  const [value, setValue] = useState(() => {
+    const raw = localStorage.getItem(full);
+    return raw != null ? JSON.parse(raw) : initial;
+  });
+  useEffect(() => {
+    localStorage.setItem(full, JSON.stringify(value));
+  }, [full, value]);
+  return [value, setValue];
+}
+
+export function useLastSession() {
+  const [session, setSession] = usePersistentState("lastSession", null);
+  const remember = useCallback((scope) => setSession({ ...scope, at: Date.now() }), [setSession]);
+  return [session, remember];
+}

--- a/ContentWebApp/src/localization-ui/lib/segments.js
+++ b/ContentWebApp/src/localization-ui/lib/segments.js
@@ -1,0 +1,54 @@
+const LOW_CONF_THRESHOLD = 0.7;
+
+export function deriveStage(doc, lang, { edited = false } = {}) {
+  const t = doc?.translations?.[lang];
+  if (t?.status === "rejected") return "rejected";
+  if (t?.status === "approved") return "approved";
+  if (!t || !t.text) return "new";
+  if (edited) return "edited";
+  return "needs_review";
+}
+
+export function toSegment(doc, lang) {
+  const t = doc.translations?.[lang] || {};
+  return {
+    id: doc.id,
+    key: doc.key,
+    route: doc.route,
+    sourceText: doc.sourceText,
+    translation: t.text,
+    hasTranslation: Boolean(t.text),
+    qualityScore: t.quality_score,
+    lowConfidence: Boolean(t.low_confidence),
+    provider: t.provider,
+    status: t.status,
+    version: doc.version,
+    stage: deriveStage(doc, lang),
+    raw: doc,
+  };
+}
+
+export function summarize(segments) {
+  const total = segments.length;
+  const approved = segments.filter((s) => s.stage === "approved").length;
+  const low = segments.filter((s) => s.lowConfidence && s.hasTranslation).length;
+  const untranslated = segments.filter((s) => !s.hasTranslation).length;
+  const pct = total ? Math.round((approved / total) * 100) : 0;
+  return { total, approved, low, untranslated, pct };
+}
+
+export function pagesFromDocs(docs, lang) {
+  const map = new Map();
+  for (const d of docs) {
+    const r = d.route || "/";
+    const e = map.get(r) || { route: r, total: 0, approved: 0, updatedAt: null };
+    e.total += 1;
+    if (d.translations?.[lang]?.status === "approved") e.approved += 1;
+    const u = d.updatedAt ? new Date(d.updatedAt).getTime() : 0;
+    if (!e.updatedAt || u > e.updatedAt) e.updatedAt = u;
+    map.set(r, e);
+  }
+  return Array.from(map.values()).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+}
+
+export { LOW_CONF_THRESHOLD };

--- a/ContentWebApp/src/localization-ui/lib/url.js
+++ b/ContentWebApp/src/localization-ui/lib/url.js
@@ -1,0 +1,8 @@
+export function extractDomain(url) {
+  const withProtocol = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+  try {
+    return new URL(withProtocol).hostname;
+  } catch {
+    return url;
+  }
+}

--- a/ContentWebApp/src/localization-ui/lib/useCrudView.js
+++ b/ContentWebApp/src/localization-ui/lib/useCrudView.js
@@ -1,0 +1,57 @@
+import { useMemo, useState } from "react";
+
+export function useCrudView({
+  items,
+  matchFn,
+  getId,
+  emptyValues,
+  onCreate,
+  onUpdate,
+  onDelete,
+  toast,
+  entityLabel,
+}) {
+  const [q, setQ] = useState("");
+  const [dlg, setDlg] = useState(null);
+  const [del, setDel] = useState(null);
+
+  const rows = useMemo(() => items.filter((item) => matchFn(item, q)), [items, q, matchFn]);
+
+  const open = (item) =>
+    setDlg(
+      item
+        ? { mode: "edit", id: getId(item), values: { ...emptyValues, ...item } }
+        : { mode: "create", values: { ...emptyValues } }
+    );
+
+  const set = (key, value) => setDlg((d) => ({ ...d, values: { ...d.values, [key]: value } }));
+
+  const save = async () => {
+    const values = dlg.values;
+    try {
+      if (dlg.mode === "edit") await onUpdate(dlg.id, values);
+      else await onCreate(values);
+      toast({
+        message: `${entityLabel} ${dlg.mode === "edit" ? "updated" : "created"}`,
+        tone: "good",
+      });
+      setDlg(null);
+    } catch (e) {
+      toast({ message: e.message, tone: "crit" });
+    }
+  };
+
+  const remove = async () => {
+    try {
+      await onDelete(getId(del));
+      toast({ message: `${entityLabel} deleted`, tone: "info" });
+    } catch (e) {
+      toast({ message: e.message, tone: "crit" });
+    }
+    setDel(null);
+  };
+
+  return { q, setQ, rows, dlg, setDlg, open, set, save, del, setDel, remove };
+}
+
+export default useCrudView;

--- a/ContentWebApp/src/localization-ui/manage.css
+++ b/ContentWebApp/src/localization-ui/manage.css
@@ -1,0 +1,73 @@
+.loca-ui .mng {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+.loca-ui .onb-page .mng {
+  max-width: none;
+  margin: 0;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: var(--sh-2);
+  padding: 32px;
+}
+.loca-ui .mng-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.loca-ui .mng-head h1 {
+  font-size: var(--fs-20);
+}
+.loca-ui .mng-head p {
+  color: var(--muted);
+  font-size: var(--fs-13);
+  margin-top: 3px;
+}
+.loca-ui .mng-tools {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.loca-ui .t-name {
+  font-weight: 600;
+  color: var(--ink);
+}
+.loca-ui .switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  border: 0;
+  background: none;
+  padding: 0;
+}
+.loca-ui .switch .track {
+  width: 34px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--line-2);
+  position: relative;
+  transition: background var(--dur) var(--ease);
+  flex: 0 0 auto;
+}
+.loca-ui .switch .track.on {
+  background: var(--good);
+}
+.loca-ui .switch .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  transition: left var(--dur) var(--ease);
+}
+.loca-ui .switch .track.on .knob {
+  left: 16px;
+}

--- a/ContentWebApp/src/localization-ui/screens/Dashboard.jsx
+++ b/ContentWebApp/src/localization-ui/screens/Dashboard.jsx
@@ -1,0 +1,276 @@
+import React, { useState } from "react";
+import "../dashboard.css";
+import "../../components/AllContent/shared/utilities.css";
+import { useToast } from "../Toast";
+import { ManageScreen } from "./Manage";
+import { extractDomain } from "../lib/url";
+
+function parseApiErrorMessage(err) {
+  const raw = err?.message || "";
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed.message || parsed.error || raw;
+  } catch {
+    return raw;
+  }
+}
+
+function SnippetBlock({ snippet }) {
+  const { toast } = useToast();
+  const lines = String(snippet || "").split("\n");
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet || "");
+      toast({ message: "Snippet copied", tone: "good" });
+    } catch {
+      toast({ message: "Copy failed", tone: "crit" });
+    }
+  };
+
+  return (
+    <div className="onb-code">
+      <button type="button" className="onb-code-copy" onClick={copy} aria-label="Copy snippet">
+        Copy
+      </button>
+      <pre className="onb-code-pre">
+        {lines.map((line, i) => (
+          <span className="onb-code-line" key={i}>
+            <span className="onb-code-num">{i + 1}</span>
+            <span className="onb-code-text">{line}</span>
+          </span>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+const buildDevToolsScript = (siteId) =>
+  [
+    "const s = document.createElement(\"script\");",
+    "s.src = \"http://localhost:3000/sdk.js\";",
+    `s.dataset.siteId = "${siteId}";`,
+    "s.dataset.apiBase = \"http://localhost:3000\";",
+    "document.body.appendChild(s);",
+  ].join("\n");
+
+function DevToolsSection({ siteId }) {
+  const [open, setOpen] = useState(false);
+  const script = buildDevToolsScript(siteId);
+
+  return (
+    <div className="onb-dev-section">
+      <button
+        type="button"
+        className="onb-dev-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span>Developer Testing (Chrome DevTools)</span>
+        <span className={`onb-dev-chev ${open ? "open" : ""}`}>▾</span>
+      </button>
+      {open && (
+        <div className="onb-dev-body">
+          <p className="onb-dev-desc">
+            If you're testing on a third-party website (for example <code>microsoft.com</code>) and
+            cannot modify its HTML, you can temporarily inject the SDK using the{" "}
+            <strong>Chrome DevTools Console</strong>.
+          </p>
+
+          <div className="onb-dev-steps">
+            <div className="onb-steps-title">Steps</div>
+            <ol>
+              <li>Open the target website in Chrome.</li>
+              <li>
+                Press <code>F12</code> (or <code>Ctrl + Shift + I</code>) to open Chrome DevTools.
+              </li>
+              <li>
+                Open the <strong>Console</strong> tab.
+              </li>
+              <li>
+                Paste the JavaScript below and press <strong>Enter</strong>.
+              </li>
+              <li>Verify that the SDK loads successfully.</li>
+            </ol>
+          </div>
+
+          <SnippetBlock snippet={script} />
+
+          <div className="onb-dev-warn">
+            <div>
+              <div className="onb-dev-warn-title">Development only</div>
+              <p>
+                This script injects the SDK only into the <strong>current browser tab</strong>.
+                Refreshing or navigating away from the page removes the injected SDK. For production
+                deployments, always install the HTML snippet before the closing{" "}
+                <code>&lt;/body&gt;</code> tag.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const DEFAULT_PROJECT_NAME = "Default Project";
+
+function OnboardingCard({ loc }) {
+  const { toast } = useToast();
+  const { projects } = loc;
+  const [domain, setDomain] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState(null);
+
+  // Project selection is not user-facing: every site still needs a
+  // projectId server-side, so resolve one transparently — reuse the first
+  // existing project, or auto-create a single default project on first use.
+  const resolveProjectId = async () => {
+    if (projects.length) return projects[0].id;
+    const created = await loc.handleCreateProject({
+      name: DEFAULT_PROJECT_NAME,
+      description: "",
+      sourceLanguage: "English",
+      status: "Active",
+    });
+    return created.id;
+  };
+
+  const register = async (e) => {
+    e.preventDefault();
+    if (!domain.trim() || busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      const projectId = await resolveProjectId();
+      const site = await loc.handleCreateSite({
+        projectId,
+        domain: extractDomain(domain.trim()),
+        name: "",
+        status: "Active",
+      });
+      setResult(site);
+    } catch (err) {
+      const friendly = parseApiErrorMessage(err) || "Failed to register website";
+      setError(friendly);
+      toast({ message: friendly, tone: "crit" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copySnippet = async () => {
+    try {
+      await navigator.clipboard.writeText(result.snippet || "");
+      toast({ message: "Snippet copied", tone: "good" });
+    } catch {
+      toast({ message: "Copy failed", tone: "crit" });
+    }
+  };
+
+  const reset = () => {
+    setResult(null);
+    setDomain("");
+    setError("");
+  };
+
+  if (result) {
+    return (
+      <div className="onb-card">
+        <div className="onb-success-head">
+          <span className="onb-success-icon">✓</span>
+          <div>
+            <div className="onb-success-title">Website Connected</div>
+            <div className="onb-sub">Your website has been registered successfully.</div>
+          </div>
+        </div>
+
+        <div className="onb-meta">
+          <div className="onb-meta-col">
+            <span className="onb-meta-label">Domain</span>
+            <span className="onb-meta-value mono">{result.domain}</span>
+          </div>
+          <div className="onb-meta-col">
+            <span className="onb-meta-label">Integration Status</span>
+            <span className="onb-meta-value onb-meta-good">Ready to install SDK</span>
+          </div>
+        </div>
+
+        <SnippetBlock snippet={result.snippet} />
+
+        <div className="onb-steps">
+          <div className="onb-steps-title">How to install</div>
+          <ol>
+            <li>Open your website's HTML file (or template layout used on every page).</li>
+            <li>
+              Paste the snippet above right before the closing <code>&lt;/body&gt;</code> tag.
+            </li>
+            <li>
+              Deploy/publish your site. This is an HTML tag, not a browser console command — it
+              won't run if pasted into DevTools.
+            </li>
+            <li>
+              Reload the live page — the SDK loads automatically and starts serving translated
+              content.
+            </li>
+          </ol>
+        </div>
+
+        <DevToolsSection siteId={result.siteId} />
+
+        <div className="onb-actions">
+          <button className="primary-button" onClick={copySnippet}>
+            Copy Snippet
+          </button>
+          <button
+            className="action-ghost-button"
+            type="button"
+            onClick={() =>
+              window.open("https://docs.example.com/sdk", "_blank", "noopener,noreferrer")
+            }
+          >
+            View Documentation
+          </button>
+          <button className="action-ghost-button" type="button" onClick={reset}>
+            Register Another Website
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="onb-card">
+      <div className="onb-head">
+        <h1 className="onb-title">Connect your website</h1>
+        <p className="onb-sub">Register your website and start localizing it in minutes.</p>
+      </div>
+      <form className="onb-form" onSubmit={register}>
+        <label className="label" htmlFor="onb-domain">Website URL</label>
+        <input
+          id="onb-domain"
+          className="input-field"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="https://example.com"
+        />
+        {error ? <p className="error-message">{error}</p> : null}
+        <button className="primary-button" type="submit" disabled={!domain.trim() || busy}>
+          {busy ? "Registering…" : "Register Website"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export function DashboardScreen({ loc }) {
+  return (
+    <div className="onb-page">
+      <OnboardingCard loc={loc} />
+      <ManageScreen nav="sites" loc={loc} />
+    </div>
+  );
+}
+
+export default DashboardScreen;

--- a/ContentWebApp/src/localization-ui/screens/Manage.jsx
+++ b/ContentWebApp/src/localization-ui/screens/Manage.jsx
@@ -1,0 +1,434 @@
+import React, { useState } from "react";
+import Modal from "../../components/AllContent/shared/Modal";
+import Select from "../../components/AllContent/shared/Select";
+import "../../components/AllContent/shared/utilities.css";
+import "../manage.css";
+import { extractDomain } from "../lib/url";
+import { useCrudView } from "../lib/useCrudView";
+import { ManageTable } from "./ManageTable";
+import { useToast } from "../Toast";
+
+const StatusPill = ({ status }) => {
+  const isActive = status.toLowerCase() === "active";
+  return <span className={`badge ${isActive ? "badge-good" : "badge-neutral"}`}>{status}</span>;
+};
+
+function Header({ title, subtitle, search, onSearch, addLabel, onAdd, children }) {
+  return (
+    <>
+      <div className="mng-head">
+        <div>
+          <h1>{title}</h1>
+          <p>{subtitle}</p>
+        </div>
+        <div className="mng-tools">
+          <input
+            type="search"
+            className="input-field"
+            placeholder={`Search ${title.toLowerCase()}`}
+            value={search}
+            onChange={(e) => onSearch(e.target.value)}
+            style={{ width: 200 }}
+            aria-label={`Search ${title.toLowerCase()}`}
+          />
+          {addLabel ? (
+            <button className="primary-button" onClick={onAdd}>
+              {addLabel}
+            </button>
+          ) : null}
+        </div>
+      </div>
+      {children}
+    </>
+  );
+}
+
+function ConfirmModal({ title, description, confirmLabel, onCancel, onConfirm }) {
+  return (
+    <Modal title={title} onClose={onCancel}>
+      <p>{description}</p>
+      <div className="modal-actions">
+        <button className="action-ghost-button" onClick={onCancel}>
+          Cancel
+        </button>
+        <button className="row-action row-action-delete" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+function ProjectsView({ loc, toast }) {
+  const { projects, handleCreateProject, handleUpdateProject, handleDeleteProject } = loc;
+  const { q, setQ, rows, dlg, setDlg, open, set, save, del, setDel, remove } = useCrudView({
+    items: projects,
+    matchFn: (project, query) => project.name.toLowerCase().includes(query.toLowerCase()),
+    getId: (project) => project.id,
+    emptyValues: { name: "", description: "", sourceLanguage: "English", status: "Active" },
+    onCreate: handleCreateProject,
+    onUpdate: handleUpdateProject,
+    onDelete: handleDeleteProject,
+    toast,
+    entityLabel: "Project",
+  });
+
+  const columns = [
+    { key: "name", header: "Name", className: "t-name", render: (project) => project.name },
+    { key: "description", header: "Description", render: (project) => project.description || "-" },
+    { key: "sourceLanguage", header: "Source", render: (project) => project.sourceLanguage },
+    {
+      key: "status",
+      header: "Status",
+      render: (project) => <StatusPill status={project.status} />,
+    },
+  ];
+
+  return (
+    <div className="mng">
+      <Header
+        title="Projects"
+        subtitle="Group your localized websites and content."
+        search={q}
+        onSearch={setQ}
+        addLabel="New project"
+        onAdd={() => open(null)}
+      />
+      <ManageTable
+        columns={columns}
+        rows={rows}
+        getId={(project) => project.id}
+        onEdit={open}
+        onDelete={setDel}
+        emptyTitle="No projects"
+        emptyMessage="Create a project to start localizing its websites."
+      />
+      {dlg ? (
+        <Modal
+          title={dlg.mode === "edit" ? "Edit project" : "New project"}
+          onClose={() => setDlg(null)}
+        >
+          <label className="label" htmlFor="project-name">Name</label>
+          <input
+            id="project-name"
+            className="input-field"
+            value={dlg.values.name}
+            onChange={(e) => set("name", e.target.value)}
+            autoFocus
+          />
+          <label className="label" htmlFor="project-source">Source language</label>
+          <input
+            id="project-source"
+            className="input-field"
+            value={dlg.values.sourceLanguage}
+            onChange={(e) => set("sourceLanguage", e.target.value)}
+          />
+          <label className="label" htmlFor="project-description">Description</label>
+          <textarea
+            id="project-description"
+            className="input-field"
+            rows={2}
+            value={dlg.values.description}
+            onChange={(e) => set("description", e.target.value)}
+          />
+          <label className="label">Status</label>
+          <Select
+            value={dlg.values.status}
+            onChange={(v) => set("status", v)}
+            options={[
+              { value: "Active", label: "Active" },
+              { value: "Inactive", label: "Inactive" },
+            ]}
+          />
+          <div className="modal-actions">
+            <button className="action-ghost-button" onClick={() => setDlg(null)}>
+              Cancel
+            </button>
+            <button className="primary-button" onClick={save} disabled={!dlg.values.name.trim()}>
+              Save
+            </button>
+          </div>
+        </Modal>
+      ) : null}
+      {del ? (
+        <ConfirmModal
+          title="Delete project?"
+          description={`"${del.name}" will be removed. This cannot be undone.`}
+          confirmLabel="Delete project"
+          onCancel={() => setDel(null)}
+          onConfirm={remove}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function SitesView({ loc, toast }) {
+  const { sites, projects, handleCreateSite, handleUpdateSite, handleDeleteSite } = loc;
+  const [visible, setVisible] = useState(false);
+
+  const projectName = (projectId) => {
+    const project = projects.find((p) => String(p.id) === String(projectId));
+    return project ? project.name : "-";
+  };
+
+  const { q, setQ, rows, dlg, setDlg, open, set, save, del, setDel, remove } = useCrudView({
+    items: sites,
+    matchFn: (site, query) => {
+      const haystack = `${site.name} ${site.domain}`.toLowerCase();
+      return haystack.includes(query.toLowerCase());
+    },
+    getId: (site) => site.id,
+    emptyValues: { name: "", url: "", projectId: projects[0]?.id || "", status: "Active" },
+    onCreate: (values) =>
+      handleCreateSite({
+        projectId: values.projectId,
+        domain: extractDomain(values.url),
+        name: values.name,
+        status: values.status,
+      }),
+    onUpdate: (id, values) =>
+      handleUpdateSite(id, {
+        name: values.name,
+        domain: extractDomain(values.url),
+        status: values.status,
+      }),
+    onDelete: handleDeleteSite,
+    toast,
+    entityLabel: "Site",
+  });
+
+  const columns = [
+    {
+      key: "name",
+      header: "Website / Domain",
+      className: "t-name mono",
+      render: (site) => site.domain,
+    },
+    { key: "project", header: "Project", render: (site) => projectName(site.projectId) },
+    { key: "status", header: "Status", render: (site) => <StatusPill status={site.status} /> },
+  ];
+
+  return (
+    <div className="mng">
+      <Header
+        title="Sites"
+        subtitle="Websites connected to the localization SDK."
+        search={q}
+        onSearch={setQ}
+        addLabel={visible ? "Hide" : "Show"}
+        onAdd={() => setVisible((v) => !v)}
+      />
+      {visible ? (
+        <ManageTable
+          columns={columns}
+          rows={rows}
+          getId={(site) => site.id}
+          onEdit={open}
+          onDelete={setDel}
+          emptyTitle="No sites found"
+          emptyMessage="Register a website above to get started."
+        />
+      ) : null}
+      {dlg ? (
+        <Modal
+          title={dlg.mode === "edit" ? "Edit site" : "Register site"}
+          onClose={() => setDlg(null)}
+        >
+          <label className="label" htmlFor="site-name">Name</label>
+          <input
+            id="site-name"
+            className="input-field"
+            value={dlg.values.name}
+            onChange={(e) => set("name", e.target.value)}
+            autoFocus
+          />
+          <label className="label" htmlFor="site-url">Domain or URL</label>
+          <input
+            id="site-url"
+            className="input-field"
+            value={dlg.values.url}
+            onChange={(e) => set("url", e.target.value)}
+            placeholder="example.com"
+          />
+          <label className="label">Project</label>
+          <Select
+            value={dlg.values.projectId}
+            onChange={(v) => set("projectId", v)}
+            options={projects.map((project) => ({ value: project.id, label: project.name }))}
+            disabled={dlg.mode === "edit"}
+          />
+          <label className="label">Status</label>
+          <Select
+            value={dlg.values.status}
+            onChange={(v) => set("status", v)}
+            options={[
+              { value: "Active", label: "Active" },
+              { value: "Inactive", label: "Inactive" },
+            ]}
+          />
+          <div className="modal-actions">
+            <button className="action-ghost-button" onClick={() => setDlg(null)}>
+              Cancel
+            </button>
+            <button className="primary-button" onClick={save} disabled={!dlg.values.url.trim()}>
+              Save
+            </button>
+          </div>
+        </Modal>
+      ) : null}
+      {del ? (
+        <ConfirmModal
+          title="Delete site?"
+          description={`"${del.name || del.domain}" will be removed. This cannot be undone.`}
+          confirmLabel="Delete site"
+          onCancel={() => setDel(null)}
+          onConfirm={remove}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function LanguagesView({ loc, toast }) {
+  const { languages, handleCreateLanguage, handleUpdateLanguage, handleDeleteLanguage } = loc;
+
+  const { q, setQ, rows, dlg, setDlg, open, set, save, del, setDel, remove } = useCrudView({
+    items: languages,
+    matchFn: (language, query) => {
+      const haystack = `${language.name} ${language.code}`.toLowerCase();
+      return haystack.includes(query.toLowerCase());
+    },
+    getId: (language) => language.id,
+    emptyValues: { name: "", code: "", direction: "ltr", enabled: true },
+    onCreate: handleCreateLanguage,
+    onUpdate: handleUpdateLanguage,
+    onDelete: handleDeleteLanguage,
+    toast,
+    entityLabel: "Language",
+  });
+
+  const toggle = async (language) => {
+    try {
+      await handleUpdateLanguage(language.id, { enabled: language.enabled === false });
+      toast({
+        message: `Language ${language.enabled === false ? "added" : "updated"}`,
+        tone: "good",
+      });
+    } catch (e) {
+      toast({ message: e.message, tone: "crit" });
+    }
+  };
+
+  const columns = [
+    { key: "name", header: "Language", className: "t-name", render: (language) => language.name },
+    { key: "code", header: "Code", className: "mono", render: (language) => language.code },
+    {
+      key: "direction",
+      header: "Direction",
+      render: (language) => language.direction.toUpperCase(),
+    },
+    {
+      key: "enabled",
+      header: "Enabled",
+      render: (language) => (
+        <button
+          className="switch"
+          onClick={() => toggle(language)}
+          aria-label={language.enabled !== false ? "Disable" : "Enable"}
+          aria-pressed={language.enabled !== false}
+        >
+          <span className={`track ${language.enabled !== false ? "on" : ""}`}>
+            <span className="knob" />
+          </span>
+        </button>
+      ),
+    },
+  ];
+
+  return (
+    <div className="mng">
+      <Header
+        title="Languages"
+        subtitle="Target languages available to the SDK and reviewers."
+        search={q}
+        onSearch={setQ}
+        addLabel="Add language"
+        onAdd={() => open(null)}
+      />
+      <ManageTable
+        columns={columns}
+        rows={rows}
+        getId={(language) => language.id}
+        onEdit={open}
+        onDelete={setDel}
+        emptyTitle="No languages"
+        emptyMessage="Add a target language to translate into."
+      />
+      {dlg ? (
+        <Modal
+          title={dlg.mode === "edit" ? "Edit language" : "Add language"}
+          onClose={() => setDlg(null)}
+        >
+          <label className="label" htmlFor="language-name">Name</label>
+          <input
+            id="language-name"
+            className="input-field"
+            value={dlg.values.name}
+            onChange={(e) => set("name", e.target.value)}
+            placeholder="Hindi"
+            autoFocus
+          />
+          <label className="label" htmlFor="language-code">Code</label>
+          <input
+            id="language-code"
+            className="input-field"
+            value={dlg.values.code}
+            onChange={(e) => set("code", e.target.value)}
+            placeholder="hi"
+          />
+          <label className="label">Direction</label>
+          <Select
+            value={dlg.values.direction}
+            onChange={(v) => set("direction", v)}
+            options={[
+              { value: "ltr", label: "Left to right" },
+              { value: "rtl", label: "Right to left" },
+            ]}
+          />
+          <div className="modal-actions">
+            <button className="action-ghost-button" onClick={() => setDlg(null)}>
+              Cancel
+            </button>
+            <button
+              className="primary-button"
+              onClick={save}
+              disabled={!dlg.values.name.trim() || !dlg.values.code.trim()}
+            >
+              Save
+            </button>
+          </div>
+        </Modal>
+      ) : null}
+      {del ? (
+        <ConfirmModal
+          title="Remove language?"
+          description={`"${del.name}" will be removed.`}
+          confirmLabel="Remove language"
+          onCancel={() => setDel(null)}
+          onConfirm={remove}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function ManageScreen({ nav, loc }) {
+  const { toast } = useToast();
+  if (nav === "projects") return <ProjectsView loc={loc} toast={toast} />;
+  if (nav === "sites") return <SitesView loc={loc} toast={toast} />;
+  if (nav === "languages") return <LanguagesView loc={loc} toast={toast} />;
+  return null;
+}
+
+export default ManageScreen;

--- a/ContentWebApp/src/localization-ui/screens/ManageTable.jsx
+++ b/ContentWebApp/src/localization-ui/screens/ManageTable.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import RowActions from "../../components/AllContent/shared/RowActions";
+import "../../components/AllContent/shared/tables.css";
+
+export function ManageTable({ columns, rows, getId, onEdit, onDelete, emptyTitle, emptyMessage }) {
+  if (!rows.length) {
+    return (
+      <div className="empty">
+        <h4>{emptyTitle}</h4>
+        <p>{emptyMessage}</p>
+      </div>
+    );
+  }
+  return (
+    <div className="table-wrapper">
+      <table className="content-table">
+        <thead>
+          <tr>
+            {columns.map((c) => (
+              <th key={c.key} className="table-header">
+                {c.header}
+              </th>
+            ))}
+            <th className="table-header table-header-actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={getId(row)} className="table-row-white">
+              {columns.map((c) => (
+                <td key={c.key} className={`table-cell ${c.className || ""}`}>
+                  {c.render(row)}
+                </td>
+              ))}
+              <td className="table-cell table-cell-actions">
+                <RowActions
+                  horizontal
+                  actions={[
+                    { key: "edit", label: "Edit", variant: "edit", onClick: () => onEdit(row) },
+                    { key: "delete", label: "Delete", variant: "delete", onClick: () => onDelete(row) },
+                  ]}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default ManageTable;

--- a/ContentWebApp/src/localization-ui/screens/Placeholder.jsx
+++ b/ContentWebApp/src/localization-ui/screens/Placeholder.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const LABELS = {
+  glossary: "Glossary",
+  projects: "Projects",
+  sites: "Sites",
+  languages: "Languages",
+  activity: "Activity",
+};
+
+export function PlaceholderScreen({ nav }) {
+  return (
+    <div className="empty">
+      <h4>{LABELS[nav] || "Section"} — adopting the new system next</h4>
+      <p>
+        Configuration lives here, off the daily workflow. This section keeps the current screen
+        until the design system is propagated in Phase 3.
+      </p>
+    </div>
+  );
+}
+
+export default PlaceholderScreen;

--- a/ContentWebApp/src/localization-ui/screens/Workspace.jsx
+++ b/ContentWebApp/src/localization-ui/screens/Workspace.jsx
@@ -1,0 +1,542 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+import Select from "../../components/AllContent/shared/Select";
+import { Pagination } from "../../components/ContentAggregatorDetails/Pagination";
+import "../workspace.css";
+import { translationService } from "../../services/translationService";
+import { toSegment } from "../lib/segments";
+import { useToast } from "../Toast";
+
+function EmptyState({ title, message, action }) {
+  return (
+    <div className="empty">
+      <h4>{title}</h4>
+      <p>{message}</p>
+      {action}
+    </div>
+  );
+}
+
+/** Status pill — every row shows exactly one state. */
+function CardStatus({ seg }) {
+  if (seg.stage === "approved") return <span className="tr-badge good">Approved</span>;
+  if (seg.stage === "rejected") return <span className="tr-badge crit">Rejected</span>;
+  return <span className="tr-badge warn">Pending Review</span>;
+}
+
+/** Translation card — autosaving inline editor. Auto-grows to fit full text, never clips. */
+const TransCard = React.forwardRef(function TransCard({ seg, onEdit, onCopy }, inputRef) {
+  const [text, setText] = useState(seg.translation);
+  useEffect(() => setText(seg.translation), [seg.translation]);
+  useEffect(() => {
+    const el = inputRef && inputRef.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = el.scrollHeight + "px";
+    }
+  }, [text, inputRef]);
+  const commit = () => {
+    if (text !== seg.translation) onEdit(seg.id, text);
+  };
+  return (
+    <div
+      className={`tr-card ${seg.stage === "approved" ? "approved" : ""} ${seg.lowConfidence && seg.hasTranslation ? "warnedge" : ""}`}
+    >
+      <textarea
+        ref={inputRef}
+        className="tr-card-input"
+        rows={1}
+        value={text}
+        placeholder="Add translation…"
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+        aria-label={`Translation for: ${seg.sourceText}`}
+      />
+      <button
+        type="button"
+        className="tr-card-copy"
+        title="Copy translation"
+        aria-label="Copy translation"
+        onClick={() => onCopy(text)}
+      >
+        Copy
+      </button>
+    </div>
+  );
+});
+
+/** Row actions column — compact, vertically centered, always-visible Approve/Reject/Edit. */
+function RowActions({ seg, onApprove, onReject, onEditFocus }) {
+  const approved = seg.stage === "approved";
+  return (
+    <div className="tr-actions">
+      <button
+        className={`tr-act tr-act-approve btn-icon ${approved ? "active" : ""}`}
+        title={approved ? "Approved" : "Approve"}
+        aria-label="Approve"
+        aria-pressed={approved}
+        onClick={() => onApprove(seg.id)}
+      >
+        ✓
+      </button>
+      <button
+        className={`tr-act tr-act-reject btn-icon ${approved ? "dim" : ""}`}
+        title="Reject"
+        aria-label="Reject"
+        onClick={() => onReject(seg.id)}
+      >
+        ✕
+      </button>
+      <button
+        className={`tr-act tr-act-edit btn-icon ${approved ? "dim" : ""}`}
+        title="Edit"
+        aria-label="Edit"
+        onClick={onEditFocus}
+      >
+        Edit
+      </button>
+    </div>
+  );
+}
+
+/** One row: index, source, editable translation, actions + status. */
+function TransRow({ seg, idx, onEdit, onApprove, onReject, onCopy }) {
+  const inputRef = useRef(null);
+  const focusInput = () => {
+    const el = inputRef.current;
+    if (el) {
+      el.focus();
+      el.select();
+    }
+  };
+  return (
+    <div className="tr-row">
+      <div className="tr-idx">{idx}</div>
+      <div className="tr-src">{seg.sourceText}</div>
+      <TransCard ref={inputRef} seg={seg} onEdit={onEdit} onCopy={onCopy} />
+      <div className="tr-rowend">
+        <RowActions seg={seg} onApprove={onApprove} onReject={onReject} onEditFocus={focusInput} />
+        <CardStatus seg={seg} />
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceScreen({
+  scope,
+  languages,
+  sites = [],
+  onScope,
+  pages = [],
+  pagesError = null,
+}) {
+  const { siteId, route, lang } = scope;
+  const { toast } = useToast();
+  const [docs, setDocs] = useState(null);
+  const [docsError, setDocsError] = useState(null);
+  const [query, setQuery] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [savedAt, setSavedAt] = useState(null);
+  const [statusTab, setStatusTab] = useState("all");
+  const rowsPerPage = 10;
+  const [pageOffset, setPageOffset] = useState(0);
+  const [revision, setRevision] = useState(0);
+  const bodyRef = useRef(null);
+
+  const load = useCallback(() => {
+    if (!siteId || !route) {
+      setDocs([]);
+      setDocsError(null);
+      return;
+    }
+    setDocs(null);
+    setDocsError(null);
+    translationService
+      .listTranslations({ siteId, route })
+      .then(async (d) => {
+        let list = d;
+        // Docs may exist without a draft for the currently selected Review Language
+        // yet (extracted but never generated for this lang) — trigger on-demand
+        // generation so the reviewer sees real translated text instead of a blank box.
+        const missing = lang && list.some((doc) => !doc?.translations?.[lang]?.text);
+        if (missing) {
+          try {
+            await translationService.generateForReview({ siteId, route, lang });
+            list = await translationService.listTranslations({ siteId, route });
+          } catch {
+            /* keep already-fetched docs on failure */
+          }
+        }
+        setDocs(list);
+      })
+      .catch((e) => {
+        setDocs([]);
+        setDocsError(e.status === 403 ? "forbidden" : e.message);
+      });
+  }, [siteId, route, lang]);
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const segments = useMemo(() => (docs ? docs.map((d) => toSegment(d, lang)) : []), [docs, lang]);
+  const tabCounts = useMemo(
+    () => ({
+      pending: segments.filter((s) => s.stage !== "approved").length,
+      approved: segments.filter((s) => s.stage === "approved").length,
+      all: segments.length,
+    }),
+    [segments]
+  );
+  const filtered = useMemo(() => {
+    let list = segments;
+    if (statusTab === "pending") list = list.filter((s) => s.stage !== "approved");
+    else if (statusTab === "approved") list = list.filter((s) => s.stage === "approved");
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      list = list.filter(
+        (s) => s.sourceText.toLowerCase().includes(q) || s.translation.toLowerCase().includes(q)
+      );
+    }
+    return list;
+  }, [segments, statusTab, query]);
+
+  useEffect(() => {
+    setPageOffset(0);
+  }, [route, lang, statusTab, query, rowsPerPage]);
+  const pageCount = Math.max(1, Math.ceil(filtered.length / rowsPerPage));
+  const clampedOffset = Math.min(pageOffset, pageCount - 1);
+  const pageSlice = useMemo(
+    () => filtered.slice(clampedOffset * rowsPerPage, clampedOffset * rowsPerPage + rowsPerPage),
+    [filtered, clampedOffset, rowsPerPage]
+  );
+
+  // docs is null while a load() is in flight (its loading sentinel). A patch
+  // that lands during that window is a no-op — the in-flight load() sets the
+  // authoritative docs — so skip it instead of mapping over null.
+  const patchLocal = (id, f) =>
+    setDocs((ds) => (ds ? ds.map((d) => (d.id === id ? { ...d, ...f } : d)) : ds));
+  // Approval/rejection is per-language: patch only translations[lang].status
+  // on the local doc so another language's displayed stage never changes.
+  const patchLangStatus = (id, status) =>
+    setDocs((ds) =>
+      ds
+        ? ds.map((d) => {
+            if (d.id !== id) return d;
+            const t = d.translations?.[lang] || {};
+            return { ...d, translations: { ...d.translations, [lang]: { ...t, status } } };
+          })
+        : ds
+    );
+  const approve = async (id) => {
+    try {
+      await translationService.approveTranslation(id, lang);
+      patchLangStatus(id, "approved");
+      setSavedAt(Date.now());
+      toast({
+        message: "Approved",
+        tone: "good",
+        onUndo: async () => {
+          await translationService.rejectTranslation(id, lang, "undo");
+          patchLangStatus(id, "rejected");
+        },
+      });
+    } catch (e) {
+      toast({ message: e.message, tone: "crit" });
+    }
+  };
+  const reject = async (id) => {
+    try {
+      await translationService.rejectTranslation(id, lang, "needs work");
+      patchLangStatus(id, "rejected");
+      toast({ message: "Rejected", tone: "info" });
+    } catch (e) {
+      toast({ message: e.message, tone: "crit" });
+    }
+  };
+  const saveEdit = async (id, text) => {
+    try {
+      const u = await translationService.updateTranslation(id, lang, text);
+      patchLocal(id, { translations: u.translations });
+      setSavedAt(Date.now());
+    } catch (e) {
+      toast({ message: e.message, tone: "crit" });
+    }
+  };
+  const translatePage = async () => {
+    setBusy(true);
+    try {
+      await translationService.generateForReview({ siteId, route, lang });
+      toast({ message: "Page translated", tone: "good" });
+      load();
+    } catch (e) {
+      toast({ message: e.message, tone: "crit" });
+    } finally {
+      setBusy(false);
+    }
+  };
+  const copyText = async (text) => {
+    try {
+      await navigator.clipboard.writeText(text || "");
+      toast({ message: "Copied", tone: "info" });
+    } catch {
+      toast({ message: "Copy failed", tone: "crit" });
+    }
+  };
+  const approveAll = async () => {
+    const ids = filtered.filter((s) => s.stage !== "approved").map((s) => s.id);
+    if (!ids.length) return toast({ message: "Nothing to approve", tone: "info" });
+    await Promise.allSettled(ids.map((id) => translationService.approveTranslation(id, lang)));
+    ids.forEach((id) => patchLangStatus(id, "approved"));
+    setSavedAt(Date.now());
+    toast({ message: `Approved ${ids.length} segments`, tone: "good" });
+  };
+  const revertAll = () => {
+    load();
+    setRevision((r) => r + 1);
+    setSavedAt(null);
+    toast({ message: "Reverted to last saved state", tone: "info" });
+  };
+
+  const pageIdx = pages.findIndex((p) => p.route === route);
+  const gotoRoute = (r) => onScope && onScope((s) => ({ ...s, route: r }));
+  const pageNumbers = useMemo(() => {
+    const n = pages.length;
+    if (n <= 7) return pages.map((_, i) => i);
+    const set = new Set([0, 1, pageIdx - 1, pageIdx, pageIdx + 1, n - 1]);
+    return [...set].filter((i) => i >= 0 && i < n).sort((a, b) => a - b);
+  }, [pages, pageIdx]);
+
+  const ready = Boolean(siteId && route);
+
+  return (
+    <div className="tr">
+      {/* Header */}
+      <div className="tr-head">
+        <div>
+          <h1>Translate & Review</h1>
+          <p>Translate full pages and review in context</p>
+        </div>
+        <div className="tr-head-ctrl">
+          <span className="tr-search">
+            <input
+              placeholder="Search source or translated text..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search source or translated text"
+            />
+            <kbd>⌘K</kbd>
+          </span>
+        </div>
+      </div>
+
+      {/* Status tabs + language filter */}
+      <div className="tr-tabs">
+        <button
+          type="button"
+          className={`tr-tab ${statusTab === "pending" ? "on" : ""}`}
+          onClick={() => setStatusTab("pending")}
+        >
+          Pending Review <span className="tr-tab-n">{tabCounts.pending}</span>
+        </button>
+        <button
+          type="button"
+          className={`tr-tab ${statusTab === "approved" ? "on" : ""}`}
+          onClick={() => setStatusTab("approved")}
+        >
+          Approved <span className="tr-tab-n">{tabCounts.approved}</span>
+        </button>
+        <button
+          type="button"
+          className={`tr-tab ${statusTab === "all" ? "on" : ""}`}
+          onClick={() => setStatusTab("all")}
+        >
+          All <span className="tr-tab-n">{tabCounts.all}</span>
+        </button>
+        <div className="tr-lang-tab">
+          <Select
+            value={lang}
+            onChange={(v) => onScope((s) => ({ ...s, lang: v }))}
+            placeholder="Select language"
+            options={languages.map((l) => ({ value: l.code, label: l.name }))}
+          />
+        </div>
+      </div>
+
+      {/* Selects */}
+      <div className="tr-selects">
+        <div className="tr-field">
+          <span>Site</span>
+          <Select
+            value={scope.siteId}
+            onChange={(v) => onScope((s) => ({ ...s, siteId: v, route: "" }))}
+            placeholder="Select site"
+            options={sites.map((s) => ({ value: s.siteId, label: s.name || s.domain }))}
+          />
+        </div>
+      </div>
+
+      {!ready ? (
+        <div style={{ flex: 1, display: "grid", placeItems: "center" }}>
+          <EmptyState
+            title="Pick a site"
+            message="Choose a project and website above to start reviewing its translations."
+          />
+        </div>
+      ) : (
+        <>
+          {/* Page navigation + stats */}
+          <div className="tr-pagenav">
+            <span className="tr-pn-label">
+              Page navigation
+              {pagesError ? (
+                <span className="tr-pn-error">
+                  {" "}
+                  — {pagesError === "forbidden" ? "permission denied loading pages" : pagesError}
+                </span>
+              ) : null}
+            </span>
+            <div className="tr-pager">
+              <button
+                className="pg-arrow"
+                disabled={pageIdx <= 0}
+                onClick={() => gotoRoute(pages[pageIdx - 1].route)}
+                aria-label="Previous page"
+              >
+                ‹
+              </button>
+              {pageNumbers.map((i, k) => {
+                const gap = k > 0 && i - pageNumbers[k - 1] > 1;
+                return (
+                  <React.Fragment key={i}>
+                    {gap ? <span className="pg-dots">…</span> : null}
+                    <button
+                      className={`pg-num ${i === pageIdx ? "on" : ""}`}
+                      onClick={() => gotoRoute(pages[i].route)}
+                      title={pages[i].route}
+                      aria-current={i === pageIdx ? "page" : undefined}
+                    >
+                      {i + 1}
+                    </button>
+                  </React.Fragment>
+                );
+              })}
+              <button
+                className="pg-arrow"
+                disabled={pageIdx >= pages.length - 1}
+                onClick={() => gotoRoute(pages[pageIdx + 1].route)}
+                aria-label="Next page"
+              >
+                ›
+              </button>
+            </div>
+          </div>
+
+          {/* Body: editor + optional live preview */}
+          <div className="tr-body" ref={bodyRef}>
+            <div className="tr-editor">
+              <div className="tr-colhead">
+                <div className="ch-idx">#</div>
+                <div className="ch-src">Source</div>
+                <div className="ch-tr">
+                  Translation
+                  <span className="ch-tools">
+                    <button title="Copy all" aria-label="Copy all">Copy all</button>
+                  </span>
+                </div>
+                <div className="ch-actions" aria-hidden="true" />
+              </div>
+              {docs === null ? (
+                <div style={{ padding: 20 }}>
+                  <SkeletonTheme baseColor="var(--surface-2)" highlightColor="var(--surface-3)">
+                    <Skeleton count={6} height={64} borderRadius={10} style={{ marginBottom: 8 }} />
+                  </SkeletonTheme>
+                </div>
+              ) : docsError ? (
+                <EmptyState
+                  title={
+                    docsError === "forbidden" ? "Permission denied" : "Couldn't load translations"
+                  }
+                  message={
+                    docsError === "forbidden"
+                      ? "Your account doesn't have access to Translate & Review."
+                      : docsError
+                  }
+                />
+              ) : filtered.length === 0 ? (
+                <EmptyState
+                  title="Nothing here"
+                  message={
+                    segments.length
+                      ? "No segments match your search."
+                      : "This page hasn't been translated yet."
+                  }
+                  action={
+                    !segments.length ? (
+                      <button className="tertiary-button" onClick={translatePage} disabled={busy}>
+                        {busy ? "Translating…" : "Translate this page"}
+                      </button>
+                    ) : null
+                  }
+                />
+              ) : (
+                <>
+                  <div className="tr-grid">
+                    {pageSlice.map((seg, i) => (
+                      <TransRow
+                        key={`${seg.id}-${revision}`}
+                        seg={seg}
+                        idx={clampedOffset * rowsPerPage + i + 1}
+                        onEdit={saveEdit}
+                        onApprove={approve}
+                        onReject={reject}
+                        onCopy={copyText}
+                      />
+                    ))}
+                  </div>
+                  <Pagination
+                    current={clampedOffset}
+                    total={pageCount}
+                    onChange={(i) => setPageOffset(i)}
+                  />
+                </>
+              )}
+              {/* Editor footer */}
+              <div className="tr-editfoot">
+                <button className="action-ghost-button" onClick={revertAll}>
+                  Revert all
+                </button>
+                <span style={{ flex: 1 }} />
+                <button
+                  className="action-ghost-button"
+                  onClick={() => {
+                    setSavedAt(Date.now());
+                    toast({ message: "Changes saved", tone: "good" });
+                  }}
+                >
+                  Save changes
+                </button>
+                <button className="tertiary-button" onClick={approveAll}>
+                  Approve all
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Status bar */}
+          <div className="tr-statusbar">
+            <span className="sb-saved">
+              {savedAt ? (
+                <>Last saved {new Date(savedAt).toLocaleTimeString()}</>
+              ) : (
+                "All changes auto-saved"
+              )}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default WorkspaceScreen;

--- a/ContentWebApp/src/localization-ui/shell.css
+++ b/ContentWebApp/src/localization-ui/shell.css
@@ -1,0 +1,135 @@
+/* ============================================================
+   App shell — single sidebar + full-height content (no rail, no context bar)
+   ============================================================ */
+.loca-ui {
+  display: block;
+}
+.loca-shell {
+  display: grid;
+  grid-template-columns: var(--side-w) 1fr;
+  height: 100%;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+/* Sidebar */
+.loca-side {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--line);
+  background: var(--surface);
+  min-width: 0;
+}
+.loca-side .s-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 12px;
+}
+
+.loca-side .s-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 8px 12px;
+  margin: 1px 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 8px;
+  color: var(--ink-2);
+  font-size: var(--fs-14);
+  font-weight: 500;
+  text-align: left;
+  transition:
+    background var(--dur) var(--ease),
+    color var(--dur) var(--ease);
+}
+.loca-side .s-item svg {
+  color: var(--muted);
+  flex: 0 0 auto;
+  transition: color var(--dur) var(--ease);
+}
+.loca-side .s-item .s-label {
+  flex: 1;
+  min-width: 0;
+}
+.loca-side .s-item:hover {
+  background: var(--surface-2);
+  color: var(--ink);
+}
+.loca-side .s-item:hover svg {
+  color: var(--ink-2);
+}
+.loca-side .s-item.on {
+  background: var(--accent-wash);
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+.loca-side .s-item.on svg {
+  color: var(--accent);
+}
+.loca-side .s-item.on::before {
+  content: "";
+  position: absolute;
+  left: -12px;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--accent);
+}
+.loca-side .s-count {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--surface-3);
+  color: var(--ink-2);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+.loca-side .s-item.on .s-count {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+/* Main content */
+.loca-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100%;
+  position: relative;
+}
+.loca-content {
+  flex: 1;
+  overflow: auto;
+  padding: 28px 32px;
+}
+.loca-content.flush {
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+}
+
+/* Mobile: sidebar becomes off-canvas */
+@media (max-width: 900px) {
+  .loca-shell {
+    grid-template-columns: 1fr;
+  }
+  .loca-side {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: var(--side-w);
+    z-index: 40;
+    box-shadow: var(--sh-3);
+    transform: translateX(-110%);
+    transition: transform var(--dur) var(--ease);
+  }
+  .loca-content {
+    padding: 56px 18px 18px;
+  }
+}

--- a/ContentWebApp/src/localization-ui/tokens.css
+++ b/ContentWebApp/src/localization-ui/tokens.css
@@ -1,0 +1,200 @@
+/* ============================================================
+   Localization UI — design tokens (scoped under .loca-ui)
+   Cool, calm, premium: slate neutrals + a restrained indigo accent.
+   Colour used only where it communicates importance. Light + dark.
+   ============================================================ */
+
+.loca-ui {
+  /* Neutrals — cool slate (chosen, not pure grey) */
+  --paper: #fafafb;
+  --surface: #ffffff;
+  --surface-2: #f4f5f8;
+  --surface-3: #eaecf1;
+  --ink: #0f1729;
+  --ink-2: #3a4358;
+  --muted: #6b7385;
+  --line: #e8eaf0;
+  --line-2: #d7dbe4;
+
+  /* Brand accent — teal/cyan. Reserved for the primary action, active nav,
+     progress, focus, links. Used subtly. Never bright orange. */
+  --accent: #0d9488; /* teal-600 */
+  --accent-ink: #0f766e; /* teal-700 */
+  --accent-2: #2dd4bf; /* aqua-400 — gradients / progress */
+  --accent-wash: #e9f8f5; /* soft aqua tint */
+  --on-accent: #ffffff;
+  --grad: linear-gradient(90deg, #0d9488 0%, #6d28d9 55%, #9f1239 100%);
+
+  /* Secondary brand — deep burgundy / wine, for the strongest commit action */
+  --wine: #9f1239; /* rose-800 */
+  --wine-ink: #881337; /* rose-900 */
+  --wine-bg: #fbe8ee;
+  --on-wine: #ffffff;
+
+  /* Semantic — calm, separate from brand; always paired with an icon */
+  --good: #15803d;
+  --good-bg: #e8f3ec;
+  --warn: #b45309;
+  --warn-bg: #fbf1de;
+  --crit: #dc2626;
+  --crit-bg: #fbeaea;
+  --info: #0d9488;
+  --info-bg: #e9f8f5;
+
+  /* Typography — Inter throughout, mono for data */
+  --font: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", Consolas, monospace;
+
+  --fs-12: 12px;
+  --fs-13: 13px;
+  --fs-14: 14px;
+  --fs-15: 15px;
+  --fs-16: 16px;
+  --fs-18: 18px;
+  --fs-20: 20px;
+  --fs-24: 24px;
+  --fs-28: 28px;
+  --fs-32: 32px;
+
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-8: 32px;
+  --s-10: 40px;
+  --s-12: 48px;
+
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+  --r-pill: 999px;
+
+  /* Elevation — soft, low, premium */
+  --sh-1: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 3px rgba(15, 23, 42, 0.05);
+  --sh-2: 0 4px 16px rgba(15, 23, 42, 0.06), 0 1px 4px rgba(15, 23, 42, 0.05);
+  --sh-3: 0 16px 48px rgba(15, 23, 42, 0.14), 0 4px 12px rgba(15, 23, 42, 0.08);
+
+  --ease: cubic-bezier(0.2, 0.6, 0.2, 1);
+  --dur: 140ms;
+
+  --ring: 0 0 0 2px var(--surface), 0 0 0 4px var(--accent);
+
+  --rail-w: 60px;
+  --side-w: 232px;
+  --topbar-h: 56px;
+
+  color-scheme: light;
+  font-family: var(--font);
+  color: var(--ink);
+  background: var(--paper);
+}
+
+@media (prefers-color-scheme: dark) {
+  .loca-ui:not([data-theme="light"]) {
+    --paper: #0b0e14;
+    --surface: #141922;
+    --surface-2: #1b212c;
+    --surface-3: #252c39;
+    --ink: #e7eaf1;
+    --ink-2: #bfc6d4;
+    --muted: #828ba0;
+    --line: #232a38;
+    --line-2: #303950;
+    --accent: #6366f1;
+    --accent-ink: #a5b4fc;
+    --accent-wash: #1b1f3a;
+    --on-accent: #ffffff;
+    --good: #4ade80;
+    --good-bg: #13251b;
+    --warn: #e0b44b;
+    --warn-bg: #2a2113;
+    --crit: #f87171;
+    --crit-bg: #2a1616;
+    --info: #7da9f8;
+    --info-bg: #121e33;
+    --sh-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --sh-2: 0 6px 22px rgba(0, 0, 0, 0.5);
+    --sh-3: 0 20px 50px rgba(0, 0, 0, 0.6);
+    color-scheme: dark;
+  }
+}
+.loca-ui[data-theme="dark"] {
+  --paper: #0b0e14;
+  --surface: #141922;
+  --surface-2: #1b212c;
+  --surface-3: #252c39;
+  --ink: #e7eaf1;
+  --ink-2: #bfc6d4;
+  --muted: #828ba0;
+  --line: #232a38;
+  --line-2: #303950;
+  --accent: #6366f1;
+  --accent-ink: #a5b4fc;
+  --accent-wash: #1b1f3a;
+  --on-accent: #ffffff;
+  --good: #4ade80;
+  --good-bg: #13251b;
+  --warn: #e0b44b;
+  --warn-bg: #2a2113;
+  --crit: #f87171;
+  --crit-bg: #2a1616;
+  --info: #7da9f8;
+  --info-bg: #121e33;
+  --sh-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --sh-2: 0 6px 22px rgba(0, 0, 0, 0.5);
+  --sh-3: 0 20px 50px rgba(0, 0, 0, 0.6);
+  color-scheme: dark;
+}
+
+/* Base — scoped, never touches the rest of the app */
+.loca-ui,
+.loca-ui * {
+  box-sizing: border-box;
+}
+.loca-ui {
+  font-size: var(--fs-14);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  text-align: left;
+}
+.loca-ui h1,
+.loca-ui h2,
+.loca-ui h3,
+.loca-ui h4 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: -0.018em;
+  color: var(--ink);
+  line-height: 1.22;
+}
+.loca-ui p {
+  margin: 0;
+}
+.loca-ui button {
+  font-family: inherit;
+}
+.loca-ui .mono {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+.loca-ui .num {
+  font-variant-numeric: tabular-nums;
+}
+
+.loca-ui :focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
+  border-radius: var(--r-sm);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loca-ui *,
+  .loca-ui *::before,
+  .loca-ui *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/ContentWebApp/src/localization-ui/ui.css
+++ b/ContentWebApp/src/localization-ui/ui.css
@@ -1,0 +1,85 @@
+/* ---------- Badges / chips ---------- */
+.loca-ui .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--fs-12);
+  font-weight: 600;
+  line-height: 1.5;
+  padding: 2px 9px;
+  border-radius: var(--r-pill);
+  white-space: nowrap;
+}
+.loca-ui .badge-good {
+  background: var(--good-bg);
+  color: var(--good);
+}
+.loca-ui .badge-neutral {
+  background: var(--surface-2);
+  color: var(--ink-2);
+}
+
+/* ---------- Empty state ---------- */
+.loca-ui .empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--s-3);
+  padding: var(--s-10) var(--s-5);
+}
+.loca-ui .empty h4 {
+  font-size: var(--fs-16);
+}
+.loca-ui .empty p {
+  font-size: var(--fs-13);
+  color: var(--muted);
+  max-width: 44ch;
+}
+
+@keyframes loca-slide {
+  from {
+    transform: translateX(24px);
+    opacity: 0.4;
+  }
+  to {
+    transform: none;
+    opacity: 1;
+  }
+}
+
+/* ---------- Toast ---------- */
+.loca-ui-toasts {
+  position: fixed;
+  z-index: 1100;
+  bottom: var(--s-5);
+  right: var(--s-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+  width: min(360px, calc(100vw - 32px));
+}
+.loca-ui-toast {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-3) var(--s-4);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  box-shadow: var(--sh-2);
+  animation: loca-slide var(--dur) var(--ease);
+  font-size: var(--fs-13);
+}
+.loca-ui-toast .msg {
+  flex: 1;
+  color: var(--ink);
+}
+.loca-ui-toast .undo {
+  color: var(--accent-ink);
+  font-weight: 600;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-size: var(--fs-13);
+}

--- a/ContentWebApp/src/localization-ui/workspace.css
+++ b/ContentWebApp/src/localization-ui/workspace.css
@@ -1,0 +1,540 @@
+/* ============================================================
+   Translate & Review — full-page document workspace (spec layout)
+   ============================================================ */
+.tr {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--paper);
+}
+
+/* Header */
+.tr-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 22px 28px 16px;
+  flex-wrap: wrap;
+}
+.tr-head h1 {
+  font-size: var(--fs-24);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+.tr-head p {
+  color: var(--muted);
+  font-size: var(--fs-14);
+  margin-top: 4px;
+}
+.tr-head-ctrl {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+}
+.tr-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 46px;
+  padding: 0 14px;
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  background: var(--surface);
+  min-width: 340px;
+  flex: 1 1 auto;
+  max-width: 460px;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
+}
+.tr-search:hover {
+  background: var(--surface-2);
+}
+.tr-search:focus-within {
+  border-color: var(--accent);
+  box-shadow: var(--ring);
+  background: var(--surface);
+}
+.tr-search svg {
+  color: var(--muted);
+  flex: 0 0 auto;
+}
+.tr-search input {
+  border: 0;
+  background: transparent;
+  outline: none;
+  font: inherit;
+  font-size: var(--fs-14);
+  line-height: 1;
+  color: var(--ink);
+  flex: 1;
+  min-width: 0;
+}
+.tr-search input::placeholder {
+  color: var(--muted);
+}
+.tr-search kbd {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 3px 7px;
+  background: var(--surface-2);
+  line-height: 1;
+}
+
+/* Status tabs */
+.tr-tabs {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  padding: 6px 28px 0;
+  border-bottom: 1px solid var(--line);
+}
+.tr-lang-tab {
+  margin-left: auto;
+  align-self: center;
+  padding-bottom: 6px;
+}
+.tr-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 2px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: var(--fs-14);
+  font-weight: 600;
+  cursor: pointer;
+}
+.tr-tab:hover {
+  color: var(--ink-2);
+}
+.tr-tab.on {
+  color: var(--accent-ink);
+  border-bottom-color: var(--accent);
+}
+.tr-tab-n {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 99px;
+  background: var(--surface-2);
+  color: var(--ink-2);
+  font-size: 11.5px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.tr-tab.on .tr-tab-n {
+  background: var(--accent-wash);
+  color: var(--accent-ink);
+}
+
+/* Selects row */
+.tr-selects {
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+  padding: 14px 28px 10px;
+  flex-wrap: wrap;
+}
+.tr-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.tr-field > span {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  padding-left: 2px;
+}
+/* Page navigation */
+.tr-pagenav {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 28px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+  flex-wrap: wrap;
+}
+.tr-pn-label {
+  font-size: var(--fs-13);
+  font-weight: 600;
+  color: var(--ink-2);
+}
+.tr-pager {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.tr-pager .pg-arrow,
+.tr-pager .pg-num {
+  min-width: 32px;
+  height: 32px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--ink-2);
+  font-size: var(--fs-13);
+  font-weight: 600;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+  padding: 0 8px;
+}
+.tr-pager .pg-arrow:hover:not(:disabled),
+.tr-pager .pg-num:hover {
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+.tr-pager .pg-arrow:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.tr-pager .pg-num.on {
+  background: var(--accent-wash);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+.tr-pager .pg-dots {
+  color: var(--muted);
+  padding: 0 2px;
+}
+
+/* Body */
+.tr-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+.tr-editor {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Column header */
+.tr-colhead {
+  display: grid;
+  grid-template-columns: 28px 1fr 1fr auto;
+  column-gap: 20px;
+  padding: 10px 28px 8px;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: color-mix(in srgb, var(--paper) 90%, transparent);
+  backdrop-filter: blur(6px);
+}
+.tr-colhead > div {
+  font-size: var(--fs-13);
+  font-weight: 600;
+  color: var(--ink-2);
+  display: flex;
+  align-items: center;
+}
+.tr-colhead .ch-idx {
+  color: var(--muted);
+}
+.tr-colhead .ch-tr {
+  justify-content: space-between;
+}
+.tr-colhead .ch-tools {
+  display: inline-flex;
+  gap: 4px;
+}
+.tr-colhead .ch-tools button {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: 7px;
+  color: var(--muted);
+  cursor: pointer;
+}
+.tr-colhead .ch-tools button:hover {
+  background: var(--surface-2);
+  color: var(--accent);
+}
+
+/* Rows */
+.tr-grid {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2px 0 20px;
+}
+.tr-row {
+  display: grid;
+  grid-template-columns: 28px 1fr 1fr auto;
+  column-gap: 20px;
+  align-items: start;
+  padding: 12px 28px;
+  border-bottom: 1px solid var(--line);
+  transition: background var(--dur) var(--ease);
+}
+.tr-row:hover {
+  background: var(--surface-2);
+}
+.tr-idx {
+  align-self: start;
+  padding-top: 12px;
+  font-size: var(--fs-13);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.tr-src {
+  align-self: start;
+  font-size: var(--fs-14);
+  line-height: 1.7;
+  color: var(--ink-2);
+  font-weight: 400;
+  padding-top: 10px;
+  white-space: pre-wrap;
+}
+
+.tr-card {
+  position: relative;
+  align-self: start;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--sh-1);
+  transition:
+    border-color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease),
+    background var(--dur) var(--ease);
+}
+.tr-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-wash);
+}
+.tr-card.warnedge {
+  border-left: 3px solid var(--warn);
+}
+.tr-card.approved {
+  border-color: color-mix(in srgb, var(--good) 35%, var(--line));
+  background: color-mix(in srgb, var(--good) 5%, var(--surface));
+}
+.tr-card-input {
+  width: 100%;
+  min-height: 52px;
+  border: 0;
+  background: transparent;
+  resize: none;
+  outline: none;
+  font: inherit;
+  font-size: var(--fs-15);
+  font-weight: 500;
+  line-height: 1.6;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 12px 36px 10px 14px;
+  overflow: hidden;
+}
+.tr-card-input::placeholder {
+  color: var(--muted);
+  font-weight: 400;
+}
+.tr-card-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  color: var(--muted);
+  cursor: pointer;
+}
+.tr-card-copy:hover {
+  background: var(--surface-3);
+  color: var(--accent);
+}
+
+/* Compact action column — vertically centered with the row */
+.tr-rowend {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.tr-actions {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.loca-ui .tr-act.btn-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--muted);
+  background: transparent;
+  border-color: transparent;
+}
+.loca-ui .tr-act.btn-icon svg {
+  width: 15px;
+  height: 15px;
+}
+.loca-ui .tr-act-approve {
+  color: var(--good);
+}
+.loca-ui .tr-act-approve:hover:not(:disabled) {
+  background: var(--good-bg);
+}
+.loca-ui .tr-act-approve.active {
+  background: var(--good-bg);
+  color: var(--good);
+}
+.loca-ui .tr-act-reject {
+  color: var(--crit);
+}
+.loca-ui .tr-act-reject:hover:not(:disabled) {
+  background: var(--crit-bg);
+}
+.loca-ui .tr-act-edit:hover:not(:disabled) {
+  background: var(--surface-3);
+  color: var(--ink);
+}
+.loca-ui .tr-act.dim {
+  opacity: 0.5;
+}
+.loca-ui .tr-act.dim:hover:not(:disabled) {
+  opacity: 1;
+}
+
+/* Status badges (spec) */
+.tr-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11.5px;
+  font-weight: 600;
+  padding: 2px 9px;
+  border-radius: 99px;
+}
+.tr-badge.good {
+  background: var(--good-bg);
+  color: var(--good);
+}
+.tr-badge.warn {
+  background: var(--warn-bg);
+  color: var(--warn);
+}
+.tr-badge.crit {
+  background: var(--crit-bg);
+  color: var(--crit);
+}
+.tr-badge.neutral {
+  background: var(--surface-3);
+  color: var(--ink-2);
+}
+
+/* Editor footer (Revert / Save / Approve all) — sticky while the table scrolls */
+.tr-editfoot {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: 0 -4px 10px rgba(0, 0, 0, 0.04);
+}
+
+/* Status bar */
+.tr-statusbar {
+  flex: 0 0 auto;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  padding: 0 28px;
+  border-top: 1px solid var(--line);
+  background: var(--surface);
+}
+.sb-saved {
+  font-size: var(--fs-12);
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 1100px) {
+  .tr-colhead,
+  .tr-row {
+    grid-template-columns: 1fr;
+  }
+  .tr-colhead .ch-idx,
+  .tr-idx {
+    display: none;
+  }
+  .tr-src {
+    padding-top: 0;
+    font-weight: 600;
+  }
+  .tr-rowend {
+    justify-content: space-between;
+    padding-top: 8px;
+  }
+  .tr-actions {
+    justify-content: flex-start;
+    padding: 0;
+  }
+  .ch-actions {
+    display: none;
+  }
+}
+@media (max-width: 860px) {
+  .tr-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .tr-head-ctrl {
+    width: 100%;
+  }
+  .tr-search {
+    min-width: 0;
+    flex: 1 1 100%;
+    order: 3;
+  }
+  .tr-lang-tab {
+    margin-left: 0;
+  }
+}
+@media (max-width: 900px) {
+  .tr-body {
+    flex-direction: column;
+  }
+}

--- a/ContentWebApp/src/services/contentService.js
+++ b/ContentWebApp/src/services/contentService.js
@@ -116,4 +116,59 @@ export const contentService = {
 
     return ContentDto.fromApi(response);
   },
+
+  /**
+   * Extract readable content from a website.
+   * @param {string} url - Website URL
+   * @returns {Promise<Object>}
+   */
+  async extractWebsite(url) {
+    if (!url || !url.trim()) {
+      throw new Error("Website URL is required");
+    }
+
+    return await apiFetch(`${SEEDS_URL}/content/extract-website`, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ url: url.trim() }),
+    });
+  },
+
+  /**
+   * Translate extracted website content.
+   * @param {string} content - Extracted website text
+   * @param {string} targetLanguage - Target language display name
+   * @param {Object} [options]
+   * @param {string} [options.targetLanguageCode] - ISO code (e.g. "hi"). When
+   *   provided together with siteId, the translation is persisted into the
+   *   same translation store the runtime SDK reads from.
+   * @param {string} [options.siteId] - Real backend siteId (UUID) for the website.
+   * @param {string} [options.route] - Route the translation applies to, default "/".
+   * @returns {Promise<Object>}
+   */
+  async translateWebsite(content, targetLanguage, options = {}) {
+    if (!content || !content.trim()) {
+      throw new Error("Content is required");
+    }
+
+    const { targetLanguageCode, siteId, route } = options;
+
+    return await apiFetch(`${SEEDS_URL}/content/translate-website`, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        content,
+        targetLanguage,
+        ...(targetLanguageCode ? { targetLanguageCode } : {}),
+        ...(siteId ? { siteId } : {}),
+        ...(route ? { route } : {}),
+      }),
+    });
+  },
 };

--- a/ContentWebApp/src/services/dtos/localizationRequests.js
+++ b/ContentWebApp/src/services/dtos/localizationRequests.js
@@ -1,0 +1,41 @@
+export const toProjectCreateRequest = ({ name, description, sourceLanguage, status }) => ({
+  name,
+  description,
+  source_language: sourceLanguage,
+  status,
+});
+
+export const toProjectUpdateRequest = ({ name, description, sourceLanguage, status }) => ({
+  name,
+  description,
+  source_language: sourceLanguage,
+  status,
+});
+
+export const toSiteCreateRequest = ({ projectId, domain, name, status }) => ({
+  project_id: projectId,
+  domain,
+  name,
+  status,
+});
+
+export const toLanguageCreateRequest = ({ name, code, direction, enabled }) => ({
+  name,
+  code,
+  direction,
+  enabled,
+});
+
+export const toSiteUpdateRequest = ({ name, domain, status }) => ({ name, domain, status });
+
+export const toLanguageUpdateRequest = ({ name, code, direction, enabled }) => ({ name, code, direction, enabled });
+
+export const toTranslationUpdateRequest = ({ lang, text }) => ({ lang, text });
+
+export const toTranslationApproveRequest = ({ lang }) => ({ lang });
+
+export const toTranslationRejectRequest = ({ lang, reason = "" }) => ({ lang, reason });
+
+export const toExtractRequest = ({ siteId, items }) => ({ site_id: siteId, items });
+
+export const toBulkApproveRequest = ({ route, lang }) => ({ route, lang });

--- a/ContentWebApp/src/services/dtos/localizationResponses.js
+++ b/ContentWebApp/src/services/dtos/localizationResponses.js
@@ -1,0 +1,54 @@
+const formatCreated = (createdAt) => {
+  if (!createdAt) return "";
+  const date = new Date(createdAt);
+  return date.toLocaleDateString();
+};
+
+export const fromProjectResponse = (doc) => {
+  if (!doc) return doc;
+  return {
+    ...doc,
+    id: doc.id,
+    sourceLanguage: doc.source_language,
+    createdAt: doc.created_at,
+    updatedAt: doc.updated_at,
+    created: formatCreated(doc.created_at),
+  };
+};
+
+export const fromSiteResponse = (doc) => {
+  if (!doc) return doc;
+  return {
+    ...doc,
+    id: doc.id,
+    projectId: doc.project_id,
+    siteId: doc.site_id,
+    createdAt: doc.created_at,
+    updatedAt: doc.updated_at,
+    created: formatCreated(doc.created_at),
+    url: doc.domain ? `https://${doc.domain}` : "",
+  };
+};
+
+export const fromLanguageResponse = (doc) => {
+  if (!doc) return doc;
+  return {
+    ...doc,
+    id: doc.id,
+    createdAt: doc.created_at,
+    updatedAt: doc.updated_at,
+  };
+};
+
+export const fromTranslationResponse = (doc) => {
+  if (!doc) return doc;
+  return {
+    ...doc,
+    id: doc.id,
+    siteId: doc.site_id,
+    sourceText: doc.source_text,
+    lowConfidence: doc.low_confidence,
+    createdAt: doc.created_at,
+    updatedAt: doc.updated_at,
+  };
+};

--- a/ContentWebApp/src/services/languageService.js
+++ b/ContentWebApp/src/services/languageService.js
@@ -1,0 +1,77 @@
+import { SEEDS_URL } from "../Constants";
+import { getAuthHeaders } from "../utils/authHelpers";
+import { apiFetch } from "./api";
+import { toLanguageCreateRequest, toLanguageUpdateRequest } from "./dtos/localizationRequests";
+import { fromLanguageResponse } from "./dtos/localizationResponses";
+
+export const languageService = {
+  /**
+   * List all languages (admin view — includes disabled)
+   * @returns {Promise<Array>}
+   */
+  async listLanguages() {
+    const url = `${SEEDS_URL}/languages?enabledOnly=false`;
+
+    const response = await apiFetch(url, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+
+    return response.map(fromLanguageResponse);
+  },
+
+  /**
+   * Create a new language
+   * @param {Object} params - { name, code, direction, enabled }
+   * @returns {Promise<Object>}
+   */
+  async createLanguage({ name, code, direction, enabled }) {
+    const url = `${SEEDS_URL}/languages`;
+
+    const response = await apiFetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toLanguageCreateRequest({ name, code, direction, enabled })),
+    });
+
+    return fromLanguageResponse(response);
+  },
+
+  /**
+   * Update a language
+   * @param {string} id
+   * @param {Object} fields
+   * @returns {Promise<Object>}
+   */
+  async updateLanguage(id, fields) {
+    const url = `${SEEDS_URL}/languages/${id}`;
+
+    const response = await apiFetch(url, {
+      method: "PUT",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toLanguageUpdateRequest(fields)),
+    });
+
+    return fromLanguageResponse(response);
+  },
+
+  /**
+   * Delete a language
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  async deleteLanguage(id) {
+    const url = `${SEEDS_URL}/languages/${id}`;
+
+    return apiFetch(url, {
+      method: "DELETE",
+      headers: getAuthHeaders(),
+    });
+  },
+};

--- a/ContentWebApp/src/services/onboardingService.js
+++ b/ContentWebApp/src/services/onboardingService.js
@@ -1,0 +1,149 @@
+import { SEEDS_URL } from "../Constants";
+import { getAuthHeaders } from "../utils/authHelpers";
+import { apiFetch, buildQueryString } from "./api";
+import { toProjectCreateRequest, toProjectUpdateRequest, toSiteCreateRequest, toSiteUpdateRequest } from "./dtos/localizationRequests";
+import { fromProjectResponse, fromSiteResponse } from "./dtos/localizationResponses";
+
+export const onboardingService = {
+  /**
+   * Create a new localization project
+   * @param {Object} params - { name, description, sourceLanguage, status }
+   * @returns {Promise<Object>}
+   */
+  async createProject({ name, description, sourceLanguage, status }) {
+    const url = `${SEEDS_URL}/projects`;
+
+    const response = await apiFetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toProjectCreateRequest({ name, description, sourceLanguage, status })),
+    });
+
+    return fromProjectResponse(response);
+  },
+
+  /**
+   * List all localization projects
+   * @returns {Promise<Array>}
+   */
+  async listProjects() {
+    const url = `${SEEDS_URL}/projects`;
+
+    const response = await apiFetch(url, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+
+    return response.map(fromProjectResponse);
+  },
+
+  /**
+   * Update a localization project
+   * @param {string} id
+   * @param {Object} fields - { name, description, sourceLanguage, status }
+   * @returns {Promise<Object>}
+   */
+  async updateProject(id, fields) {
+    const url = `${SEEDS_URL}/projects/${id}`;
+
+    const response = await apiFetch(url, {
+      method: "PUT",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toProjectUpdateRequest(fields)),
+    });
+
+    return fromProjectResponse(response);
+  },
+
+  /**
+   * Delete a localization project
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  async deleteProject(id) {
+    const url = `${SEEDS_URL}/projects/${id}`;
+
+    return apiFetch(url, {
+      method: "DELETE",
+      headers: getAuthHeaders(),
+    });
+  },
+
+  /**
+   * Register a website under a project, generating its real backend siteId
+   * @param {Object} params - { projectId, domain, name, status }
+   * @returns {Promise<Object>}
+   */
+  async createSite({ projectId, domain, name, status }) {
+    const url = `${SEEDS_URL}/websites`;
+
+    const response = await apiFetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toSiteCreateRequest({ projectId, domain, name, status })),
+    });
+
+    return fromSiteResponse(response);
+  },
+
+  /**
+   * List registered websites, optionally filtered by project
+   * @param {string} [projectId]
+   * @returns {Promise<Array>}
+   */
+  async listSites(projectId) {
+    const queryString = projectId ? `?${buildQueryString({ projectId })}` : "";
+    const url = `${SEEDS_URL}/websites${queryString}`;
+
+    const response = await apiFetch(url, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+
+    return response.map(fromSiteResponse);
+  },
+
+  /**
+   * Update a registered website
+   * @param {string} id
+   * @param {Object} fields - { name, domain, status }
+   * @returns {Promise<Object>}
+   */
+  async updateSite(id, fields) {
+    const url = `${SEEDS_URL}/websites/${id}`;
+
+    const response = await apiFetch(url, {
+      method: "PUT",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toSiteUpdateRequest(fields)),
+    });
+
+    return fromSiteResponse(response);
+  },
+
+  /**
+   * Delete a registered website
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  async deleteSite(id) {
+    const url = `${SEEDS_URL}/websites/${id}`;
+
+    return apiFetch(url, {
+      method: "DELETE",
+      headers: getAuthHeaders(),
+    });
+  },
+};

--- a/ContentWebApp/src/services/translationService.js
+++ b/ContentWebApp/src/services/translationService.js
@@ -1,0 +1,132 @@
+import { SEEDS_URL } from "../Constants";
+import { getAuthHeaders } from "../utils/authHelpers";
+import { apiFetch, buildQueryString } from "./api";
+import {
+  toExtractRequest,
+  toTranslationUpdateRequest,
+  toTranslationApproveRequest,
+  toTranslationRejectRequest,
+  toBulkApproveRequest,
+} from "./dtos/localizationRequests";
+import { fromTranslationResponse } from "./dtos/localizationResponses";
+
+export const translationService = {
+  async extractItems(siteId, items) {
+    return apiFetch(`${SEEDS_URL}/translations/extract`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(toExtractRequest({ siteId, items })),
+    });
+  },
+
+  async getRuntimeTranslations(siteId, route, lang) {
+    const queryString = buildQueryString({ site_id: siteId, route, lang });
+    return apiFetch(`${SEEDS_URL}/translations?${queryString}`, { method: "GET" });
+  },
+
+  async generateForReview({ siteId, route, lang }) {
+    const queryString = buildQueryString({ site_id: siteId, route, lang });
+    return apiFetch(`${SEEDS_URL}/translations/generate?${queryString}`, {
+      method: "POST",
+      headers: getAuthHeaders(),
+    });
+  },
+
+  async getAuditTrail({ siteId, route, key } = {}) {
+    const queryString = buildQueryString({ site_id: siteId, route, key });
+    return apiFetch(`${SEEDS_URL}/translations/audit?${queryString}`, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+  },
+
+  async listTranslations({ siteId, route, status } = {}) {
+    const queryString = buildQueryString({ site_id: siteId, route, status });
+    const url = `${SEEDS_URL}/translations/list?${queryString}`;
+
+    const response = await apiFetch(url, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+
+    return response.map(fromTranslationResponse);
+  },
+
+  async getTranslation(id) {
+    const url = `${SEEDS_URL}/translations/${id}`;
+
+    const response = await apiFetch(url, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+
+    return fromTranslationResponse(response);
+  },
+
+  async getVersions(id) {
+    const url = `${SEEDS_URL}/translations/${id}/versions`;
+
+    return apiFetch(url, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+  },
+
+  async updateTranslation(id, lang, text) {
+    const url = `${SEEDS_URL}/translations/${id}`;
+
+    const response = await apiFetch(url, {
+      method: "PUT",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toTranslationUpdateRequest({ lang, text })),
+    });
+
+    return fromTranslationResponse(response);
+  },
+
+  async approveTranslation(id, lang) {
+    const url = `${SEEDS_URL}/translations/${id}/approve`;
+
+    const response = await apiFetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toTranslationApproveRequest({ lang })),
+    });
+
+    return fromTranslationResponse(response);
+  },
+
+  async rejectTranslation(id, lang, reason = "") {
+    const url = `${SEEDS_URL}/translations/${id}/reject`;
+
+    const response = await apiFetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toTranslationRejectRequest({ lang, reason })),
+    });
+
+    return fromTranslationResponse(response);
+  },
+
+  async bulkApproveTranslations({ siteId, route, lang }) {
+    const url = `${SEEDS_URL}/translations/bulk-approve?${buildQueryString({ site_id: siteId })}`;
+
+    return apiFetch(url, {
+      method: "POST",
+      headers: {
+        ...getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toBulkApproveRequest({ route, lang })),
+    });
+  },
+};

--- a/ContentWebApp/src/setupProxy.js
+++ b/ContentWebApp/src/setupProxy.js
@@ -1,0 +1,24 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+const BACKEND = process.env.REACT_APP_BACKEND_ORIGIN || "http://localhost:8000";
+
+module.exports = function (app) {
+  app.use(
+    "/api",
+    createProxyMiddleware({
+      target: BACKEND,
+      changeOrigin: true,
+      pathRewrite: { "^/api": "" },
+      logLevel: "warn",
+    })
+  );
+
+  app.use(
+    ["/translations", "/languages"],
+    createProxyMiddleware({
+      target: BACKEND,
+      changeOrigin: true,
+      logLevel: "warn",
+    })
+  );
+};

--- a/ContentWebApp/tests/localization-ui/CrudTable.test.jsx
+++ b/ContentWebApp/tests/localization-ui/CrudTable.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CrudTable } from "../../src/localization-ui/primitives/CrudTable";
+
+const columns = [{ key: "name", header: "Name", render: (r) => r.name }];
+const rows = [{ id: "1", name: "Alpha" }];
+
+test("renders EmptyState when rows is empty", () => {
+  render(
+    <CrudTable
+      columns={columns}
+      rows={[]}
+      getId={(r) => r.id}
+      onEdit={jest.fn()}
+      onDelete={jest.fn()}
+      emptyTitle="No items"
+      emptyMessage="Nothing here yet."
+    />
+  );
+  expect(screen.getByText("No items")).toBeInTheDocument();
+});
+
+test("renders a row per item with edit/delete actions", () => {
+  const onEdit = jest.fn();
+  const onDelete = jest.fn();
+  render(
+    <CrudTable columns={columns} rows={rows} getId={(r) => r.id} onEdit={onEdit} onDelete={onDelete} />
+  );
+  expect(screen.getByText("Alpha")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+  expect(onEdit).toHaveBeenCalledWith(rows[0]);
+  fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+  expect(onDelete).toHaveBeenCalledWith(rows[0]);
+});

--- a/ContentWebApp/tests/localization-ui/LocalizationUI.test.jsx
+++ b/ContentWebApp/tests/localization-ui/LocalizationUI.test.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("../../src/services/translationService", () => ({
+  translationService: { listTranslations: jest.fn().mockResolvedValue([]) },
+}));
+
+jest.mock("../../src/hooks/useLocalization", () => ({
+  useLocalization: () => ({
+    projects: [], sites: [], languages: [], isLoadingWorkspace: true, workspaceLoadError: "",
+    handleCreateProject: jest.fn(), handleUpdateProject: jest.fn(), handleDeleteProject: jest.fn(),
+    handleCreateSite: jest.fn(), handleUpdateSite: jest.fn(), handleDeleteSite: jest.fn(),
+    handleCreateLanguage: jest.fn(), handleUpdateLanguage: jest.fn(), handleDeleteLanguage: jest.fn(),
+  }),
+}));
+
+import LocalizationUI from "../../src/localization-ui/LocalizationUI";
+
+test("shows a loading skeleton instead of a blank screen while the dashboard loads", () => {
+  render(<LocalizationUI />);
+  expect(document.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+});

--- a/ContentWebApp/tests/localization-ui/Manage.test.jsx
+++ b/ContentWebApp/tests/localization-ui/Manage.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ToastProvider } from "../../src/localization-ui/primitives";
+import { ManageScreen } from "../../src/localization-ui/screens/Manage";
+
+function makeLoc() {
+  return {
+    projects: [{ id: "p1", name: "Site A", description: "", sourceLanguage: "English", status: "Active" }],
+    sites: [{ id: "s1", name: "Home", domain: "a.com", projectId: "p1", status: "Active" }],
+    languages: [{ id: "l1", name: "Hindi", code: "hi", direction: "ltr", enabled: true }],
+    handleCreateProject: jest.fn(async (v) => ({ id: "p2", ...v })),
+    handleUpdateProject: jest.fn(async (id, v) => ({ id, ...v })),
+    handleDeleteProject: jest.fn(async () => {}),
+    handleCreateSite: jest.fn(async (v) => ({ id: "s2", ...v })),
+    handleUpdateSite: jest.fn(async (id, v) => ({ id, ...v })),
+    handleDeleteSite: jest.fn(async () => {}),
+    handleCreateLanguage: jest.fn(async (v) => ({ id: "l2", ...v })),
+    handleUpdateLanguage: jest.fn(async (id, v) => ({ id, ...v })),
+    handleDeleteLanguage: jest.fn(async () => {}),
+  };
+}
+
+function renderNav(nav, loc) {
+  return render(<ToastProvider><ManageScreen nav={nav} loc={loc} /></ToastProvider>);
+}
+
+test("projects view lists existing projects and creates a new one", async () => {
+  const loc = makeLoc();
+  renderNav("projects", loc);
+  expect(screen.getByText("Site A")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: /new project/i }));
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Site B" } });
+  fireEvent.click(screen.getByRole("button", { name: /save/i }));
+  await waitFor(() => expect(loc.handleCreateProject).toHaveBeenCalled());
+});
+
+test("sites view lists existing sites and deletes one", async () => {
+  const loc = makeLoc();
+  renderNav("sites", loc);
+  expect(screen.getByText("a.com")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+  fireEvent.click(screen.getByRole("button", { name: /delete site/i }));
+  await waitFor(() => expect(loc.handleDeleteSite).toHaveBeenCalledWith("s1"));
+});
+
+test("languages view toggles enabled without opening a dialog", async () => {
+  const loc = makeLoc();
+  renderNav("languages", loc);
+  fireEvent.click(screen.getByRole("button", { name: /disable/i }));
+  await waitFor(() => expect(loc.handleUpdateLanguage).toHaveBeenCalledWith("l1", { enabled: false }));
+});

--- a/ContentWebApp/tests/localization-ui/prefs.test.js
+++ b/ContentWebApp/tests/localization-ui/prefs.test.js
@@ -1,0 +1,22 @@
+import { renderHook, act } from "@testing-library/react";
+import { usePersistentState } from "../../src/localization-ui/lib/prefs";
+
+test("reads initial value when nothing stored", () => {
+  const { result } = renderHook(() => usePersistentState("k1", { a: 1 }));
+  expect(result.current[0]).toEqual({ a: 1 });
+});
+
+test("persists updates to localStorage under the locaui. namespace", () => {
+  const { result } = renderHook(() => usePersistentState("k2", "x"));
+  act(() => result.current[1]("y"));
+  expect(JSON.parse(localStorage.getItem("locaui.k2"))).toBe("y");
+});
+
+test("propagates a localStorage write failure instead of swallowing it", () => {
+  const { result } = renderHook(() => usePersistentState("k3", "x"));
+  const spy = jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    throw new Error("QuotaExceededError");
+  });
+  expect(() => act(() => result.current[1]("y"))).toThrow("QuotaExceededError");
+  spy.mockRestore();
+});

--- a/ContentWebApp/tests/localization-ui/useCrudView.test.js
+++ b/ContentWebApp/tests/localization-ui/useCrudView.test.js
@@ -1,0 +1,88 @@
+// tests/localization-ui/useCrudView.test.js
+import { renderHook, act } from "@testing-library/react";
+import { useCrudView } from "../../src/localization-ui/lib/useCrudView";
+
+const items = [
+  { id: "1", name: "Alpha" },
+  { id: "2", name: "Beta" },
+];
+
+function setup(overrides = {}) {
+  const toast = jest.fn();
+  const onCreate = jest.fn(async (v) => ({ id: "3", ...v }));
+  const onUpdate = jest.fn(async (id, v) => ({ id, ...v }));
+  const onDelete = jest.fn(async () => {});
+  const hook = renderHook(() =>
+    useCrudView({
+      items,
+      matchFn: (item, q) => item.name.toLowerCase().includes(q.toLowerCase()),
+      getId: (item) => item.id,
+      emptyValues: { name: "" },
+      onCreate,
+      onUpdate,
+      onDelete,
+      toast,
+      entityLabel: "Item",
+      ...overrides,
+    })
+  );
+  return { hook, toast, onCreate, onUpdate, onDelete };
+}
+
+test("filters rows by matchFn against q", () => {
+  const { hook } = setup();
+  act(() => hook.result.current.setQ("bet"));
+  expect(hook.result.current.rows).toEqual([{ id: "2", name: "Beta" }]);
+});
+
+test("open(null) starts create mode with emptyValues", () => {
+  const { hook } = setup();
+  act(() => hook.result.current.open(null));
+  expect(hook.result.current.dlg).toEqual({ mode: "create", values: { name: "" } });
+});
+
+test("open(item) starts edit mode with item merged into values", () => {
+  const { hook } = setup();
+  act(() => hook.result.current.open(items[0]));
+  expect(hook.result.current.dlg).toEqual({
+    mode: "edit",
+    id: "1",
+    values: { name: "Alpha", id: "1" },
+  });
+});
+
+test("save() in create mode calls onCreate and closes dialog", async () => {
+  const { hook, onCreate, toast } = setup();
+  act(() => hook.result.current.open(null));
+  act(() => hook.result.current.set("name", "Gamma"));
+  await act(async () => hook.result.current.save());
+  expect(onCreate).toHaveBeenCalledWith({ name: "Gamma" });
+  expect(hook.result.current.dlg).toBeNull();
+  expect(toast).toHaveBeenCalledWith({ message: "Item created", tone: "good" });
+});
+
+test("save() in edit mode calls onUpdate with id", async () => {
+  const { hook, onUpdate } = setup();
+  act(() => hook.result.current.open(items[1]));
+  act(() => hook.result.current.set("name", "Beta 2"));
+  await act(async () => hook.result.current.save());
+  expect(onUpdate).toHaveBeenCalledWith("2", { name: "Beta 2", id: "2" });
+});
+
+test("save() error toasts crit and keeps dialog open", async () => {
+  const onCreate = jest.fn(async () => { throw new Error("boom"); });
+  const { hook, toast } = setup({ onCreate });
+  act(() => hook.result.current.open(null));
+  await act(async () => hook.result.current.save());
+  expect(toast).toHaveBeenCalledWith({ message: "boom", tone: "crit" });
+  expect(hook.result.current.dlg).not.toBeNull();
+});
+
+test("remove() calls onDelete with id, toasts, clears del", async () => {
+  const { hook, onDelete, toast } = setup();
+  act(() => hook.result.current.setDel(items[0]));
+  await act(async () => hook.result.current.remove());
+  expect(onDelete).toHaveBeenCalledWith("1");
+  expect(toast).toHaveBeenCalledWith({ message: "Item deleted", tone: "info" });
+  expect(hook.result.current.del).toBeNull();
+});

--- a/ContentWebApp/tests/localization_verify.test.js
+++ b/ContentWebApp/tests/localization_verify.test.js
@@ -1,0 +1,270 @@
+import React from "react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider, ToastProvider } from "../src/localization-ui/primitives";
+import WorkspaceScreen from "../src/localization-ui/screens/Workspace.jsx";
+
+jest.mock("../src/services/translationService", () => ({
+  translationService: {
+    listTranslations: jest.fn(),
+    generateForReview: jest.fn(),
+    approveTranslation: jest.fn(),
+    rejectTranslation: jest.fn(),
+    updateTranslation: jest.fn(),
+  },
+}));
+import { translationService } from "../src/services/translationService";
+
+beforeAll(() => {
+  window.HTMLElement.prototype.hasPointerCapture = jest.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.setPointerCapture = jest.fn();
+  window.HTMLElement.prototype.releasePointerCapture = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  if (!window.PointerEvent) {
+    window.PointerEvent = window.MouseEvent;
+  }
+});
+
+const langs = [
+  { id: "en", code: "en", name: "English" },
+  { id: "kn", code: "kn", name: "Kannada" },
+];
+const sites = [{ id: "s1", siteId: "site-1", name: "example.com", domain: "example.com" }];
+
+function makeDoc(key, sourceText, { translated, status } = {}) {
+  return {
+    id: key,
+    _id: key,
+    key,
+    route: "/",
+    sourceText,
+    translations: translated ? { kn: { text: translated, status: status || "pending" } } : {},
+    status,
+  };
+}
+
+function renderWorkspace(scope) {
+  const onScope = jest.fn((updater) => {
+    const next = typeof updater === "function" ? updater(scope) : updater;
+    Object.assign(scope, next);
+  });
+  const utils = render(
+    <TooltipProvider>
+      <ToastProvider>
+        <WorkspaceScreen scope={scope} languages={langs} sites={sites} onScope={onScope} pages={[{ route: "/" }]} />
+      </ToastProvider>
+    </TooltipProvider>
+  );
+  return { ...utils, onScope };
+}
+
+describe("Translate & Review — live component verification", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(navigator, { clipboard: { writeText: jest.fn().mockResolvedValue() } });
+  });
+
+  test("PASS — Search filters rows by source/translation text, calls listTranslations", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್", status: "approved" }),
+      makeDoc("k2", "Good Morning", { translated: "ಶುಭೋದಯ" }),
+    ]);
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await waitFor(() => expect(translationService.listTranslations).toHaveBeenCalledWith({ siteId: "site-1", route: "/" }));
+    await screen.findByText("Hello World");
+    expect(screen.getByText("Good Morning")).toBeInTheDocument();
+
+    const search = screen.getByPlaceholderText(/Search source or translated text/i);
+    await userEvent.type(search, "Morning");
+
+    expect(screen.queryByText("Hello World")).not.toBeInTheDocument();
+    expect(screen.getByText("Good Morning")).toBeInTheDocument();
+  });
+
+  test("PASS — Language filter switches Review Language and reloads translations for new lang", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್", status: "approved" }),
+    ]);
+    const scope = { siteId: "site-1", route: "/", lang: "kn" };
+    renderWorkspace(scope);
+    await screen.findByText("Hello World");
+
+    const langBtn = screen.getByRole("button", { name: /Kannada/i });
+    await userEvent.click(langBtn);
+    const enOption = await screen.findByText("English");
+    await userEvent.click(enOption);
+
+    expect(scope.lang).toBe("en");
+  });
+
+  test("PASS — Pagination slices rows per page and page buttons switch pages", async () => {
+    const docs = Array.from({ length: 15 }, (_, i) => makeDoc(`k${i}`, `Source ${i}`, { translated: `T${i}` }));
+    translationService.listTranslations.mockResolvedValue(docs);
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Source 0");
+
+    expect(screen.getByText("Source 9")).toBeInTheDocument();
+    expect(screen.queryByText("Source 10")).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing 1 to 10 of 15/)).toBeInTheDocument();
+
+    const page2 = screen.getByRole("button", { name: "2" });
+    await userEvent.click(page2);
+    expect(screen.getByText("Source 10")).toBeInTheDocument();
+    expect(screen.queryByText("Source 0")).not.toBeInTheDocument();
+  });
+
+  test("PASS — Copy translation writes translated text to clipboard", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್" }),
+    ]);
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+
+    const copyBtn = screen.getByLabelText("Copy translation");
+    await userEvent.click(copyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ಹಲೋ ವರ್ಲ್ಡ್");
+  });
+
+  test("PASS — Individual Approve calls approveTranslation and flips row to Approved", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್" }),
+    ]);
+    translationService.approveTranslation.mockResolvedValue({});
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+
+    expect(document.querySelector(".tr-badge.warn")).toBeInTheDocument();
+    const approveBtn = screen.getByRole("button", { name: "Approve" });
+    await userEvent.click(approveBtn);
+
+    expect(translationService.approveTranslation).toHaveBeenCalledWith("k1", "kn");
+    await waitFor(() => expect(document.querySelector(".tr-badge.good")).toBeInTheDocument());
+  });
+
+  test("PASS — Reject calls rejectTranslation and flips row to Rejected", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್" }),
+    ]);
+    translationService.rejectTranslation.mockResolvedValue({});
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+
+    const rejectBtn = screen.getByRole("button", { name: "Reject" });
+    await userEvent.click(rejectBtn);
+
+    expect(translationService.rejectTranslation).toHaveBeenCalledWith("k1", "kn", "needs work");
+    await waitFor(() => expect(document.querySelector(".tr-badge.crit")).toBeInTheDocument());
+  });
+
+  test("PASS — Approve All approves every non-approved row in current scope", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್" }),
+      makeDoc("k2", "Good Morning", { translated: "ಶುಭೋದಯ" }),
+      makeDoc("k3", "Already Approved", { translated: "X", status: "approved" }),
+    ]);
+    translationService.approveTranslation.mockResolvedValue({});
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+
+    const approveAllBtn = screen.getByRole("button", { name: /Approve all/i });
+    await userEvent.click(approveAllBtn);
+
+    await waitFor(() => expect(translationService.approveTranslation).toHaveBeenCalledTimes(2));
+    expect(translationService.approveTranslation).toHaveBeenCalledWith("k1", "kn");
+    expect(translationService.approveTranslation).toHaveBeenCalledWith("k2", "kn");
+    expect(translationService.approveTranslation).not.toHaveBeenCalledWith("k3", "kn");
+  });
+
+  test("PASS — Edit translation commits on blur via updateTranslation", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್" }),
+    ]);
+    translationService.updateTranslation.mockResolvedValue({ translations: { kn: { text: "Edited text" } }, status: "" });
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+
+    const textarea = screen.getByLabelText("Translation for: Hello World");
+    fireEvent.change(textarea, { target: { value: "Edited text" } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => expect(translationService.updateTranslation).toHaveBeenCalledWith("k1", "kn", "Edited text"));
+  });
+
+  test("PASS — Save changes button shows saved confirmation (autosave already committed the edit on blur)", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್" }),
+    ]);
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+
+    expect(screen.getByText("All changes auto-saved")).toBeInTheDocument();
+    const saveBtn = screen.getByRole("button", { name: "Save changes" });
+    await userEvent.click(saveBtn);
+    expect(screen.getByText(/Last saved/)).toBeInTheDocument();
+  });
+
+  test("PASS — Revert All discards an unsaved (unblurred) edit and reloads from backend", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್" }),
+    ]);
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+
+    const textarea = screen.getByLabelText("Translation for: Hello World");
+    fireEvent.change(textarea, { target: { value: "Unsaved garbage text" } });
+    expect(textarea.value).toBe("Unsaved garbage text");
+    expect(translationService.updateTranslation).not.toHaveBeenCalled();
+
+    const revertBtn = screen.getByRole("button", { name: /Revert all/i });
+    await userEvent.click(revertBtn);
+
+    await waitFor(() => expect(translationService.listTranslations).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      const el = screen.getByLabelText("Translation for: Hello World");
+      expect(el.value).toBe("ಹಲೋ ವರ್ಲ್ಡ್");
+    });
+  });
+
+  test("PASS — Revert All leaves an already-approved row's status unchanged", async () => {
+    translationService.listTranslations.mockResolvedValue([
+      makeDoc("k1", "Hello World", { translated: "ಹಲೋ ವರ್ಲ್ಡ್", status: "approved" }),
+    ]);
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+    await screen.findByText("Hello World");
+    expect(document.querySelector(".tr-badge.good")).toBeInTheDocument();
+
+    const revertBtn = screen.getByRole("button", { name: /Revert all/i });
+    await userEvent.click(revertBtn);
+
+    await waitFor(() => expect(translationService.listTranslations).toHaveBeenCalledTimes(2));
+    expect(document.querySelector(".tr-badge.good")).toBeInTheDocument();
+  });
+
+  test("PASS — a genuinely empty successful response shows the empty state, not an error", async () => {
+    translationService.listTranslations.mockResolvedValue([]);
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+
+    await screen.findByText("This page hasn't been translated yet.");
+    expect(screen.queryByText("Permission denied")).not.toBeInTheDocument();
+    expect(screen.queryByText("Couldn't load translations")).not.toBeInTheDocument();
+  });
+
+  test("PASS — a 403 from /translations/list shows a permission error, not a fake empty list", async () => {
+    translationService.listTranslations.mockRejectedValue({ status: 403, message: "Forbidden" });
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+
+    await screen.findByText("Permission denied");
+    expect(screen.getByText("Your account doesn't have access to Translate & Review.")).toBeInTheDocument();
+    expect(screen.queryByText("This page hasn't been translated yet.")).not.toBeInTheDocument();
+    expect(translationService.generateForReview).not.toHaveBeenCalled();
+  });
+
+  test("PASS — a non-403 failure shows a distinct load error, not a fake empty list", async () => {
+    translationService.listTranslations.mockRejectedValue({ message: "Network error" });
+    renderWorkspace({ siteId: "site-1", route: "/", lang: "kn" });
+
+    await screen.findByText("Couldn't load translations");
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+    expect(screen.queryByText("Permission denied")).not.toBeInTheDocument();
+  });
+});

--- a/ContentWebApp/tests/sdk.test.js
+++ b/ContentWebApp/tests/sdk.test.js
@@ -1,0 +1,417 @@
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const SDK_PATH = path.resolve(__dirname, "../public/sdk.js");
+const API_BASE = "https://api.example.com";
+const SITE_ID = "site-1";
+
+function flush(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function makeDom({ url = "https://app.example.com/authn/login", bodyHtml = "<p>Hello World</p>" } = {}) {
+  const dom = new JSDOM(
+    `<!doctype html><html><head></head><body>${bodyHtml}</body></html>`,
+    { url, runScripts: "dangerously", pretendToBeVisual: true }
+  );
+
+  const fetchMock = jest.fn((url) => {
+    const u = String(url);
+    if (u.includes("/languages")) {
+      return Promise.resolve({
+        json: () => Promise.resolve([{ code: "en", name: "English" }, { code: "hi", name: "Hindi" }]),
+      });
+    }
+    if (u.includes("/translations/extract")) {
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    }
+    if (u.includes("/translations?")) {
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    }
+    return Promise.resolve({ json: () => Promise.resolve({}) });
+  });
+  dom.window.fetch = fetchMock;
+
+  const script = dom.window.document.createElement("script");
+  script.setAttribute("data-site-id", SITE_ID);
+  script.setAttribute("data-api-base", API_BASE);
+  script.textContent = fs.readFileSync(SDK_PATH, "utf8");
+  dom.window.document.head.appendChild(script);
+
+  await flush(10);
+
+  return { dom, fetchMock };
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("initial SDK initialization walks the DOM and sets the init guard", async () => {
+  const { dom } = await makeDom();
+  expect(dom.window.__translationSdkInitialized).toBe(true);
+  expect(dom.window.document.getElementById("translation-sdk-widget")).not.toBeNull();
+});
+
+test("duplicate SDK initialization is a no-op (idempotency guard)", async () => {
+  const { dom, fetchMock } = await makeDom();
+  const callsAfterFirstInit = fetchMock.mock.calls.length;
+
+  const script2 = dom.window.document.createElement("script");
+  script2.setAttribute("data-site-id", SITE_ID);
+  script2.setAttribute("data-api-base", API_BASE);
+  script2.textContent = fs.readFileSync(SDK_PATH, "utf8");
+  dom.window.document.head.appendChild(script2);
+  await flush(10);
+
+  expect(fetchMock.mock.calls.length).toBe(callsAfterFirstInit);
+  expect(dom.window.document.querySelectorAll("#translation-sdk-widget").length).toBe(1);
+});
+
+test("history.pushState navigation triggers a route re-scan using the new route", async () => {
+  const { dom, fetchMock } = await makeDom({ url: "https://app.example.com/authn/login" });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  fetchMock.mockClear();
+
+  dom.window.document.body.innerHTML = "<p>Dashboard content</p>";
+  dom.window.history.pushState({}, "", "/dashboard");
+  await flush(80);
+
+  expect(dom.window.location.pathname).toBe("/dashboard");
+  const translationsCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations?"));
+  expect(translationsCalls.length).toBeGreaterThan(0);
+  expect(String(translationsCalls[translationsCalls.length - 1][0])).toContain("route=%2Fdashboard");
+});
+
+test("history.replaceState navigation triggers a route re-scan", async () => {
+  const { dom, fetchMock } = await makeDom({ url: "https://app.example.com/authn/login" });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  fetchMock.mockClear();
+
+  dom.window.document.body.innerHTML = "<p>Profile content</p>";
+  dom.window.history.replaceState({}, "", "/profile");
+  await flush(80);
+
+  const translationsCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations?"));
+  expect(translationsCalls.length).toBeGreaterThan(0);
+  expect(String(translationsCalls[translationsCalls.length - 1][0])).toContain("route=%2Fprofile");
+});
+
+test("browser back/forward (popstate) triggers a route re-scan", async () => {
+  const { dom, fetchMock } = await makeDom({ url: "https://app.example.com/authn/login" });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+
+  dom.window.history.pushState({}, "", "/courses");
+  await flush(80);
+  fetchMock.mockClear();
+
+  dom.window.history.pushState({}, "", "/authn/login");
+  await flush(80);
+  fetchMock.mockClear();
+  dom.window.window.dispatchEvent(new dom.window.PopStateEvent("popstate"));
+  await flush(80);
+
+  const translationsCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations?"));
+  expect(translationsCalls.length).toBe(0);
+});
+
+test("popstate to a genuinely different route re-scans", async () => {
+  const { dom, fetchMock } = await makeDom({ url: "https://app.example.com/authn/login" });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  fetchMock.mockClear();
+
+  dom.window.history.pushState({}, "", "/dashboard");
+  await flush(10);
+  Object.defineProperty(dom.window, "location", {
+    value: new dom.window.URL("https://app.example.com/courses"),
+    writable: true,
+  });
+  dom.window.dispatchEvent(new dom.window.PopStateEvent("popstate"));
+  await flush(80);
+
+  const translationsCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations?"));
+  expect(translationsCalls.length).toBeGreaterThan(0);
+});
+
+test("dynamic DOM insertion (new nodes) is picked up by the MutationObserver", async () => {
+  const { dom, fetchMock } = await makeDom();
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  fetchMock.mockClear();
+
+  const p = dom.window.document.createElement("p");
+  p.textContent = "Dynamically added content";
+  dom.window.document.body.appendChild(p);
+  await flush(20);
+
+  const extractCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations/extract"));
+  expect(extractCalls.length).toBeGreaterThan(0);
+  const body = JSON.parse(extractCalls[extractCalls.length - 1][1].body);
+  expect(body.items.some((i) => i.text === "Dynamically added content")).toBe(true);
+});
+
+test("characterData mutation (in-place text change) is detected and re-extracted", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Original text</p>" });
+  await flush(10);
+  fetchMock.mockClear();
+
+  const textNode = dom.window.document.querySelector("p").firstChild;
+  textNode.textContent = "Mutated text";
+  await flush(850);
+
+  const extractCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations/extract"));
+  expect(extractCalls.length).toBeGreaterThan(0);
+  const body = JSON.parse(extractCalls[extractCalls.length - 1][1].body);
+  expect(body.items.some((i) => i.text === "Mutated text")).toBe(true);
+});
+
+test("characterData mutation does not create an infinite loop from our own translation writes", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Hello</p>" });
+  fetchMock.mockClear();
+  fetchMock.mockImplementation((url) => {
+    const u = String(url);
+    if (u.includes("/translations/extract")) return Promise.resolve({ json: () => Promise.resolve({}) });
+    if (u.includes("/translations?")) {
+      return Promise.resolve({ json: () => Promise.resolve({ t3hchgd: "नमस्ते" }) });
+    }
+    return Promise.resolve({ json: () => Promise.resolve({}) });
+  });
+
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  const select = dom.window.document.querySelector("#translation-sdk-widget select");
+  select.value = "hi";
+  select.dispatchEvent(new dom.window.Event("change"));
+  await flush(50);
+
+  const extractCallsAfterSettle = fetchMock.mock.calls.filter((c) =>
+    String(c[0]).includes("/translations/extract")
+  ).length;
+  await flush(100);
+  const extractCallsLater = fetchMock.mock.calls.filter((c) =>
+    String(c[0]).includes("/translations/extract")
+  ).length;
+
+  expect(extractCallsLater).toBe(extractCallsAfterSettle);
+});
+
+test("language selection persists across route changes (localStorage, origin-scoped)", async () => {
+  const { dom } = await makeDom({ url: "https://app.example.com/authn/login" });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+
+  dom.window.history.pushState({}, "", "/dashboard");
+  await flush(80);
+  dom.window.history.pushState({}, "", "/courses");
+  await flush(80);
+  dom.window.history.pushState({}, "", "/profile");
+  await flush(80);
+
+  expect(dom.window.localStorage.getItem("translationSdk.lang")).toBe("hi");
+});
+
+test("each route navigation requests translations for that route only", async () => {
+  const { dom, fetchMock } = await makeDom({ url: "https://app.example.com/authn/login" });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+
+  const routes = ["/dashboard", "/courses", "/profile"];
+  for (const route of routes) {
+    fetchMock.mockClear();
+    dom.window.document.body.innerHTML = `<p>Content for ${route}</p>`;
+    dom.window.history.pushState({}, "", route);
+    await flush(80);
+
+    const translationsCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations?"));
+    expect(translationsCalls.length).toBeGreaterThan(0);
+    expect(String(translationsCalls[translationsCalls.length - 1][0])).toContain(
+      "route=" + encodeURIComponent(route)
+    );
+  }
+});
+
+test("pending (not-yet-approved) translations fall back to source text, not an empty swap", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Pending Phrase</p>" });
+  fetchMock.mockImplementation((url) => {
+    const u = String(url);
+    if (u.includes("/translations?")) return Promise.resolve({ json: () => Promise.resolve({}) });
+    if (u.includes("/translations/extract")) return Promise.resolve({ json: () => Promise.resolve({}) });
+    return Promise.resolve({ json: () => Promise.resolve({}) });
+  });
+
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  dom.window.history.pushState({}, "", "/pending-route");
+  await flush(80);
+
+  expect(dom.window.document.querySelector("p").textContent).toBe("Pending Phrase");
+});
+
+test("approved translations are rendered via swapText", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Approved Phrase</p>" });
+  await flush(10);
+
+  const hashed = dom.window.eval(`
+    (function hashText(text) {
+      var hash = 0;
+      for (var i = 0; i < text.length; i++) {
+        hash = (hash << 5) - hash + text.charCodeAt(i);
+        hash |= 0;
+      }
+      return "t" + Math.abs(hash).toString(36);
+    })("Approved Phrase")
+  `);
+  fetchMock.mockImplementation((url) => {
+    const u = String(url);
+    if (u.includes("/translations?")) {
+      const result = {};
+      result[hashed] = "अनुमोदित वाक्यांश";
+      return Promise.resolve({ json: () => Promise.resolve(result) });
+    }
+    if (u.includes("/translations/extract")) return Promise.resolve({ json: () => Promise.resolve({}) });
+    return Promise.resolve({ json: () => Promise.resolve({}) });
+  });
+
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  dom.window.history.pushState({}, "", "/approved-route");
+  await flush(80);
+
+  expect(dom.window.document.querySelector("p").textContent).toBe("अनुमोदित वाक्यांश");
+});
+
+function sdkHash(dom, text) {
+  return dom.window.eval(`
+    (function hashText(t){var h=0;for(var i=0;i<t.length;i++){h=(h<<5)-h+t.charCodeAt(i);h|=0;}return "t"+Math.abs(h).toString(36);})(${JSON.stringify(text)})
+  `);
+}
+
+function countExtract(fetchMock) {
+  return fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations/extract")).length;
+}
+function countTranslationGets(fetchMock) {
+  return fetchMock.mock.calls.filter((c) => String(c[0]).includes("/translations?")).length;
+}
+function extractedTexts(fetchMock) {
+  const out = [];
+  for (const c of fetchMock.mock.calls) {
+    if (!String(c[0]).includes("/translations/extract")) continue;
+    try {
+      JSON.parse(c[1].body).items.forEach((i) => out.push(i.text));
+    } catch (e) {
+    }
+  }
+  return out;
+}
+
+async function applyHindi(dom, fetchMock, source, translated) {
+  const hashed = sdkHash(dom, source);
+  fetchMock.mockImplementation((url) => {
+    const u = String(url);
+    if (u.includes("/translations?")) {
+      const r = {};
+      r[hashed] = translated;
+      return Promise.resolve({ json: () => Promise.resolve(r) });
+    }
+    return Promise.resolve({ json: () => Promise.resolve({}) });
+  });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+  const select = dom.window.document.querySelector("#translation-sdk-widget select");
+  select.value = "hi";
+  select.dispatchEvent(new dom.window.Event("change"));
+  await flush(60);
+}
+
+test("guard: SDK's own translated write does not trigger another extraction or translation pass", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Approved Phrase</p>" });
+  await flush(10);
+  fetchMock.mockClear();
+
+  await applyHindi(dom, fetchMock, "Approved Phrase", "अनुवादित वाक्यांश");
+  expect(dom.window.document.querySelector("p").textContent).toBe("अनुवादित वाक्यांश");
+
+  const extractAtSettle = countExtract(fetchMock);
+  const getsAtSettle = countTranslationGets(fetchMock);
+  await flush(1000);
+  expect(countExtract(fetchMock)).toBe(extractAtSettle);
+  expect(countTranslationGets(fetchMock)).toBe(getsAtSettle);
+  expect(extractedTexts(fetchMock)).not.toContain("अनुवादित वाक्यांश");
+});
+
+test("guard: re-asserting the already-applied translated value is ignored (no re-extraction)", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Approved Phrase</p>" });
+  await flush(10);
+  fetchMock.mockClear();
+  await applyHindi(dom, fetchMock, "Approved Phrase", "अनुवादित वाक्यांश");
+
+  const node = dom.window.document.querySelector("p").firstChild;
+  const extractBefore = countExtract(fetchMock);
+  node.textContent = "अनुवादित वाक्यांश";
+  await flush(1000);
+
+  expect(countExtract(fetchMock)).toBe(extractBefore);
+  expect(extractedTexts(fetchMock)).not.toContain("अनुवादित वाक्यांश");
+});
+
+test("guard: React-style revert-to-source burst re-applies translation and converges (no infinite loop)", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Approved Phrase</p>" });
+  await flush(10);
+  fetchMock.mockClear();
+  await applyHindi(dom, fetchMock, "Approved Phrase", "अनुवादित वाक्यांश");
+
+  const node = dom.window.document.querySelector("p").firstChild;
+  for (let i = 0; i < 6; i++) {
+    node.textContent = "Approved Phrase";
+    await flush(20);
+  }
+  await flush(1000);
+
+  expect(dom.window.document.querySelector("p").textContent).toBe("अनुवादित वाक्यांश");
+  const extractAtSettle = countExtract(fetchMock);
+  const getsAtSettle = countTranslationGets(fetchMock);
+  await flush(1000);
+  expect(countExtract(fetchMock)).toBe(extractAtSettle);
+  expect(countTranslationGets(fetchMock)).toBe(getsAtSettle);
+});
+
+test("guard: switching back to English reverts text and does not loop", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Approved Phrase</p>" });
+  await flush(10);
+  fetchMock.mockClear();
+  await applyHindi(dom, fetchMock, "Approved Phrase", "अनुवादित वाक्यांश");
+  expect(dom.window.document.querySelector("p").textContent).toBe("अनुवादित वाक्यांश");
+
+  const select = dom.window.document.querySelector("#translation-sdk-widget select");
+  select.value = "en";
+  select.dispatchEvent(new dom.window.Event("change"));
+  await flush(60);
+  expect(dom.window.document.querySelector("p").textContent).toBe("Approved Phrase");
+
+  const extractAtSettle = countExtract(fetchMock);
+  const getsAtSettle = countTranslationGets(fetchMock);
+  await flush(1000);
+  expect(countExtract(fetchMock)).toBe(extractAtSettle);
+  expect(countTranslationGets(fetchMock)).toBe(getsAtSettle);
+});
+
+test("guard: a genuine app change to a NEW phrase is still extracted (guards do not block real changes)", async () => {
+  const { dom, fetchMock } = await makeDom({ bodyHtml: "<p>Approved Phrase</p>" });
+  await flush(10);
+  fetchMock.mockClear();
+  await applyHindi(dom, fetchMock, "Approved Phrase", "अनुवादित वाक्यांश");
+
+  const node = dom.window.document.querySelector("p").firstChild;
+  node.textContent = "Brand New Phrase";
+  await flush(1000);
+
+  expect(extractedTexts(fetchMock)).toContain("Brand New Phrase");
+});
+
+test("multiple sequential route navigations each re-scan without duplicating the widget or listeners", async () => {
+  const { dom } = await makeDom({ url: "https://app.example.com/authn/login" });
+  dom.window.localStorage.setItem("translationSdk.lang", "hi");
+
+  for (const route of ["/a", "/b", "/c", "/d"]) {
+    dom.window.document.body.innerHTML = `<p>Page ${route}</p><div id="translation-sdk-widget-holder"></div>`;
+    dom.window.history.pushState({}, "", route);
+    await flush(80);
+  }
+
+  expect(dom.window.location.pathname).toBe("/d");
+  expect(dom.window.document.querySelectorAll("#translation-sdk-widget").length).toBeLessThanOrEqual(1);
+});

--- a/platform/app/static/sdk.js
+++ b/platform/app/static/sdk.js
@@ -1,0 +1,80 @@
+(function () {
+  "use strict";
+
+  var script = document.currentScript;
+  var siteId = script.getAttribute("data-site-id");
+  var apiBase = script.getAttribute("data-api-base");
+  var lang = script.getAttribute("data-lang") || navigator.language || "en";
+  var route = window.location.pathname;
+
+  function hashText(text) {
+    var hash = 0;
+    for (var i = 0; i < text.length; i++) {
+      hash = (hash * 31 + text.charCodeAt(i)) | 0;
+    }
+    return "t" + (hash >>> 0).toString(16);
+  }
+
+  function textNodes() {
+    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        var text = node.nodeValue.trim();
+        if (!text || node.parentElement.closest("script,style")) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+    var nodes = [];
+    var node;
+    while ((node = walker.nextNode())) {
+      nodes.push(node);
+    }
+    return nodes;
+  }
+
+  function apply(translations) {
+    textNodes().forEach(function (node) {
+      var key = hashText(node.nodeValue.trim());
+      var translated = translations[key];
+      if (translated) {
+        node.nodeValue = node.nodeValue.replace(node.nodeValue.trim(), translated);
+      }
+    });
+  }
+
+  function fetchTranslations() {
+    var url =
+      apiBase +
+      "/translations?site_id=" +
+      encodeURIComponent(siteId) +
+      "&route=" +
+      encodeURIComponent(route) +
+      "&lang=" +
+      encodeURIComponent(lang);
+    fetch(url)
+      .then(function (res) {
+        return res.json();
+      })
+      .then(apply);
+  }
+
+  function extract() {
+    var items = textNodes().map(function (node) {
+      var text = node.nodeValue.trim();
+      return { key: hashText(text), text: text, route: route, source_lang: "en" };
+    });
+    if (!items.length) {
+      return;
+    }
+    fetch(apiBase + "/translations/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ site_id: siteId, items: items }),
+    }).then(fetchTranslations);
+  }
+
+  if (siteId && apiBase) {
+    extract();
+  }
+})();

--- a/translation-proxy/Dockerfile
+++ b/translation-proxy/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+FROM node:18-alpine AS runner
+
+WORKDIR /app
+
+COPY --from=builder /app ./
+
+EXPOSE 4000
+
+CMD ["npm", "start"]

--- a/translation-proxy/env.example
+++ b/translation-proxy/env.example
@@ -1,0 +1,7 @@
+PORT=4000
+
+# Platform backend base URL the SDK calls for real AI translation.
+SOURCE_APP_BASE=http://localhost:8000
+
+# siteId returned by POST /websites when this demo domain is onboarded.
+SITE_ID=

--- a/translation-proxy/package-lock.json
+++ b/translation-proxy/package-lock.json
@@ -1,0 +1,858 @@
+{
+  "name": "translation-proxy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "translation-proxy",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "express": "^4.21.1"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.8",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.8.tgz",
+      "integrity": "sha512-JNcyFQ64OiijEkPzUBTCe+hyPXUD/3LEldGQ6iF5LR1w00mx9o7xtDWHXBY2iItjdCFGoilOLNQbH943ut7pHA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.16.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/translation-proxy/package.json
+++ b/translation-proxy/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "translation-proxy",
+  "version": "1.0.0",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "description": "Reverse proxy that injects the web-translation SDK into content-webapp-service HTML responses without requiring source changes.",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.21.1"
+  }
+}

--- a/translation-proxy/public/site/index.html
+++ b/translation-proxy/public/site/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Vidya Learning Center</title>
+  <style>
+    :root { --brand:#1d4ed8; --ink:#0f172a; --muted:#64748b; --bg:#f8fafc; }
+    * { box-sizing:border-box; }
+    body { margin:0; font-family:system-ui,Arial,sans-serif; color:var(--ink); background:#fff; line-height:1.55; }
+    header { background:var(--brand); color:#fff; }
+    .bar { max-width:1000px; margin:0 auto; display:flex; align-items:center; justify-content:space-between; padding:16px 24px; }
+    .logo { font-weight:800; font-size:20px; }
+    nav a { color:#e0e7ff; text-decoration:none; margin-left:20px; font-size:15px; }
+    .hero { max-width:1000px; margin:0 auto; padding:64px 24px; }
+    .hero h1 { font-size:40px; margin:0 0 12px; }
+    .hero p { font-size:18px; color:var(--muted); max-width:620px; }
+    .btn { display:inline-block; margin-top:24px; background:var(--brand); color:#fff; padding:12px 22px; border:none; border-radius:8px; font-size:16px; cursor:pointer; }
+    section { max-width:1000px; margin:0 auto; padding:40px 24px; }
+    h2 { font-size:28px; }
+    .grid { display:grid; grid-template-columns:repeat(3,1fr); gap:20px; margin-top:24px; }
+    .card { background:var(--bg); border:1px solid #e2e8f0; border-radius:12px; padding:22px; }
+    .card h3 { margin:0 0 8px; font-size:18px; }
+    .card p { margin:0; color:var(--muted); font-size:15px; }
+    blockquote { margin:0; background:var(--bg); border-left:4px solid var(--brand); padding:16px 20px; border-radius:8px; color:var(--ink); }
+    footer { background:var(--ink); color:#cbd5e1; margin-top:40px; }
+    footer .bar { display:block; text-align:center; font-size:14px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="bar">
+      <div class="logo">Vidya Learning Center</div>
+      <nav>
+        <a href="#courses">Courses</a>
+        <a href="#about">About Us</a>
+        <a href="#testimonials">Testimonials</a>
+        <a href="#contact">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="hero">
+    <h1>Learning that reaches every child</h1>
+    <p>We help schools deliver accessible, audio-first education to visually impaired students across the country. Trusted by hundreds of teachers.</p>
+    <button class="btn">Start Free Trial</button>
+  </div>
+
+  <section id="courses">
+    <h2>Our Courses</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Foundations of Reading</h3>
+        <p>Interactive audio lessons that build strong literacy skills from the very first day.</p>
+      </div>
+      <div class="card">
+        <h3>Everyday Mathematics</h3>
+        <p>Practical number sense taught through stories, games, and real-world examples.</p>
+      </div>
+      <div class="card">
+        <h3>Science for Curious Minds</h3>
+        <p>Hands-on experiments and narrated guides that make science come alive.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="about">
+    <h2>About Us</h2>
+    <p>Vidya Learning Center was founded to make quality education available to every learner, regardless of ability. Our teaching materials are designed with accessibility at their core.</p>
+  </section>
+
+  <section id="testimonials">
+    <h2>What Teachers Say</h2>
+    <blockquote>"My students are more engaged than ever. The audio lessons are a joy to use in the classroom every single day."</blockquote>
+  </section>
+
+  <section id="contact">
+    <h2>Get in Touch</h2>
+    <p>Have a question or want a demo for your school? Send us a message and our team will respond within one business day.</p>
+    <button class="btn">Contact Sales</button>
+  </section>
+
+  <footer>
+    <div class="bar">
+      <p>Accessible. Audio-First. Inclusive. &copy; Vidya Learning Center.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/translation-proxy/src/server.js
+++ b/translation-proxy/src/server.js
@@ -1,0 +1,48 @@
+"use strict";
+
+require("dotenv").config();
+const path = require("path");
+const fs = require("fs");
+const express = require("express");
+
+const PORT = process.env.PORT || 4000;
+const SOURCE_APP_BASE = process.env.SOURCE_APP_BASE || "http://localhost:3000";
+const SITE_ID = process.env.SITE_ID || "";
+
+const SITE_DIR = path.join(__dirname, "..", "public", "site");
+
+function buildSnippet() {
+  return (
+    `<script src="${SOURCE_APP_BASE}/sdk.js" ` +
+    `data-site-id="${SITE_ID}" ` +
+    `data-api-base="${SOURCE_APP_BASE}" defer></script>`
+  );
+}
+
+function injectSdk(html) {
+  const snippet = buildSnippet();
+  return html.includes("</body>")
+    ? html.replace("</body>", `${snippet}\n</body>`)
+    : html + snippet;
+}
+
+const app = express();
+
+app.use(express.static(SITE_DIR, { index: false, extensions: [] }));
+
+app.get("*", (req, res) => {
+  const file = path.join(SITE_DIR, "index.html");
+  fs.readFile(file, "utf8", (err, html) => {
+    if (err) {
+      res.status(500).send("Target site not found");
+      return;
+    }
+    res.type("html").send(injectSdk(html));
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(
+    `TARGET customer website on http://localhost:${PORT} — SDK injected from ${SOURCE_APP_BASE} (siteId=${SITE_ID || "unset"})`
+  );
+});


### PR DESCRIPTION
```markdown
## Summary
- Adds the finalized Localization UI to ContentWebApp — Registration (connect a website, generate SDK snippet) and Translate & Review (browse/approve translations, switch languages) screens, plus supporting hooks, services, and DTOs.
- Adds the client-side translation SDK (`ContentWebApp/public/sdk.js`) that gets injected into a customer site to auto-translate page content and expose a language switcher.
- Adds `translation-proxy/` — a standalone demo harness (Node/Express) that fronts a sample customer site with the SDK injected, for local end-to-end testing.
- No backend changes included — this branch is UI/frontend only.

## What's included
- `ContentWebApp/src/localization-ui/**` — Registration, Translate & Review (Workspace), Manage screens, CrudTable/useCrudView primitives, shared styles/tokens
- `ContentWebApp/src/hooks/useLocalization.js`, `services/{languageService,onboardingService,translationService}.js`, `services/dtos/**`
- `ContentWebApp/public/sdk.js`, `public/index.html` (SDK snippet wiring), `src/setupProxy.js` (dev proxy to backend)
- Minor integration touch-ups: `AllContent.js` (Localization tab), `AppHeader.js` (nav link), shared `Select` component (disabled state)
- Tests: `tests/localization-ui/**`, `tests/sdk.test.js`, `tests/localization_verify.test.js`
- `translation-proxy/**` — demo customer-site proxy for local SDK testing
- `platform/app/static/sdk.js` — client-side SDK asset (served by the backend; no backend logic changed)

## Test plan
- [x] `npm start` compiles clean (only pre-existing lint warnings, no errors)
- [x] Registration screen lists connected sites, generates install snippet
- [x] Translate & Review loads translations, switches languages (Kannada/Punjabi/Bengali verified), approves/reviews entries
- [x] SDK widget injects and calls `/translations`, `/translations/extract`, `/languages` successfully against a local backend

