### PR TITLE
fix: validate current password before tenant change-password (#592)

### DIFF
--- a/platform/app/controllers/tenant_auth_controller.py
+++ b/platform/app/controllers/tenant_auth_controller.py
@@ -101,7 +101,7 @@ async def tenant_change_password(
     current_user: dict[str, Any] = Depends(require_tenant),
     service: AuthService = Depends(get_auth_service),
 ) -> MessageResponse:
-    await service.change_password(current_user.get("sub", ""), body.new_password)
+    await service.change_password(current_user.get("sub", ""), body.current_password, body.new_password)
     return MessageResponse(message="Password changed successfully")
 
 

--- a/platform/app/models/requests/auth_requests.py
+++ b/platform/app/models/requests/auth_requests.py
@@ -25,6 +25,7 @@ class TenantRegisterRequest(BaseModel):
 
 
 class TenantChangePasswordRequest(BaseModel):
+    current_password: str
     new_password: str
 
 

--- a/platform/app/services/auth_service.py
+++ b/platform/app/services/auth_service.py
@@ -295,13 +295,17 @@ async def get_user_profile(
 
 async def change_password(
     user_id: str,
+    current_password: str,
     new_password: str,
     db: AsyncDatabase,  # type: ignore[type-arg]
 ) -> None:
     """Hash *new_password* and persist it for *user_id*. Raises NotFoundError if absent."""
     repo = UserRepository(db)
-    if await repo.find_by_id(user_id) is None:
+    user = await repo.find_by_id(user_id)
+    if user is None:
         raise NotFoundError("User", user_id)
+    if not verify_password(current_password, user.hashed_password):
+        raise UnauthorizedError("Current password is incorrect")
     await repo.update(user_id, {"hashed_password": hash_password(new_password)})
 
 
@@ -396,8 +400,8 @@ class AuthService:
     async def get_user_profile(self, user_id: str, entity_label: str) -> User:
         return await get_user_profile(user_id, entity_label, self._db)
 
-    async def change_password(self, user_id: str, new_password: str) -> None:
-        return await change_password(user_id, new_password, self._db)
+    async def change_password(self, user_id: str, current_password: str, new_password: str) -> None:
+        return await change_password(user_id, current_password, new_password, self._db)
 
     async def get_school_admin_profile(self, school_id: str, tenant_id: str) -> UserPublicResponse:
         return await get_school_admin_profile(school_id, tenant_id, self._db)

--- a/platform/tests/integration/test_controllers_extended.py
+++ b/platform/tests/integration/test_controllers_extended.py
@@ -23,7 +23,7 @@ from httpx import ASGITransport, AsyncClient
 from app.main import app
 from app.models.user import UserRole
 from app.platform.auth.dependencies import get_db
-from app.platform.auth.hashing import hash_password
+from app.platform.auth.hashing import hash_password, verify_password
 from app.platform.auth.jwt import create_access_token
 from tests.support.mongomock_async import AsyncMongoMockClient
 
@@ -396,6 +396,38 @@ class TestTenantDashboard:
         tenant = await _seed_tenant(mock_db)
         token = _tenant_token(tenant["_id"])
         resp = await client.post("/tenant/change-password", json={
+            "current_password": "tenantpass",
             "new_password": "newSecurePass123",
         }, headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
+        stored = await mock_db["users"].find_one({"_id": ObjectId(tenant["_id"])})
+        assert verify_password("newSecurePass123", stored["hashed_password"])
+
+    @pytest.mark.asyncio
+    async def test_change_password_missing_current_password_rejected(self, client, mock_db):
+        tenant = await _seed_tenant(mock_db)
+        token = _tenant_token(tenant["_id"])
+        resp = await client.post("/tenant/change-password", json={
+            "new_password": "newSecurePass123",
+        }, headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_change_password_wrong_current_rejected(self, client, mock_db):
+        tenant = await _seed_tenant(mock_db)
+        token = _tenant_token(tenant["_id"])
+        resp = await client.post("/tenant/change-password", json={
+            "current_password": "wrongpass",
+            "new_password": "newSecurePass123",
+        }, headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+        stored = await mock_db["users"].find_one({"_id": ObjectId(tenant["_id"])})
+        assert stored["hashed_password"] == tenant["hashed_password"]
+
+    @pytest.mark.asyncio
+    async def test_school_admin_has_no_change_password_route(self, client, mock_db):
+        resp = await client.post("/school/admin/change-password", json={
+            "current_password": "whatever",
+            "new_password": "newSecurePass123",
+        })
+        assert resp.status_code == 404

--- a/platform/tests/integration/test_shared_helpers_and_gaps.py
+++ b/platform/tests/integration/test_shared_helpers_and_gaps.py
@@ -219,7 +219,7 @@ class TestTenantAuthGapEndpoints:
         token = _tenant_token(tenant["_id"])
         resp = await client.post(
             "/tenant/change-password",
-            json={"new_password": "newpass456"},
+            json={"current_password": "gappass", "new_password": "newpass456"},
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
Fixes #592.

`POST /tenant/change-password` let a tenant set a new password without proving they know the current one. Any authenticated (or leaked/stolen) tenant JWT could silently rewrite the password.

## Root cause
- `TenantChangePasswordRequest` only had `new_password`.
- `AuthService.change_password` / `change_password()` never verified `current_password` before hashing and persisting.

## Fix
- Added `current_password: str` to `TenantChangePasswordRequest`.
- `change_password(user_id, current_password, new_password, db)` now fetches the user, verifies `current_password` via existing `verify_password`, raises `UnauthorizedError("Current password is incorrect")` on mismatch (mapped to HTTP 401), before hashing/persisting `new_password`.
- Controller passes `body.current_password` through.
- Checked `/school/admin/change-password` and other password-change endpoints — no equivalent route exists, no other gap found.

## Tests
- `test_change_password_success` — updated (seeded tenant password is `"tenantpass"`).
- `test_change_password_wrong_current_rejected` — new: wrong `current_password` → 401, stored hash unchanged.
- `test_change_password_missing_current_password_rejected` — new: missing field → 422.
- `test_change_password_with_tenant_token` (existing gap test) — updated to include correct `current_password`.

Full backend suite: 1181 passed, 0 failed.

